### PR TITLE
chore(release): 0.9.62

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "leerie",
       "source": ".",
-      "version": "0.9.61",
+      "version": "0.9.62",
       "description": "Deterministic, headless task orchestrator for Claude Code. Classifies a task, decomposes it into dependency-ordered waves, and executes each subtask in an isolated git worktree under an evidence-gated implement/validate loop. Runs entirely on the Claude Code CLI/subscription via `claude -p` workers."
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "leerie",
   "displayName": "Leerie",
-  "version": "0.9.61",
+  "version": "0.9.62",
   "description": "Deterministic, headless task orchestrator for Claude Code. Classifies a task, decomposes it into granular subtasks, schedules them into dependency-ordered waves, and executes each in an isolated git worktree under an evidence-gated implement/validate loop. Runs entirely on the Claude Code CLI/subscription via `claude -p` workers.",
   "author": { "name": "Andres Restrepo", "email": "andres@enricai.com", "url": "https://enricai.com" },
   "license": "MIT",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to Leerie will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.9.62]
 
 ### Fixed
 


### PR DESCRIPTION
Version bump + CHANGELOG for **v0.9.62**, following the repo's existing `chore(release)` convention (version bump and CHANGELOG in their own commit; the annotated tag then points at it).

## What ships

Two user-facing fixes since v0.9.61:

- **`resolve_task_argument`'s ENAMETOOLONG guard no longer depends on the interpreter** (#61). `Path.is_file()` swallows `OSError` on Python 3.14+ (it propagated through 3.13), silently defeating the guard — a long literal task ending in `.md`/`.txt` died with a bogus `task file not found: fix the login bug…`, telling the operator to fix a file that was never meant to be one. Latent today (the container runs 3.13); would have surfaced whenever Debian bumps.

- **A plan whose parent subtask got split no longer dies at `validate_plan`**, discarding the entire planning spend (#60).

#59 (`HAS_JSONSCHEMA` test gate) is **test-only** — 2 test files, no shipped code — so it carries no CHANGELOG entry, consistent with "notable changes".

## Verification

- Both manifests valid JSON and in sync at `0.9.62`; `tests/test_version_flag.py` (the drift guard) passes.
- `ast.parse` clean.
- Diff scoped to the three release files — no code changes ride along.
- `[Unreleased]` is now empty; both entries sit under `## [0.9.62]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)