### PR TITLE
leerie: Fix release.yml's silent-skip bugs and untested squash-merge regex

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,11 +41,18 @@ jobs:
           set -euo pipefail
           subject="$(git log -1 --pretty=%s)"
           echo "subject=$subject"
-          # Match exactly `chore(release): X.Y.Z` (semver, three numeric
-          # components). Trailing whitespace is tolerated; anything else
-          # in the subject is not — this prevents accidental matches
-          # from "chore(release): 0.3.15 plus follow-up" etc.
-          if [[ "$subject" =~ ^chore\(release\):[[:space:]]+([0-9]+\.[0-9]+\.[0-9]+)[[:space:]]*$ ]]; then
+          # Match `chore(release): X.Y.Z` (semver, three numeric
+          # components), optionally followed by the squash-merge PR-title
+          # suffix `(#N)` that GitHub appends because this repo sets
+          # squash_merge_commit_title: COMMIT_OR_PR_TITLE. Without the
+          # optional group, every PR-merged release commit (the default
+          # path) fails to match — v0.9.62 was released this way and has
+          # no tag or release to this day. The space before `(#` inside
+          # the group is required, so "0.9.62(#62)" (no space) still
+          # fails; anything else in the subject is also rejected — this
+          # prevents accidental matches from "chore(release): 0.3.15 plus
+          # follow-up" etc.
+          if [[ "$subject" =~ ^chore\(release\):[[:space:]]+([0-9]+\.[0-9]+\.[0-9]+)([[:space:]]+\(#[0-9]+\))?[[:space:]]*$ ]]; then
             version="${BASH_REMATCH[1]}"
             echo "version=$version" >> "$GITHUB_OUTPUT"
             echo "is_release=true" >> "$GITHUB_OUTPUT"
@@ -82,7 +89,7 @@ jobs:
           print(f"version OK: {plugin}")
           PY
 
-      - name: Skip if tag already exists (idempotent)
+      - name: Check whether the tag exists (idempotent)
         if: steps.parse.outputs.is_release == 'true'
         id: tagcheck
         env:
@@ -90,15 +97,34 @@ jobs:
         run: |
           set -euo pipefail
           tag="v$VERSION"
-          if git ls-remote --tags origin "refs/tags/$tag" | grep -q "$tag"; then
-            echo "Tag $tag already exists on origin — nothing to do."
-            echo "skip=true" >> "$GITHUB_OUTPUT"
+          # Unanchored `grep -q "$tag"` would match "v0.9.6" inside
+          # "v0.9.64"; require ls-remote to return a non-empty line for
+          # the exact ref instead.
+          if [ -n "$(git ls-remote --tags origin "refs/tags/$tag")" ]; then
+            echo "Tag $tag already exists on origin."
+            echo "exists=true" >> "$GITHUB_OUTPUT"
           else
-            echo "skip=false" >> "$GITHUB_OUTPUT"
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Check whether the release exists (idempotent)
+        if: steps.parse.outputs.is_release == 'true'
+        id: relcheck
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.parse.outputs.version }}
+        run: |
+          set -euo pipefail
+          tag="v$VERSION"
+          if gh release view "$tag" >/dev/null 2>&1; then
+            echo "Release $tag already exists."
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Create and push annotated tag
-        if: steps.parse.outputs.is_release == 'true' && steps.tagcheck.outputs.skip != 'true'
+        if: steps.parse.outputs.is_release == 'true' && steps.tagcheck.outputs.exists != 'true'
         env:
           VERSION: ${{ steps.parse.outputs.version }}
         run: |
@@ -110,7 +136,7 @@ jobs:
           git push origin "$tag"
 
       - name: Create GitHub Release
-        if: steps.parse.outputs.is_release == 'true' && steps.tagcheck.outputs.skip != 'true'
+        if: steps.parse.outputs.is_release == 'true' && steps.relcheck.outputs.exists != 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION: ${{ steps.parse.outputs.version }}
@@ -120,4 +146,27 @@ jobs:
           # --generate-notes pulls PRs/commits since the prior tag.
           # First-ever release (v0.3.15) will include all repo history
           # in its notes — one-time noise; the operator can hand-edit.
-          gh release create "$tag" --title "$tag" --generate-notes
+          # --verify-tag refuses to invent a tag from the wrong commitish
+          # if the tag push above silently failed.
+          gh release create "$tag" --title "$tag" --generate-notes --verify-tag
+
+      - name: Verify both tag and release exist
+        if: steps.parse.outputs.is_release == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.parse.outputs.version }}
+        run: |
+          set -euo pipefail
+          tag="v$VERSION"
+          missing=()
+          if [ -z "$(git ls-remote --tags origin "refs/tags/$tag")" ]; then
+            missing+=("tag")
+          fi
+          if ! gh release view "$tag" >/dev/null 2>&1; then
+            missing+=("release")
+          fi
+          if [ "${#missing[@]}" -gt 0 ]; then
+            echo "::error::Release $tag ended in a half-broken state — missing: ${missing[*]}"
+            exit 1
+          fi
+          echo "End state OK: $tag has both a tag and a release."

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v7
+        with:
+          # Full history: tests/test_release_workflow.py walks every
+          # `chore(release):` subject on the repo. The default fetch-depth: 1
+          # (shallow, detached HEAD, no `main` ref) makes that test fail — do
+          # not shrink this back without updating that test.
+          fetch-depth: 0
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v6

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -890,6 +890,18 @@ unresolvable; profile resolution precedence (`--profile` passthrough,
 in both the `aws sts get-caller-identity` call and the sso-login hint. Not
 yet wired into the launcher's `RUNTIME=ec2` dispatch branch (that lands in a
 separate subtask); this test file covers only the standalone helper.
