### PR TITLE
fix: use -xF in new-worktree.sh idempotency check to handle absolute paths

### DIFF
--- a/scripts/new-worktree.sh
+++ b/scripts/new-worktree.sh
@@ -20,7 +20,7 @@ WT="${LEERIE_ROOT}/runs/${RUN_ID}/worktrees/${ID}"
 BRANCH="leerie/subtasks/${RUN_ID}/${ID}"
 PARENT_BRANCH="leerie/runs/${RUN_ID}"
 
-if git worktree list --porcelain | grep -q "worktree .*/${WT}$"; then
+if git worktree list --porcelain | grep -qxF "worktree $WT"; then
   : # already present — reuse it
 elif git show-ref --verify --quiet "refs/heads/${BRANCH}"; then
   # branch exists but worktree was removed — re-attach

--- a/tests/test_setup_run_script_paths.py
+++ b/tests/test_setup_run_script_paths.py
@@ -105,6 +105,20 @@ def test_new_worktree_branches_off_run_branch():
     assert 'leerie/staging' not in src
 
 
+def test_new_worktree_idempotency_check_uses_fixed_string():
+    """The already-present check must use -xF (fixed-string, whole-line) so it
+    works for absolute LEERIE_STATE_DIR values like /leerie-state.
+
+    The old pattern `grep -q "worktree .*/${WT}$"` expands to a double-slash
+    when $WT is absolute, e.g. `worktree .*/` + `/leerie-state/...` =
+    `worktree .*/` + `/leerie-state/...`.  grep never finds a match, the
+    script falls through to `git worktree add` on an existing directory, and
+    every continuation retry dies with "fatal: '...' already exists"."""
+    src = _script("new-worktree.sh")
+    assert 'grep -qxF "worktree $WT"' in src
+    assert 'grep -q "worktree .*/' not in src
+
+
 # --- integrate.sh ---------------------------------------------------------
 
 def test_integrate_takes_run_id_arg():


### PR DESCRIPTION
The grep pattern `worktree .*/${WT}$` produces a double-slash when LEERIE_STATE_DIR is an absolute path (e.g. /leerie-state inside the container), so the already-present check never matched and the script always fell through to `git worktree add` on an existing directory. This caused every continuation retry (e.g. after NO_PLANNED_FILES_TOUCHED) to die with "fatal: '...' already exists".

Switch to `grep -qxF "worktree $WT"` (fixed-string, whole-line match) which works correctly for both absolute and relative paths.
