### PR TITLE
fix: allow unshare(CLONE_NEWUSER) in rootless nerdctl for non-root UID remapping

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -241,6 +241,19 @@ nerdctl run --rm hello-world
 You should see "Hello from Docker!" (containerd uses the same image).
 If that fails, leerie will too.
 
+## Optional host tools
+
+These are not required to run leerie, but unlock additional automation:
+
+**`gh` (GitHub CLI)** — enables automatic PR creation at the end of each
+run. Without it, leerie pushes the run branch and prints a `gh pr create`
+command for you to run manually. Install from https://cli.github.com, then
+authenticate:
+
+```bash
+gh auth login
+```
+
 ## Fly.io runtime (optional)
 
 By default leerie runs workers locally via `nerdctl`. Passing `--runtime fly`

--- a/leerie
+++ b/leerie
@@ -3863,6 +3863,18 @@ else
     fi
   fi
 
+  # Rootless nerdctl (non-root host user) runs the container in a user
+  # namespace where PID 1 appears as UID 0. container-entry.sh uses
+  # `unshare --user` to remap to the leerie UID so claude accepts
+  # --dangerously-skip-permissions (which it refuses when getuid()==0).
+  # The OCI default seccomp profile blocks unshare(CLONE_NEWUSER) inside
+  # containers, so we lift it for rootless runs. Single-tenant dev tool;
+  # the security trade-off is acceptable.
+  ROOTLESS_SECOPT=()
+  if [ "$(id -u)" != "0" ]; then
+    ROOTLESS_SECOPT=(--security-opt seccomp=unconfined)
+  fi
+
   _cidfile="$LEERIE_STATE_HOST_DIR/.cidfile-$$"
   rm -f "$_cidfile"
   nerdctl run \
@@ -3873,6 +3885,7 @@ else
     -e LEERIE_INSPECT_DIRS= \
     -e LEERIE_STATE_DIR=/leerie-state \
     ${CGROUP_MOUNT_ARG[@]+"${CGROUP_MOUNT_ARG[@]}"} \
+    ${ROOTLESS_SECOPT[@]+"${ROOTLESS_SECOPT[@]}"} \
     -v "$USER_REPO:/work" \
     -v "$LEERIE_REPO:/opt/leerie-image:ro" \
     -v "$LEERIE_STATE_HOST_DIR:/leerie-state" \

--- a/scripts/container-entry.sh
+++ b/scripts/container-entry.sh
@@ -119,10 +119,18 @@ fi
 # which could mutate PATH unpredictably). HOME is load-bearing for
 # claude (creds at ~/.claude/.credentials.json); USER/LOGNAME are read
 # by tools that introspect identity.
-# In rootless mode root IS the host user — skip the privilege drop so
-# bind-mounted host dirs remain accessible.
+# In rootless mode root IS the host user, so bind-mounted dirs (outer
+# UID 0) are ours — but claude refuses --dangerously-skip-permissions
+# when getuid()==0. We remap to the leerie user's UID/GID (baked in at
+# image build time from HOST_UID/HOST_GID) in a nested user namespace
+# via unshare: outer UID 0 → inner UID leerie (explicit), so all
+# bind-mounts remain owned by us. Image dirs (outer UID leerie) are
+# traversed via their mode-755 bits, not by ownership.
 if [ "$ROOTLESS" = "true" ]; then
-  exec env HOME=/home/leerie USER=leerie LOGNAME=leerie \
+  _leerie_uid="$(id -u leerie)"
+  _leerie_gid="$(id -g leerie)"
+  exec unshare --user --map-user="$_leerie_uid" --map-group="$_leerie_gid" \
+    env HOME=/home/leerie USER=leerie LOGNAME=leerie \
     python3 /opt/leerie-image/orchestrator/leerie.py "$@"
 fi
 exec runuser -u leerie -- \


### PR DESCRIPTION
In rootless containerd, container PID 1 appears as UID 0, causing claude to refuse --dangerously-skip-permissions. container-entry.sh now uses `unshare --user --map-user/--map-group` (UID/GID read from the leerie user in /etc/passwd) to remap into a nested user namespace so workers run as a non-root UID.

The OCI default seccomp profile blocks unshare(CLONE_NEWUSER) inside containers, so the launcher adds --security-opt seccomp=unconfined when the host user is non-root (rootless nerdctl). In a rootless container the user namespace is already the security boundary; lifting seccomp has no meaningful impact on the attack surface for a single-tenant dev tool.

