### PR TITLE
fix(local): orchestrator log() shows host repo name, not "work"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to Leerie will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **Local runs now log the repo name instead of `[work]`.** Every line from
+  a local (nerdctl) run rendered `[leerie] [work]` regardless of the repo:
+  `log()` derives its `[leerie] [<repo>]` tag from `USER_REPO`, falling back
+  to `Path(os.getcwd()).name` — and the container's cwd is `/work`. The
+  launcher's env-forwarding loop filters `^LEERIE_`, which `USER_REPO`
+  cannot match, so the value never crossed the container boundary. With
+  several concurrent runs (chains, groups, multiple repos) the tag is the
+  only thing distinguishing whose line is whose, so it was uniformly
+  useless. The Fly path already injected `USER_REPO` via `child_env`; the
+  local path is now brought in line with an explicit
+  `-e "USER_REPO=$(basename "$USER_REPO")"` on the `nerdctl run` argv, which
+  sidesteps the `LEERIE_*` filter without touching the forwarding loop or
+  its deny-list. The basename (never the host path) is passed: the host path
+  does not resolve inside the container, and `log()` — the only in-container
+  reader — takes `Path(...).name`. Two new boundary guards pin that *both*
+  runtimes deliver the tag; the two mechanisms are independent, which is why
+  the bug survived on one runtime while the other was fixed.
+
 ## [0.9.60]
 
 ### Fixed

--- a/docs/IMPLEMENTATION.md
+++ b/docs/IMPLEMENTATION.md
@@ -641,6 +641,26 @@ orchestrator-read override is deny-listed except four justified exceptions
 On the Fly path the equivalent forwarding is via `child_env` in the
 detached-launch heredoc, not this loop.
 