+The release workflow's previously-untested embedded shell
+(`.github/workflows/release.yml`) is covered in `tests/test_release_workflow.py`,
+which works against the raw YAML text (no pyyaml dependency) using the
+extract-the-real-text-at-test-time pattern from `tests/test_config_verb.py`'s
+`_extract_config_arm`: a regex table (including the v0.9.62 squash-merge
+subject and every historical `chore(release):` subject on `main`, run live
+rather than pinned to a stale count) and structural pins that the tag and
+release steps gate on different `if:` conditions, that the release step
+never references `tagcheck`, that `relcheck` exists and probes via
+`gh release view`, that `gh release create` carries `--verify-tag`, and that
+a final end-state step (gated on default `success()`, not `always()`) is the
+job's last step and asserts both artifacts exist.
 No coverage
 target is set — the suite was introduced from scratch and a number
 now would be arbitrary.

--- a/docs/IMPLEMENTATION.md
+++ b/docs/IMPLEMENTATION.md
@@ -6272,19 +6272,24 @@ lifecycle tiers) completes in roughly a minute end to end. The table
 above lists a representative subset; the live count under `tests/`
 is the authoritative inventory.
 
-**CI surface.** GitHub Actions runs three independent workflows on every
-pull request to `main` (and on pushes to `main`):
+**CI surface.** GitHub Actions runs four independent workflows: three on
+every pull request to `main` (and on pushes to `main`), plus `release.yml`
+on pushes to `main` only:
 
 | Workflow | What it does |
 |----------|--------------|
 | `.github/workflows/test.yml` | `pytest tests/ -ra` across Python 3.10 / 3.11 / 3.12, with `pytest-cov` reporting line coverage to the job summary (no gate per CLAUDE.md). Coverage XML is uploaded as a 7-day artifact from the 3.12 job. Dev dependencies (`pytest`, `pytest-cov`) installed inline per CLAUDE.md's "pytest is the only dev dependency" stance. |
 | `.github/workflows/syntax.yml` | The AST parse from CLAUDE.md's task-completion checklist, plus the same parse over every file under `tests/`. Path-filtered to `orchestrator/**/*.py` and `tests/**/*.py` for fast feedback ahead of the full pytest matrix. |
 | `.github/workflows/shellcheck.yml` | `shellcheck -x scripts/*.sh` — the worktree mechanics scripts are load-bearing (DESIGN §6). Path-filtered to `scripts/**/*.sh`. |
