### PR TITLE
test: gate schema tests on HAS_JSONSCHEMA so they pass without the dep

### DIFF
--- a/tests/test_filter_satisfied_subtasks.py
+++ b/tests/test_filter_satisfied_subtasks.py
@@ -14,6 +14,11 @@ Covers:
   - a subtask with no success_criteria_seed is never probed (survives)
   - a probe crash (WorkerError) fails safe — subtask survives, no drop
   - SCHEMAS["satisfied_probe"] validates good / rejects malformed payloads
+
+The schema tests use a HAS_JSONSCHEMA gate with a manual structural fallback
+(mirroring test_dep_capture_schema.py / test_fit_judge_schema.py) so CI
+without jsonschema installed still catches drift — it is not a declared
+dependency.
 """
 from __future__ import annotations
 
@@ -22,6 +27,12 @@ import json
 from pathlib import Path
 
 import pytest
+
+try:
+    import jsonschema  # type: ignore
+    HAS_JSONSCHEMA = True
+except ImportError:
+    HAS_JSONSCHEMA = False
 
 
 _CAPS = {"max_parallel": 4, "max_total_workers": 999}
@@ -237,18 +248,35 @@ def test_budget_exhaustion_propagates_not_swallowed(leerie, tmp_path,
 # schema
 # ---------------------------------------------------------------------------
 
-def test_schema_accepts_good_payload(leerie):
-    import jsonschema
+def _validate(leerie, instance: dict) -> None:
+    """Validate using jsonschema when available; otherwise fall back to
+    structural assertions that mirror what the schema declares. Tests must
+    pass in both modes so CI without jsonschema installed still catches
+    drift."""
     schema = leerie.SCHEMAS["satisfied_probe"]
-    jsonschema.validate(
-        {"satisfied": True, "evidence": "cited", "checked": ["a.py"]},
-        schema)
+    if HAS_JSONSCHEMA:
+        jsonschema.validate(instance, schema)
+        return
+    for k in schema["required"]:
+        assert k in instance, f"missing required field {k!r}"
+    assert isinstance(instance["satisfied"], bool)
+    assert isinstance(instance["evidence"], str)
+    if "checked" in instance:
+        assert isinstance(instance["checked"], list)
+        for path in instance["checked"]:
+            assert isinstance(path, str)
+
+
+def test_schema_accepts_good_payload(leerie):
+    _validate(leerie, {"satisfied": True, "evidence": "cited",
+                       "checked": ["a.py"]})
     # checked is optional
-    jsonschema.validate({"satisfied": False, "evidence": "missing"}, schema)
+    _validate(leerie, {"satisfied": False, "evidence": "missing"})
 
 
 def test_schema_rejects_malformed(leerie):
-    import jsonschema
+    if not HAS_JSONSCHEMA:
+        pytest.skip("jsonschema not available; rejection requires a validator")
     schema = leerie.SCHEMAS["satisfied_probe"]
     with pytest.raises(jsonschema.ValidationError):
         jsonschema.validate({"evidence": "no satisfied field"}, schema)

--- a/tests/test_phase_overlap_judge.py
+++ b/tests/test_phase_overlap_judge.py
@@ -10,7 +10,10 @@ the helpers and is easier to test directly.
 
 Mirrors the test style of test_reconciler_schema.py +
 test_apply_reconciler_output_*.py: extract the schema / call the pure
-helper / reason over the result.
+helper / reason over the result. The schema tests use a HAS_JSONSCHEMA gate
+with a manual structural fallback (as test_dep_capture_schema.py /
+test_fit_judge_schema.py do) so CI without jsonschema installed still
+catches drift — it is not a declared dependency.
 """
 from __future__ import annotations
 
@@ -18,6 +21,12 @@ import asyncio
 import copy
 
 import pytest
+
+try:
+    import jsonschema  # type: ignore
+    HAS_JSONSCHEMA = True
+except ImportError:
+    HAS_JSONSCHEMA = False
 
 
 # --------------------------------------------------------------------- #
@@ -66,6 +75,33 @@ def _valid_collision_unresolvable() -> dict:
     }
 
 
+def _validate(leerie, instance: dict) -> None:
+    """Validate using jsonschema when available; otherwise fall back to
+    structural assertions that mirror what the schema declares. Tests must
+    pass in both modes so CI without jsonschema installed still catches
+    drift."""
+    schema = leerie.SCHEMAS["plan_overlap_judge"]
+    if HAS_JSONSCHEMA:
+        jsonschema.validate(instance, schema)
+        return
+    for k in schema["required"]:
+        assert k in instance, f"missing required field {k!r}"
+    assert isinstance(instance["collisions"], list)
+    item = schema["properties"]["collisions"]["items"]
+    allowed = set(item["properties"])
+    for c in instance["collisions"]:
+        assert isinstance(c, dict)
+        for k in item["required"]:
+            assert k in c, f"collision missing required field {k!r}"
+        assert not set(c) - allowed, f"collision has unknown keys: {set(c) - allowed}"
+        assert c["resolution"] in item["properties"]["resolution"]["enum"]
+    conf_schema = schema["properties"]["confidence"]
+    conf = instance["confidence"]
+    assert isinstance(conf, dict)
+    for k in conf_schema["required"]:
+        assert k in conf, f"confidence missing required field {k!r}"
+
+
 def test_schema_exists(leerie):
     assert "plan_overlap_judge" in leerie.SCHEMAS
 
