### PR TITLE
docs(design): state the volume lifecycle in the canonical layer

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -2227,8 +2227,10 @@ branch).
 
 The compromise: classify the orchestrator's exit code on the host side
 and route to either *stop* (preserves volume, frees compute), *destroy*
-(full reap), or *leave alone* (the user merely detached the local
-stream — the orchestrator on the machine is still working). With the
+(full reap — machine **and** its volume; see *Volume lifecycle* below,
+since Fly reaps neither for us), or *leave alone* (the user merely
+detached the local stream — the orchestrator on the machine is still
+working). With the
 detached orchestrator above, the classification is no longer "how did
 the orchestrator's run exit?" but "what just happened on the host
 side?" — because the launcher process now exits when the *tail*
@@ -2316,6 +2318,46 @@ treat the spillover as a rootfs problem to solve separately. The
 rootfs's throughput cap (2,000 IOPS / 8 MiB/s) compounds disk
 pressure by slowing spillover; the volume accelerates it as a
 side-effect since per-machine tiers run 4k–32k IOPS.
+
+**Volume lifecycle — leerie owns the reap, because Fly does not.** A Fly
+volume is an independent resource with its own lifetime: *"a Machine can
+be destroyed without destroying its volume"*, and what survives is a
+documented **"unattached volume"** that keeps accruing per-GB-month
+charges indefinitely. There is no platform-side lifecycle hook to lean
+on — the Machines API's `auto_destroy` destroys the *machine* when its
+work completes, and says nothing about that machine's volumes; `mounts`
+has no ephemeral or destroy-on-exit mode. Since `FLY_VM_DISK_GB`
+defaults to `8`, **every** Fly run creates a volume, so an unreaped one
+is not an edge case — it is the default outcome of any teardown path
+that forgets. The obligation is therefore structural: *every* path that
+destroys a machine must also destroy its volume, and "the machine is
+already gone" is precisely when a known volume still needs reaping — not
+a reason to skip it. Gating the reap behind a live-machine check inverts
+the requirement, and did: it silently leaked the volume of every run
+whose machine died first.
+
+Two platform facts fix the ordering, and they pull in opposite
+directions. The volume→machine association lives **only** on Fly (the
+volume's `attached_machine_id`, and the machine's own `config.mounts`)
+and it vanishes the instant the machine is destroyed — so anything that
+needs to *learn* a volume from its machine must do so **before** the
+destroy. But Fly refuses to destroy a volume that is still attached
+("in use by machine X") — so the reap itself must come **after**. The
+reap is thus pinned between the two: look up, destroy machine, destroy
+volume. (A *stopped* machine keeps its attachment, which is what makes
+the pause/resume contract above compatible with this: a paused run's
+volume is still owned, still attached, and must not be reaped.)
+
+One residue is irreducible and deliberately unsolved. If a machine is
+destroyed **and** the launcher dies before reaping the volume (SIGKILL,
+crash), the association is gone from both sides — Fly no longer links
+them, and the host sidecar may never have recorded it. Such a volume
+cannot be attributed to its run by any mechanism, since volume names are
+random and encode nothing. leerie does not guess: there is no
+reconciliation sweep, because "unattached" alone cannot distinguish a
+true orphan from a volume whose machine is seconds away from attaching.
+The operator reaps these by hand (`flyctl volumes list` + `destroy`),
+and the code says so where it gives up.
 
 Six sidecar fields on `run.json` capture remote lifecycle state:
 


### PR DESCRIPTION
## What this is

A post-merge compliance audit of #64 and #66 against every rule in `CLAUDE.md`. **15 of 16 checks passed.** This PR fixes the one that didn't — a three-layer-rule violation I introduced in #66.

## The violation

CLAUDE.md: *"change the highest layer that the change touches **first**, then propagate down"* and *"DESIGN.md vs code → DESIGN.md wins; the code is the defect."*

#66 changed IMPLEMENTATION and code without touching DESIGN, on my judgment that a function split is "mechanism only." **That judgment was wrong, and DESIGN.md is the proof:**

- **`:2229`** asserted teardown routes to *"destroy (**full reap**)"* — an architectural claim that was **false in three code paths**. A reader of the canonical layer would have concluded the leak was impossible.
- **"Remote disk policy"** documented volume *creation*, the `/work` rationale, and the pause contract — but never said **who destroys the volume**.
- **`grep` for `unattached|outlive|orphan volume` in DESIGN → zero hits.** The platform semantic the whole fix depends on — *"a Machine can be destroyed without destroying its volume"*, leaving a documented *"unattached volume"* — was **absent from the canonical layer**.
- Meanwhile DESIGN names `destroy_machine`/`stop_machine` **six times**: the *machine* side of teardown was treated as architecture, the volume side wasn't. **That asymmetry is the blind spot that let the leak exist in the first place.**

"No platform lifecycle hook exists, therefore leerie owns volume reaping" is a constraint imposed from outside — the same class of fact as §6's *"the container PID 1 is not an init"*, which DESIGN **does** record. It belongs in the canonical layer, not only in a code comment.

## The change

Adds a *Volume lifecycle* subsection to *Remote disk policy*:

- **Fly volumes outlive their machines**; `auto_destroy` applies to the machine, not its volumes; `mounts` has no destroy-on-exit mode. Since `FLY_VM_DISK_GB` defaults to `8`, an unreaped volume isn't an edge case — it's the default outcome of any teardown path that forgets.
- **The obligation is structural**: every path that destroys a machine must destroy its volume, and *"the machine is already gone"* is precisely when a known volume still needs reaping — not a reason to skip it.
- **Ordering is pinned by two opposing platform facts**: the association vanishes with the machine (so look up **before**), but Fly refuses to destroy an attached volume (so reap **after**) → look up → destroy machine → destroy volume.
- **A stopped machine keeps its attachment**, which is what makes the pause/resume contract compatible: a paused run's volume is still owned and must not be reaped.
- **The irreducible residue** (machine destroyed *and* launcher SIGKILLed) is deliberately unsolved rather than guessed at — "unattached" alone can't distinguish a true orphan from a volume seconds away from attaching.

Also corrects `:2229` to say the reap covers the volume.

## Verification

- **Docs-only** — `git diff --stat` is `docs/DESIGN.md` only (44 insertions, 2 deletions).
- **IMPLEMENTATION and code already conform to every claim added here** — verified per-claim, so no downward propagation was needed. The code was never the defect; the canonical layer was silent.
- `pytest tests/` — **3390 passed**, unchanged (a delta would mean something unintended).
- No `docs/ANALYSIS.md` regen (`orchestrator/leerie.py` untouched).

## Audit results for the record

Everything else passed, executed rather than eyeballed: full suite (3390), AST parse, `docs/ANALYSIS.md` **byte-matches a fresh regeneration**, plugin manifests valid JSON, chain deprecated-alias guard (all five arms), no stragglers from the deleted `_orphan_zombie_children` (3 hits, all intentional), type hints + PEP 604 unions on every new signature, `shellcheck -S error` clean, and the `volume_id ⇒ fly_machine_id` sidecar invariant still coherent. **#64 followed the three-layer rule correctly** (DESIGN → IMPLEMENTATION → code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)