+| `.github/workflows/release.yml` | On a `chore(release): X.Y.Z` commit subject landing on `main`, creates the `vX.Y.Z` tag and a matching GitHub Release, or fails loudly (`::error::` + exit 1) if either is missing at job end. Both idempotency checks (tag-exists, release-exists) gate independently so a pre-existing tag or release never silently skips the other. |
 
-Each workflow has a `concurrency:` block keyed on `github.ref` with
-`cancel-in-progress: true`, so a force-push or rapid pushes do not
-leave superseded jobs in flight. Dependabot (`.github/dependabot.yml`)
-tracks the GitHub-Actions ecosystem on a weekly cadence.
+Most workflows have a `concurrency:` block keyed on `github.ref` with
+`cancel-in-progress: true`, so a force-push or rapid pushes do not leave
+superseded jobs in flight; `release.yml` is the exception —
+`cancel-in-progress: false`, since cancelling a release mid-flight (after
+the tag push but before the release is created) is worse than letting it
+finish. Dependabot (`.github/dependabot.yml`) tracks the GitHub-Actions
+ecosystem on a weekly cadence.
 
 **Not tested.** No worker has run against a live `claude -p`. The flag
 contract in §3 is from CLI documentation, not from observed runs. The

--- a/tests/test_release_workflow.py
+++ b/tests/test_release_workflow.py
@@ -107,14 +107,27 @@ def test_regex_matches_every_historical_release_subject_on_main():
     subject ever merged to main must match the widened regex. This is the
     131/131 (measured) claim — run live rather than pinned to a stale
     count, so it keeps holding as new releases land."""
-    result = subprocess.run(
-        ["git", "log", "main", "--pretty=%s"],
-        cwd=REPO_ROOT, capture_output=True, text=True, check=True,
+    # Resolve a ref that carries full history in whichever environment we run:
+    # `origin/main` exists in a full-history PR checkout (detached HEAD, but the
+    # remote-tracking ref is present), `main` in a normal local clone, and
+    # `HEAD` is the universal fallback — a PR branch descended from main still
+    # contains every historical `chore(release):` subject. (CI's default
+    # fetch-depth: 1 has no `main` ref at all; test.yml sets fetch-depth: 0.)
+    subjects = None
+    for ref in ("origin/main", "main", "HEAD"):
+        result = subprocess.run(
+            ["git", "log", ref, "--pretty=%s"],
+            cwd=REPO_ROOT, capture_output=True, text=True,
+        )
+        if result.returncode == 0:
+            subjects = [
+                line for line in result.stdout.splitlines()
+                if line.startswith("chore(release):")
+            ]
+            break
+    assert subjects is not None, (
+        "no release-history ref resolved (origin/main, main, HEAD)"
     )
-    subjects = [
-        line for line in result.stdout.splitlines()
-        if line.startswith("chore(release):")
-    ]
     assert len(subjects) > 100, (
         "expected the repo's real release history (100+ commits); got "
         f"{len(subjects)} — is this running against a shallow clone?"

--- a/tests/test_release_workflow.py
+++ b/tests/test_release_workflow.py
@@ -1,0 +1,300 @@
+"""Tests for `.github/workflows/release.yml`.
+
+Nothing in `tests/` previously touched `.github/workflows/`, and
+`shellcheck.yml` lints only `scripts/*.sh` — the embedded `run:` shell in
+this workflow was untested, which is how it shipped two silent-skip bugs
+(see CLAUDE.md's central principle: guarantees that matter and can be
+checked mechanically live in code, not in a workflow prompt/comment).
+
+No YAML parser is used (pyyaml isn't a dependency — CLAUDE.md: "pytest is
+the only dev dependency"). Instead this file works against the raw text of
+the shipped workflow, either by re-running the exact regex embedded in the
+`run:` block (regex table) or by pinning structural properties of the YAML
+text via string search (gate independence, end-state step).
+"""
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "release.yml"
+
+# The exact pattern embedded in release.yml's "Parse release version from
+# commit subject" step. Bash [[:space:]] is equivalent to Python's \s for
+# ASCII whitespace, which is all that appears in real commit subjects.
+_RELEASE_SUBJECT_RE = re.compile(
+    r"^chore\(release\):[ \t]+([0-9]+\.[0-9]+\.[0-9]+)"
+    r"([ \t]+\(#[0-9]+\))?[ \t]*$"
+)
+
+
+def _workflow_text() -> str:
+    return WORKFLOW_PATH.read_text()
+
+
+# ---------------------------------------------------------------------------
+# Regex table: the widened pattern must match every real release subject
+# (including the v0.9.62 squash-merge casualty) while still rejecting
+# malformed subjects.
+# ---------------------------------------------------------------------------
+
+_SHOULD_MATCH = [
+    "chore(release): 0.9.65",
+    "chore(release): 0.9.64",
+    "chore(release): 0.9.63",
+    "chore(release): 0.9.62 (#62)",  # the squash-merge casualty
+    "chore(release): 0.3.15",
+    "chore(release): 1.0.0 (#1)",
+    "chore(release): 0.9.9 (#999)",
+]
+
+_SHOULD_NOT_MATCH = [
+    "chore(release): 0.9.62(#62)",  # no space before "(#" — still rejected
+    "chore(release): 0.3.15 plus follow-up",
+    "chore(release): (#abc)",
+    "chore(release):0.3.15",  # no space after colon
+    "chore(release): 0.3",  # not three components
+    "feat: chore(release): 0.9.62",
+    "chore(release): 0.9.62 (62)",  # missing '#'
+    "chore(release): 0.9.62 extra (#62)",
+]
+
+
+def test_regex_source_matches_shipped_workflow():
+    """Pin that the module-level test regex is byte-identical (modulo the
+    bash->python [[:space:]]->[ \\t] translation) to the pattern actually
+    shipped in release.yml, so this file cannot silently drift from the
+    real workflow."""
+    text = _workflow_text()
+    marker = "if [[ \"$subject\" =~ "
+    start = text.index(marker) + len(marker)
+    end = text.index(" ]]; then", start)
+    shipped_pattern = text[start:end]
+    expected = (
+        r"^chore\(release\):[[:space:]]+([0-9]+\.[0-9]+\.[0-9]+)"
+        r"([[:space:]]+\(#[0-9]+\))?[[:space:]]*$"
+    )
+    assert shipped_pattern == expected, (
+        f"release.yml regex changed without updating this test's mirror: "
+        f"{shipped_pattern!r}"
+    )
+
+
+def test_regex_matches_valid_release_subjects():
+    for subject in _SHOULD_MATCH:
+        assert _RELEASE_SUBJECT_RE.match(subject), (
+            f"expected match: {subject!r}"
+        )
+
+
+def test_regex_rejects_invalid_release_subjects():
+    for subject in _SHOULD_NOT_MATCH:
+        assert not _RELEASE_SUBJECT_RE.match(subject), (
+            f"expected no match: {subject!r}"
+        )
+
+
+def test_regex_extracts_version_ignoring_pr_suffix():
+    m = _RELEASE_SUBJECT_RE.match("chore(release): 0.9.62 (#62)")
+    assert m is not None
+    assert m.group(1) == "0.9.62"
+
+
+def test_regex_matches_every_historical_release_subject_on_main():
+    """Executed against the repo's real history: every `chore(release):`
+    subject ever merged to main must match the widened regex. This is the
+    131/131 (measured) claim — run live rather than pinned to a stale
+    count, so it keeps holding as new releases land."""
+    result = subprocess.run(
+        ["git", "log", "main", "--pretty=%s"],
+        cwd=REPO_ROOT, capture_output=True, text=True, check=True,
+    )
+    subjects = [
+        line for line in result.stdout.splitlines()
+        if line.startswith("chore(release):")
+    ]
+    assert len(subjects) > 100, (
+        "expected the repo's real release history (100+ commits); got "
+        f"{len(subjects)} — is this running against a shallow clone?"
+    )
+    unmatched = [s for s in subjects if not _RELEASE_SUBJECT_RE.match(s)]
+    assert unmatched == [], f"regex failed to match real subjects: {unmatched}"
+
+
+def test_old_regex_misses_the_v0_9_62_subject():
+    """Documents the bug this subtask fixes: the pre-fix regex (no optional
+    PR-suffix group) rejects the exact subject that shipped v0.9.62's PR
+    merge, which is why that release has no tag and no release to this
+    day."""
+    old_re = re.compile(
+        r"^chore\(release\):[ \t]+([0-9]+\.[0-9]+\.[0-9]+)[ \t]*$"
+    )
+    assert not old_re.match("chore(release): 0.9.62 (#62)")
+    assert _RELEASE_SUBJECT_RE.match("chore(release): 0.9.62 (#62)")
+
+
+# ---------------------------------------------------------------------------
+# Gate independence: tag creation and release creation must not share a
+# single `if:` condition (Bug 1 — a pre-existing tag silently skipped both).
+# ---------------------------------------------------------------------------
+
+def _step_block(text: str, step_name: str) -> str:
+    """Return the YAML text of a single step, from its `- name:` line up to
+    (not including) the next `- name:` line, or end-of-file if this is the
+    last step."""
+    marker = f"- name: {step_name}\n"
+    start = text.index(marker)
+    try:
+        next_step = text.index("- name:", start + len(marker))
+    except ValueError:
+        next_step = len(text)
+    return text[start:next_step]
+
+
+def test_tag_and_release_steps_have_different_if_gates():
+    text = _workflow_text()
+    tag_step = _step_block(text, "Create and push annotated tag")
+    release_step = _step_block(text, "Create GitHub Release")
+
+    tag_if = re.search(r"if: (.+)", tag_step).group(1).strip()
+    release_if = re.search(r"if: (.+)", release_step).group(1).strip()
+
+    assert tag_if != release_if, (
+        "tag and release steps share one `if:` gate again — a pre-existing "
+        "tag will silently skip release creation too (the v0.9.64 bug)"
+    )
+
+
+def test_release_step_does_not_reference_tagcheck():
+    text = _workflow_text()
+    release_step = _step_block(text, "Create GitHub Release")
+    assert "tagcheck" not in release_step, (
+        "release step must gate on relcheck, not tagcheck — gating on "
+        "tagcheck ties release creation to tag existence again"
+    )
+
+
+def test_tagcheck_step_emits_exists_output():
+    text = _workflow_text()
+    tagcheck_step = _step_block(text, "Check whether the tag exists (idempotent)")
+    assert 'id: tagcheck' in tagcheck_step
+    assert "exists=true" in tagcheck_step
+    assert "exists=false" in tagcheck_step
+    # The old `skip` output name conflated "tag present" (a fact) with
+    # "don't release" (a policy) — must not reappear.
+    assert "skip=" not in tagcheck_step
+
+
+def test_tagcheck_uses_nonempty_string_check_not_grep():
+    """Unanchored `grep -q "$tag"` matches "v0.9.6" inside "v0.9.64"; the
+    fix must use an exact-ref-presence check instead. (The step's comment
+    is allowed to mention `grep -q` when explaining why it was replaced —
+    only the executable `run:` body must not use it.)"""
+    text = _workflow_text()
+    tagcheck_step = _step_block(text, "Check whether the tag exists (idempotent)")
+    run_body = tagcheck_step.split("run: |", 1)[1]
+    executable_lines = [
+        line for line in run_body.splitlines()
+        if line.strip() and not line.strip().startswith("#")
+    ]
+    executable_body = "\n".join(executable_lines)
+    assert "grep -q" not in executable_body
+    assert '[ -n "$(git ls-remote' in executable_body
+
+
+def test_relcheck_step_exists_and_probes_via_gh_release_view():
+    text = _workflow_text()
+    relcheck_step = _step_block(text, "Check whether the release exists (idempotent)")
+    assert "id: relcheck" in relcheck_step
+    assert "gh release view" in relcheck_step
+    assert "exists=true" in relcheck_step
+    assert "exists=false" in relcheck_step
+
+
+def test_tag_step_gates_on_tagcheck_exists():
+    text = _workflow_text()
+    tag_step = _step_block(text, "Create and push annotated tag")
+    assert "steps.tagcheck.outputs.exists != 'true'" in tag_step
+
+
+def test_release_step_gates_on_relcheck_exists():
+    text = _workflow_text()
+    release_step = _step_block(text, "Create GitHub Release")
+    assert "steps.relcheck.outputs.exists != 'true'" in release_step
+
+
+def test_release_create_carries_verify_tag():
+    text = _workflow_text()
+    release_step = _step_block(text, "Create GitHub Release")
+    assert "gh release create" in release_step
+    assert "--verify-tag" in release_step
+    # --generate-notes must be preserved as-is (the --notes-start-tag idea
+    # was investigated and cut — the live GitHub API already picks the
+    # right prior tag in this repo).
+    assert "--generate-notes" in release_step
+    assert "--notes-start-tag" not in release_step
+
+
+# ---------------------------------------------------------------------------
+# Final end-state guard: half-broken releases must fail loudly.
+# ---------------------------------------------------------------------------
+
+def test_end_state_step_exists_and_gates_on_default_success():
+    text = _workflow_text()
+    step = _step_block(text, "Verify both tag and release exist")
+    # No explicit `if:` beyond the is_release guard means it inherits the
+    # default `success()` gate. `always()` would double-report a manifest
+    # failure and fire on cancellation — must not appear here.
+    assert "always()" not in step
+    assert "::error::" in step
+    assert re.search(r"\bexit 1\b", step)
+
+
+def test_end_state_step_checks_both_tag_and_release():
+    text = _workflow_text()
+    step = _step_block(text, "Verify both tag and release exist")
+    assert "git ls-remote" in step
+    assert "gh release view" in step
+
+
+def test_end_state_step_is_last_step_in_the_job():
+    text = _workflow_text()
+    end_state_marker = "- name: Verify both tag and release exist\n"
+    assert text.count(end_state_marker) == 1
+    idx = text.index(end_state_marker)
+    remaining = text[idx + len(end_state_marker):]
+    assert "- name:" not in remaining, (
+        "the end-state guard must be the final step so it observes the "
+        "true end state of the job"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Ordering and untouched-surface pins.
+# ---------------------------------------------------------------------------
+
+def test_manifest_check_precedes_tagcheck():
+    text = _workflow_text()
+    manifest_idx = text.index("- name: Verify both manifests agree with subject version")
+    tagcheck_idx = text.index("- name: Check whether the tag exists")
+    assert manifest_idx < tagcheck_idx, (
+        "the manifest version check must run before tagcheck — a "
+        "version-mismatched release must never reach a tag"
+    )
+
+
+def test_checkout_concurrency_permissions_untouched():
+    text = _workflow_text()
+    assert "actions/checkout@v7" in text
+    assert "cancel-in-progress: false" in text
+    assert "contents: write" in text
+
+
+def test_manifest_python_step_untouched():
+    text = _workflow_text()
+    step = _step_block(text, "Verify both manifests agree with subject version")
+    assert "plugin.json" in step
+    assert "marketplace.json" in step
+    assert "sys.exit(1)" in step


### PR DESCRIPTION
## Summary

<!-- 1-2 sentences. Why is this change being made, and what does it do? -->

`release.yml` could report success while creating no release: a pre-existing tag silently skipped both tag *and* release creation (the v0.9.64 bug), and the release-commit regex rejected squash-merged PR titles like `chore(release): 0.9.62 (#62)` (the v0.9.62 bug — no tag or release to this day). This splits the tag/release idempotency gates so they no longer share one `if:` condition, widens the regex to accept the `(#N)` suffix, adds `--verify-tag` to `gh release create`, and adds a final end-state step that fails loudly instead of reporting a false green.

## Which layer(s) does this PR touch?

(See [`CLAUDE.md`](../CLAUDE.md) for the three-layer rule.)

- [ ] `docs/DESIGN.md` (architecture)
- [x] `docs/IMPLEMENTATION.md` (code surface)
- [ ] `orchestrator/leerie.py` (code)
- [x] docs (`README.md`, `docs/USAGE.md`, `CONTRIBUTING.md`, etc.) — `CLAUDE.md`
- [x] tests (`tests/`)
- [x] CI / repo meta (`.github/`, `CHANGELOG.md`) — `.github/workflows/release.yml`

If multiple, has the change propagated **top-down** per the three-layer rule
(DESIGN → IMPLEMENTATION → code)?

- [x] yes
- [ ] not applicable (single layer)

## Task-completion checklist

(Mirrors `CLAUDE.md` and `CONTRIBUTING.md`.)

- [x] `docs/IMPLEMENTATION.md` updated if code surface changed — CI-surface section corrected: "three" → "four" workflows, `release.yml` row added, blanket `cancel-in-progress: true` claim qualified
- [ ] `docs/DESIGN.md` updated if architecture changed — not touched; its only tag-related content concerns leerie's own chain-wave tagging, not releases
- [x] `pytest tests/` passes — see Conformance notes below
- [x] `python3 -c "import ast; ast.parse(open('orchestrator/leerie.py').read())"` passes
- [ ] `CHANGELOG.md` `[Unreleased]` updated
- [x] `git diff --stat` reviewed for scope (no collateral edits)

## Testing notes

<!-- What new test coverage did you add? If none, why not? -->

Added `tests/test_release_workflow.py` (20 tests), working against the raw YAML text (no pyyaml — pytest stays the only dev dependency), using the extract-the-real-text-at-test-time pattern from `tests/test_config_verb.py`'s `_extract_config_arm`. Covers:

- The regex table, including the v0.9.62 squash-merge subject and every historical `chore(release):` subject on `main` (run live, not pinned to a stale count).
- Gate independence: the tag and release steps gate on different `if:` conditions, the release step never references `tagcheck`, and the new `relcheck` step exists and probes via `gh release view`.
- The end-state step: gated on default `success()` (not `always()`), asserts both artifacts exist, and is the job's last step.

## Related issue

<!-- Closes #N -->

Fixes the two silent-skip bugs surfaced by the hand-pushed `v0.9.64` tag (run 29394636066, green in 9s, created nothing) and the still-unreleased `v0.9.62` (squash-merged, no tag/release to this day).

## Conformance notes

- **tests**: `pytest` → 3508 passed, 2 skipped, 34 failed. All 34 failures are in files outside this run's diff (`tests/test_host_finalize_sh.py`, `tests/test_finalize_sh_behavior.py`, `tests/test_decide_teardown_auto_finalize.py`, `tests/test_external_leerie_branch.py`, `tests/test_launcher_finalize_no_work.py`, `tests/test_launcher_no_push_skips.py`, `tests/test_provision_sh_lifecycle.py`, `tests/test_re_seed.py`, `tests/test_signal_cleanup.py`) and stem from sandbox environment gaps (missing `jq` binary, sandbox lacking privileges for signal/cgroup/subreaper tests) — not from the `release.yml` hardening change. This run's own `tests/test_release_workflow.py` (20 tests) passes cleanly.
- **residual — "build/lint/tests must pass"**: not fixed, for the same reason above — the 34 failures are attributed by diff-membership per the conformer instructions (baseline for the `tests` axis was unmeasurable on the base tree).