@@ -73,24 +109,20 @@ def test_schema_exists(leerie):
 def test_schema_empty_collisions_valid(leerie):
     """The no-collision case is the common one — the judge must be able
     to return {collisions: []}."""
-    import jsonschema
-    jsonschema.validate({"collisions": [], "confidence": _stub_confidence()},
-                        leerie.SCHEMAS["plan_overlap_judge"])
+    _validate(leerie, {"collisions": [], "confidence": _stub_confidence()})
 
 
 def test_schema_full_payload_valid(leerie):
-    import jsonschema
-    jsonschema.validate(
-        {"collisions": [
-            _valid_collision_merge(),
-            _valid_collision_drop_a(),
-            _valid_collision_unresolvable(),
-        ], "confidence": _stub_confidence()},
-        leerie.SCHEMAS["plan_overlap_judge"])
+    _validate(leerie, {"collisions": [
+        _valid_collision_merge(),
+        _valid_collision_drop_a(),
+        _valid_collision_unresolvable(),
+    ], "confidence": _stub_confidence()})
 
 
 def test_schema_rejects_unknown_resolution(leerie):
-    import jsonschema
+    if not HAS_JSONSCHEMA:
+        pytest.skip("jsonschema not available; enum check requires it")
     bad = _valid_collision_drop_a()
     bad["resolution"] = "merge_or_split"
     with pytest.raises(jsonschema.ValidationError):
@@ -100,7 +132,8 @@ def test_schema_rejects_unknown_resolution(leerie):
 
 
 def test_schema_rejects_extra_top_level_keys(leerie):
-    import jsonschema
+    if not HAS_JSONSCHEMA:
+        pytest.skip("jsonschema not available; additionalProperties requires it")
     with pytest.raises(jsonschema.ValidationError):
         jsonschema.validate(
             {"collisions": [], "confidence": _stub_confidence(),
@@ -109,7 +142,8 @@ def test_schema_rejects_extra_top_level_keys(leerie):
 
 
 def test_schema_requires_core_fields(leerie):
-    import jsonschema
+    if not HAS_JSONSCHEMA:
+        pytest.skip("jsonschema not available; required check requires it")
     incomplete = {"a_sid": "feat-001", "b_sid": "refactor-001",
                   "resolution": "merge"}
     with pytest.raises(jsonschema.ValidationError):


### PR DESCRIPTION
## The problem

Seven tests fail with:

```
ModuleNotFoundError: No module named 'jsonschema'
```

`jsonschema` is **not a declared dependency anywhere**:

- absent from `requirements.txt` (which pins only `tenacity`, `tree-sitter`, `tree-sitter-language-pack`)
- absent from the container image — verified: `import jsonschema` fails inside `leerie:0.9.60`
- never imported by `orchestrator/leerie.py` at runtime
- CLAUDE.md states **"`pytest` is the only dev dependency"**

So these tests could not pass in a clean checkout, in the container, or in CI. They only passed on a machine where someone happened to `pip install jsonschema`.

## Root cause

The repo **already standardises the fix** — 4 of the 7 jsonschema-importing test files use it, 3 do not:

| File | Status |
|---|---|
| `test_pr_writer_schema.py` | guarded |
| `test_splitter_schema.py` | guarded |
| `test_dep_capture_schema.py` | guarded |
| `test_fit_judge_schema.py` | guarded |
| `test_phase_overlap_judge.py` | **unguarded** — 5 failures |
| `test_filter_satisfied_subtasks.py` | **unguarded** — 2 failures |
| `test_patch_generator.py` | unguarded but passes (never reaches the import) — left alone, out of scope |

Quoting `test_dep_capture_schema.py`'s own docstring:

> *"uses a HAS_JSONSCHEMA gate with a manual structural fallback so CI without jsonschema installed still catches drift."*

This is a **test defect**, not a code bug.

## The fix

Brings the two files in line with `test_dep_capture_schema.py` / `test_fit_judge_schema.py`: a module-level `HAS_JSONSCHEMA` gate, a `_validate()` helper whose fallback mirrors what the schema declares, and `pytest.skip` on the rejection cases (proving *rejection* needs a real validator — it can't be faked).

No new dependency. Test-only: `orchestrator/leerie.py` untouched, so no DESIGN / IMPLEMENTATION / `docs/ANALYSIS.md` changes.

## Verification

**Both modes tested** — a fallback that only ever skips would silently stop testing anything:

| mode | result |
|---|---|
| without `jsonschema` (clean checkout / container / CI) | **64 passed, 4 skipped, 0 failed** — was 7 failed |
| with `jsonschema` installed | **68 passed, 0 skipped** — all reject-cases run and pass |

**The fallbacks are load-bearing, not decorative.** With `HAS_JSONSCHEMA=False`, `_validate` was fed four broken payloads and caught every one:

- missing top-level required key ✓
- collision missing a required field ✓
- `resolution` outside the enum ✓
- unknown collision keys ✓

**Full suite: 8 failures → 1, zero new.** The remaining `test_resolve_task_argument::test_very_long_string_ending_in_suffix_treated_as_literal` is a **separate pre-existing failure** on `main` (verified across 3 consecutive runs), unrelated to jsonschema and out of scope here — flagging so it isn't forgotten.

🤖 Generated with [Claude Code](https://claude.com/claude-code)