+**`USER_REPO` (non-`LEERIE_*`, both runtimes).** `log()` renders its
+`[leerie] [<repo>]` prefix from `Path(os.environ.get("USER_REPO") or
+os.getcwd()).name`. The container's cwd is `/work`, so without an injected
+`USER_REPO` the fallback fires and every line reads `[leerie] [work]`. Both
+runtimes therefore inject it, each outside the `LEERIE_*` loop (the name
+does not match `^LEERIE_`):
+
+- **Local:** an explicit `-e "USER_REPO=$(basename "$USER_REPO")"` in the
+  `_run_argv` array, next to the other explicit `-e` lines.
+- **Fly:** `child_env["USER_REPO"] = "$(basename "$USER_REPO")"` in the
+  detached-launch heredoc (reproduced verbatim under §"Worker auth +
+  config seeding", `seed-auth.sh`).
+
+Both pass the **basename**, never the host path: `$USER_REPO` is a host
+absolute path that does not resolve inside the container (the repo is at
+`/work`), and `Path(x).name` is identity for a bare name. `log()` is the
+only in-container reader, so nothing treats the value as a path. The two
+mechanisms are independent — a change to one that is not mirrored in the
+other regresses that runtime to `[work]`.
+
 ### `--inspect-dir` path translation
 
 Inspect dirs (`--add-dir` forwarded to `claude -p` for cross-repo

--- a/leerie
+++ b/leerie
@@ -6137,6 +6137,11 @@ else
     -v "$_cidfile:/run/leerie-cidfile:ro"
     -e LEERIE_INSPECT_DIRS=
     -e LEERIE_STATE_DIR=/leerie-state
+    # Basename only: the host path doesn't exist in the container (the repo
+    # is at /work), and log() takes Path(USER_REPO).name. Without this the
+    # orchestrator's cwd=/work falls back to basename "work" and every line
+    # reads [leerie] [work]. Mirrors the Fly path's child_env["USER_REPO"].
+    -e "USER_REPO=$(basename "$USER_REPO")"
     ${_leerie_env_args[@]+"${_leerie_env_args[@]}"}
     ${CGROUP_MOUNT_ARG[@]+"${CGROUP_MOUNT_ARG[@]}"}
     --cgroupns=host

--- a/tests/test_launcher_env_forwarding.py
+++ b/tests/test_launcher_env_forwarding.py
@@ -93,6 +93,95 @@ def _forwarded_names(tokens: list[str]) -> set[str]:
     return names
 
 
+def _extract_run_argv() -> str:
+    """Pull the `_run_argv` array assignment verbatim from the launcher, same
+    reason as _extract_forwarding_loop: assert against real code, not a copy."""
+    src = LAUNCHER.read_text()
+    m = re.search(r"(  _run_argv=\(\n.*?\n  \)\n)", src, re.DOTALL)
+    assert m, "could not locate the _run_argv array in the launcher"
+    return m.group(1)
+
+
+_ARGV_HARNESS = r"""
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Stub every var the array interpolates; USER_REPO is the one under test.
+USER_REPO=/Users/andres/src/enric/stackpulse
+LEERIE_REPO=/opt/leerie
+LEERIE_STATE_HOST_DIR=/tmp/state
+TTY_FLAGS=""
+_cidfile=/tmp/cid
+REPO_IMAGE_TAG=""
+IMAGE_TAG=leerie:test
+_leerie_env_args=()
+
+# ---- _run_argv, extracted verbatim from the launcher --------------------
+__RUN_ARGV__
+
+for a in "${_run_argv[@]}"; do printf '%s\n' "$a"; done
+"""
+
+
+def _run_argv_tokens() -> list[str]:
+    """Assemble the launcher's real _run_argv with stubbed vars; return tokens."""
+    harness = _ARGV_HARNESS.replace("__RUN_ARGV__", _extract_run_argv())
+    result = subprocess.run(
+        ["bash", "-c", harness],
+        env={"PATH": "/usr/bin:/bin"},
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    return [t for t in result.stdout.splitlines() if t]
+
+
+def _env_pairs(tokens: list[str]) -> dict[str, str]:
+    """Explicit `-e NAME=VALUE` pairs. The forwarding loop's bare `-e NAME`
+    form is handled by _forwarded_names(); this is its NAME=VALUE sibling."""
+    pairs = {}
+    for i, tok in enumerate(tokens):
+        if tok == "-e" and i + 1 < len(tokens) and "=" in tokens[i + 1]:
+            name, _, value = tokens[i + 1].partition("=")
+            pairs[name] = value
+    return pairs
+
+
+def test_user_repo_delivered_to_container():
+    """The boundary guard this whole class of bug fell through.
+
+    `log()` renders `[leerie] [<repo>]` from USER_REPO, falling back to cwd —
+    which is /work inside the container. USER_REPO does not match `^LEERIE_`,
+    so the forwarding loop cannot carry it; it needs an explicit `-e`. Without
+    it every local run prints `[leerie] [work]` regardless of the repo.
+    """
+    pairs = _env_pairs(_run_argv_tokens())
+    assert "USER_REPO" in pairs, (
+        "USER_REPO is not passed to the container — log() will fall back to "
+        "cwd (/work) and every line will render [leerie] [work]"
+    )
+    assert pairs["USER_REPO"] == "stackpulse", (
+        f"expected the basename 'stackpulse', got {pairs['USER_REPO']!r} — "
+        "the host path does not exist inside the container (repo is at /work), "
+        "so a path value would be misleading to any future reader"
+    )
+
+
+def test_fly_path_also_delivers_user_repo():
+    """Both runtimes must deliver the tag, by independent mechanisms.
+
+    The Fly path has no `LEERIE_*` forwarding loop — it hand-picks keys into
+    `child_env` in the detached-launch heredoc. This bug existed because the
+    two mechanisms drifted: the fix landed on Fly (5f151c88) and not local.
+    Pin both so a future change to one surfaces the other.
+    """
+    src = LAUNCHER.read_text()
+    assert 'child_env["USER_REPO"] = "$(basename "$USER_REPO")"' in src, (
+        "the Fly detached-launch child_env no longer injects USER_REPO — "
+        "the remote orchestrator's log() will regress to [leerie] [work]"
+    )
+
+
 def test_worker_pids_max_forwarded():
     names = _forwarded_names(_run({"LEERIE_WORKER_PIDS_MAX": "1024"}))
     assert "LEERIE_WORKER_PIDS_MAX" in names

--- a/tests/test_orchestrator_log.py
+++ b/tests/test_orchestrator_log.py
@@ -8,9 +8,17 @@ mid-stream when the launcher starts tailing the remote orchestrator
 (observed: bash prints `[stackpulse]`, python prints `[work]` because
 cwd inside the Fly machine is /work).
 
-The critical property locked in here: USER_REPO wins over cwd, so the
-fix that injects USER_REPO into the remote orchestrator's env is
-sufficient to keep the prefix stable.
+The critical property locked in here: USER_REPO wins over cwd, so
+injecting USER_REPO into the orchestrator's env keeps the prefix stable.
+
+Scope note: these tests stub USER_REPO into the subprocess env directly,
+so they pin log()'s *precedence* and nothing about whether a launcher
+actually delivers the var across the container boundary. That seam is
+where the bug lives, and it is guarded separately — for both runtimes —
+by test_launcher_env_forwarding.py::test_user_repo_delivered_to_container
+(local `-e`) and ::test_fly_path_also_delivers_user_repo (Fly child_env).
+An earlier version of this docstring described the injection as done,
+which was true of Fly and false of local for months.
 """
 from __future__ import annotations
 


### PR DESCRIPTION
## Summary

Every line from a local (nerdctl) run rendered `[leerie] [work]` regardless of the repo, because `USER_REPO` never crossed the container boundary and `log()` fell back to `Path(os.getcwd()).name` — and cwd is `/work`. The Fly path already fixed this in 5f151c8; this brings the local path in line with the same mechanism.

## Which layer(s) does this PR touch?

(See [`CLAUDE.md`](../CLAUDE.md) for the three-layer rule.)

- [ ] `docs/DESIGN.md` (architecture)
- [x] `docs/IMPLEMENTATION.md` (code surface)
- [ ] `orchestrator/leerie.py` (code)
- [x] docs (`CHANGELOG.md`)
- [x] tests (`tests/`)
- [ ] CI / repo meta (`.github/`)

The `leerie` launcher (bash) is the code layer here; `orchestrator/leerie.py` is untouched.

If multiple, has the change propagated **top-down** per the three-layer rule (DESIGN → IMPLEMENTATION → code)?

- [x] yes — IMPLEMENTATION first, then the launcher. DESIGN is deliberately silent on the log prefix (code surface, not architecture), so it needs no change.

## Task-completion checklist

- [x] `docs/IMPLEMENTATION.md` updated if code surface changed
- [x] `docs/DESIGN.md` updated if architecture changed — n/a, see above
- [ ] `pytest tests/` passes — **see caveat below**
- [x] `python3 -c "import ast; ast.parse(...)"` passes (file untouched)
- [x] `CHANGELOG.md` `[Unreleased]` updated
- [x] `git diff --stat` reviewed for scope (no collateral edits)

**pytest caveat (please verify in CI):** pytest is not installed on the host I ran this from, so I ran the suite from a scratch venv: **3336 passed**, with 8 failures that are **pre-existing and unrelated** — reproduced on a pristine checkout with this diff stashed. All 8 are `ModuleNotFoundError: jsonschema` (7) plus one tree-sitter `inspect.getsource` issue — artifacts of the bare venv lacking `requirements.txt` deps, not of this change. The 5 files here are green.

## Root cause

`log()` (`orchestrator/leerie.py:1626`) derives its tag from `USER_REPO`, falling back to cwd:

```python
repo = Path(os.environ.get("USER_REPO") or os.getcwd()).name or "?"
```

The launcher's forwarding loop (`leerie:6121`) filters `compgen -v | grep '^LEERIE_'`, which `USER_REPO` cannot match, so it never reached the container — it appeared in the argv only as the bind-mount source `-v "$USER_REPO:/work"`.

The fix is an explicit `-e "USER_REPO=$(basename "$USER_REPO")"`, which sidesteps the `LEERIE_*` filter entirely — no change to the loop or its deny-list, and no new env var. The **basename**, never the host path: the host path doesn't resolve inside the container, and `log()` is the only in-container reader (verified by grep across `orchestrator/`, the container scripts, and `prompts/`), taking `Path(...).name`, for which a bare name is identity.

## Testing notes

Two new boundary guards in `tests/test_launcher_env_forwarding.py`:

- `test_user_repo_delivered_to_container` — extracts `_run_argv` verbatim from the launcher (the file's existing convention) and asserts the argv carries the basename, not the host path.
- `test_fly_path_also_delivers_user_repo` — pins the Fly `child_env` line.

Both were **mutation-tested**: passing the host path instead of the basename fails the first; deleting the Fly line fails the second.

The gap that let this survive: the existing `test_orchestrator_log.py` tests stub `USER_REPO` into the env themselves, so they pin `log()`'s *precedence* while never touching the boundary where the bug lived. Its docstring even described the injection as done — true of Fly, false of local, for months. Corrected here.

## Verification

- **Real local run** — real launcher → real image → real orchestrator: every `[leerie] [...]` line renders `[leerie] [leerie]`, zero `[work]`.
- **In-container control** — `leerie:0.9.60`, real `runuser` hop: without the var → `[leerie] [work]`; with it → `[leerie] [leerie]`.
- **Repo names with spaces** survive as exactly one argv token (`/x/my repo` → `USER_REPO=my repo`).
- **Fly path unaffected** — the diff is a single hunk (`@@ -6139,0 +6140,5 @@`); the entire Fly launch region (5600-5850, containing `child_env["USER_REPO"]` at `:5729`) is byte-identical to HEAD. No `--runtime fly` run was made: it would provision a billed machine to exercise code the diff provably never touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)