### PR TITLE
docs: expand the README "How it works" phase diagram to match the pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,12 +38,21 @@ leerie "<task>"
    ├─ Phase 1  Classify into 1..9 categories                    → 1 claude -p
    │             ↓ derive run_id (category + slug + start-hex)
    │           • Clarify — intent-only questions (optional; skipped for fully-specified tasks)
-   ├─ Phase 2  Plan — one planner per category (parallel)        → N claude -p
+   ├─ Phase 2  Plan — one planner per category (parallel)        → N×3 claude -p (multi-sampled)
+   │           • Decompose — repo-map-grounded recursive split into
+   │             right-sized leaf subtasks (P6 + P1)             → fit_judge / splitter
    │           • Reconcile — cross-domain capability-tag bridging (0 or 1 claude -p, when needed)
-   ├─ Phase 3  Schedule — global dependency graph → topo waves   (pure Python)
+   │           • Overlap-judge — cross-planner surface collisions (multi-planner runs only)
+   ├─ Phase 3  Schedule — global dependency graph → topo waves   (topo-sort pure Python;
+   │             a satisfied-probe drops already-done criterion-bearing subtasks → 1 claude -p each)
    ├─ Phase 4  Create leerie/runs/<run-id> branch + worktree (per-run unique)
-   ├─ Phase 5  Per wave: implement (parallel, isolated worktrees) → claude -p each
-   │           integrate into the run branch; validate the run branch
+   ├─ Phase 5  Per wave:
+   │   ├─ Implement each subtask (parallel, isolated worktrees)  → claude -p each
+   │   │     • self-gates on evidence-anchored confidence — the only hard gate
+   │   │     • Conform — post-work doc/test/lint/build pass (advisory) → 1 conformer claude -p
+   │   ├─ Integrate the wave into the run branch; on conflict    → 1 integrator claude -p
+   │   └─ Validate the integrated run branch (conflict-marker scan)
+   │         (after the final wave: one more conformer pass on the whole tree)
    └─ Phase 6  Push run branch; open PR against working branch; cleanup
                (working branch not modified locally)
 ```


### PR DESCRIPTION
## Summary

Docs-only. The README's "How it works" phase diagram was a stale subset of what the orchestrator actually does — it predates the P6+P1 recursive-decomposition work (#49/#51) and was never updated, even though the tagline right above it promises leerie "decomposes" the task. This brings the diagram up to the code (every claim verified line-by-line against `orchestrator/leerie.py`). No behavior change.

## Which layer(s) does this PR touch?

(See [`CLAUDE.md`](../CLAUDE.md) for the three-layer rule.)

- [ ] `docs/DESIGN.md` (architecture)
- [ ] `docs/IMPLEMENTATION.md` (code surface)
- [ ] `orchestrator/leerie.py` (code)
- [x] docs (`README.md`)
- [ ] tests (`tests/`)
- [ ] CI / repo meta (`.github/`, `CHANGELOG.md`)

If multiple, has the change propagated **top-down** per the three-layer rule (DESIGN → IMPLEMENTATION → code)?

- [x] not applicable (single layer) — the code and DESIGN/IMPLEMENTATION are authoritative and already describe all of this; the README is being brought *up to* them. DESIGN §3's own peer diagram deliberately stays leaner; this README diagram is allowed to show more.

### What changed

**Phase 2**
- Add **Decompose** (repo-map-grounded recursive split into right-sized leaf subtasks; `fit_judge` / `splitter`, P6 + P1) — runs inside `phase_plan` after the planners return (`recursive_decompose`, leerie.py:11934; `plan["subtasks"] = leaves`, :11942).
- Add **Overlap-judge**, distinct from Reconcile (cross-planner surface collisions; `plan_overlap_judge` worker; multi-planner runs only).
- `→ N claude -p` → `→ N×3 claude -p (multi-sampled)` — planners are multi-sampled 3× by default (`planner_samples`, leerie.py:129) then selected down to one per domain.

**Phase 3**
- Corrected the inaccurate bare `(pure Python)`: the topo-sort is pure Python, but the satisfied-probe filter spawns one `satisfied_probe` LLM worker per criterion-bearing subtask (`filter_satisfied_subtasks`, leerie.py:6211).

**Phase 5** (restructured to the real order + granularity)
- Implement and Conform are **per-subtask** (Conform runs inside `settle_subtask`, leerie.py:17526, **before** the wave integrates); Integrate and Validate are **per-wave** (`integrate_wave` :17833 → `scan_conflict_markers` :17841).
- Surface the confidence gate ("the only hard gate") under Implement.
- Add the integrator worker on conflict, the advisory conformer pass, the final-tree conformer pass after the last wave (`run_final_conformance`, :18795), and clarify "Validate" is a deterministic conflict-marker scan (not an LLM gate).

Deliberately **not** added (kept at DESIGN.md's altitude): Provision, budget-feasibility preflight, base-health baseline, dep_capture/pr_writer at finalize, cgroup containment, runtime/chain/groups.

## Task-completion checklist

- [x] `docs/IMPLEMENTATION.md` updated if code surface changed — N/A (no code-surface change; README describes existing behavior)
- [x] `docs/DESIGN.md` updated if architecture changed — N/A (architecture unchanged)
- [x] `pytest tests/` — N/A, no code touched
- [x] `python3 -c "import ast; ast.parse(...)"` — N/A, `orchestrator/leerie.py` untouched
- [x] `CHANGELOG.md` `[Unreleased]` — not updated (README overview polish, no user-facing behavior change; consistent with how prior diagram/prose tweaks were handled)
- [x] `git diff --stat` reviewed for scope — 1 file (`README.md`), 13 insertions / 4 deletions; scratch files (`DEPLOY-FIX.md`, `leerie-deploy.log`) deliberately left untracked

## Testing notes

No test coverage — documentation-only, no runtime surface. Every claim in the diagram was verified against `orchestrator/leerie.py`, including two independent adversarial passes. One defect was caught and fixed pre-PR: an earlier draft placed Conform after Integrate in Phase 5, but conformance runs per-subtask inside `settle_subtask` before the wave integrates — the diagram now reflects `Implement → Conform → Integrate → Validate`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
