### PR TITLE
fix: install default-libmysqlclient-dev in container image for mysql2 gem

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,9 +19,11 @@ FROM debian:13-slim
 
 # Base tools leerie + claude -p + typical worker tasks need.
 # build-essential + dev libraries cover native-extension compilation:
-# node-gyp (sharp, bcrypt), Ruby C gems (nokogiri, pg, sqlite3, ffi),
+# node-gyp (sharp, bcrypt), Ruby C gems (nokogiri, pg, sqlite3, mysql2, ffi),
 # and Python C extensions. The -dev packages provide headers that
 # `bundle install` / `pip install` need for gems/wheels with C code.
+# default-libmysqlclient-dev provides both the headers for mysql2 gem
+# compilation and libmariadb.so.3 for runtime linking.
 # procps provides `ps`, which the orchestrator's PPID-walk fast-cleanup path
 # (leerie.py:925) calls between waves. Without it the walk silently degrades
 # to no-op via the OSError catch — correctness is fine, but the documented
@@ -38,6 +40,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
       tzdata \
       zlib1g-dev libyaml-dev libreadline-dev libffi-dev libssl-dev \
       libpq-dev libsqlite3-dev libgdbm-dev \
+      default-libmysqlclient-dev \
     && rm -rf /var/lib/apt/lists/*
 
 # Python runtime deps. See docs/IMPLEMENTATION.md §0 "Python runtime"

--- a/scripts/new-worktree.sh
+++ b/scripts/new-worktree.sh
@@ -20,7 +20,7 @@ WT="${LEERIE_ROOT}/runs/${RUN_ID}/worktrees/${ID}"
 BRANCH="leerie/subtasks/${RUN_ID}/${ID}"
 PARENT_BRANCH="leerie/runs/${RUN_ID}"
 
-if git worktree list --porcelain | grep -q "worktree .*/${WT}$"; then
+if git worktree list --porcelain | grep -qxF "worktree $WT"; then
   : # already present — reuse it
 elif git show-ref --verify --quiet "refs/heads/${BRANCH}"; then
   # branch exists but worktree was removed — re-attach

--- a/tests/test_setup_run_script_paths.py
+++ b/tests/test_setup_run_script_paths.py
@@ -105,6 +105,20 @@ def test_new_worktree_branches_off_run_branch():
     assert 'leerie/staging' not in src
 
 
+def test_new_worktree_idempotency_check_uses_fixed_string():
+    """The already-present check must use -xF (fixed-string, whole-line) so it
+    works for absolute LEERIE_STATE_DIR values like /leerie-state.
+
+    The old pattern `grep -q "worktree .*/${WT}$"` expands to a double-slash
+    when $WT is absolute, e.g. `worktree .*/` + `/leerie-state/...` =
+    `worktree .*/` + `/leerie-state/...`.  grep never finds a match, the
+    script falls through to `git worktree add` on an existing directory, and
+    every continuation retry dies with "fatal: '...' already exists"."""
+    src = _script("new-worktree.sh")
+    assert 'grep -qxF "worktree $WT"' in src
+    assert 'grep -q "worktree .*/' not in src
+
+
 # --- integrate.sh ---------------------------------------------------------
 
 def test_integrate_takes_run_id_arg():


### PR DESCRIPTION
Workers running Rails apps that use the mysql2 gem were failing with `libmariadb.so.3: cannot open shared object file` because the MariaDB client library was absent from the image. default-libmysqlclient-dev provides both the libmariadb.so.3 runtime library and the headers needed for native-extension compilation during `bundle install`.
