### PR TITLE
test: gate host-only tests on jq (fixes 23 container-only failures)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1174,6 +1174,34 @@ so it is a macOS-developer guard, never a CI flake. Paired with a
 source-level `local -n` / `declare -n` ban (namerefs are bash 4.3+;
 echo the tokens instead — see `_aws_region_profile_args`).
 
+**Host-only tests are gated on `jq`** (`HAS_JQ` in `tests/conftest.py`,
+mirroring the `HAS_TREESITTER` pattern). Four modules —
+`test_host_finalize_sh.py` (19 tests), `test_decide_teardown_auto_finalize.py`
+(2), `test_launcher_finalize_no_work.py` (1), `test_launcher_no_push_skips.py`
+(1) — source bash the **host** owns: `scripts/host-finalize.sh`,
+`provision.sh`'s `decide_teardown`, and the launcher's `--finalize` /
+`no_push` paths. All parse `run.json` with real `jq`. The harnesses stub
+`git` and `gh` onto PATH but not `jq`, so jq is silently inherited from
+whichever machine runs pytest — it passes on a dev host and in CI (both ship
+jq) and failed only inside the leerie image, which deliberately omits it.
+That is the host/container split: host bash uses `jq` (the launcher
+hard-fails at preflight without it — "jq not found on PATH", `brew install
+jq`), while code running *inside* the container uses python3, exactly as
+`scripts/remote/seed-auth.sh` documents ("python3 over jq because jq isn't in
+the leerie image (see Dockerfile)"). `gh` **is** in the image for the mirror
+reason: Python inside the container preflights for it.
+**Do not "fix" a skip here by adding `jq` to the Dockerfile.** Per DESIGN §6
+*Finalization* those scripts can never succeed in-container anyway (gh auth,
+ssh-agent, and Keychain are host-side), so installing jq buys a green tick,
+not working code, and erodes the boundary. Note a `grep jq` does **not**
+reproduce the gated list — two of the four never mention jq and fail only
+because the script under test shells out to it; the list is measured from a
+real in-container run. `tests/test_jq_gate_wiring.py` is the guard-the-guard
+(conftest exposes a module-level `HAS_JQ` bool derived from a live
+`shutil.which` probe; each of the four both imports it and carries a
+`skipif` referencing it) — dropping one file's skipif fails it, which is the
+same silent regression the `HAS_TREESITTER` gate exists to prevent.
+
 Three test-side traps in the same area, all of which made a test pass or
 hang while proving nothing:
 `tests/test_ec2_transport.py::_stub_timeout` must **kill the process

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,7 @@ fixture.
 from __future__ import annotations
 
 import importlib.util
+import shutil
 from pathlib import Path
 
 import pytest
@@ -43,3 +44,26 @@ def _has_treesitter() -> bool:
 # Evaluated once at collection; extraction-dependent repo-map test modules
 # import this to skip cleanly on hosts without a working parser.
 HAS_TREESITTER = _has_treesitter()
+
+
+# Evaluated once at collection; test modules that exercise *host-side* bash
+# import this to skip cleanly where `jq` is absent.
+#
+# Why a gate rather than adding jq to the image: the host/container split is
+# deliberate. Host bash uses `jq` — the launcher hard-fails at preflight
+# without it (`leerie`'s "jq not found on PATH" check, which tells you to
+# `brew install jq`) — while code that runs *inside* the container uses
+# python3, exactly as `scripts/remote/seed-auth.sh` documents: "python3 over
+# jq because jq isn't in the leerie image (see Dockerfile)".
+#
+# The gated modules source scripts the host owns (`host-finalize.sh`,
+# `provision.sh`'s `decide_teardown`, the launcher's finalize path) and stub
+# `git`/`gh` on PATH but not `jq`, so they silently inherit it from whichever
+# machine runs pytest. They pass on a dev host and in CI (both ship jq) and
+# fail only inside `leerie:<version>` — where the scripts under test could
+# never succeed anyway, since gh auth, ssh-agent, and Keychain are all
+# host-side (DESIGN §6 *Finalization*).
+#
+# Do NOT "fix" a skip here by installing jq into the image: that buys a green
+# tick, not working code, and erodes the boundary.
+HAS_JQ = shutil.which("jq") is not None

--- a/tests/test_decide_teardown_auto_finalize.py
+++ b/tests/test_decide_teardown_auto_finalize.py
@@ -17,6 +17,19 @@ import os
 import subprocess
 from pathlib import Path
 
+import pytest
+
+from tests.conftest import HAS_JQ
+
+# decide_teardown runs in the launcher's own host shell (an EXIT/INT/TERM
+# trap), and reads run.json's finished_at with real `jq`. Host-only by
+# construction; see `tests/conftest.py`'s HAS_JQ.
+pytestmark = pytest.mark.skipif(
+    not HAS_JQ,
+    reason="host-only script: needs real `jq`, which the launcher guarantees "
+           "on the host and the leerie image deliberately omits",
+)
+
 REPO_ROOT = Path(__file__).resolve().parent.parent
 PROVISION_SH = REPO_ROOT / "scripts" / "remote" / "provision.sh"
 

--- a/tests/test_host_finalize_sh.py
+++ b/tests/test_host_finalize_sh.py
@@ -22,6 +22,23 @@ import json
 import subprocess
 from pathlib import Path
 
+import pytest
+
+from tests.conftest import HAS_JQ
+
+# host-finalize.sh is host-owned by design (DESIGN §6 *Finalization*: gh auth,
+# ssh-agent, and Keychain are host-side, so the container cannot push). It
+# parses run.json with real `jq`, which this harness stubs neither — unlike
+# `git`/`gh`, jq is inherited from whatever machine runs pytest. A dev host and
+# CI both ship it; the leerie image deliberately does not. See
+# `tests/conftest.py`'s HAS_JQ for why installing jq into the image is the
+# wrong fix.
+pytestmark = pytest.mark.skipif(
+    not HAS_JQ,
+    reason="host-only script: needs real `jq`, which the launcher guarantees "
+           "on the host and the leerie image deliberately omits",
+)
+
 REPO_ROOT = Path(__file__).resolve().parent.parent
 HOST_FINALIZE_SH = REPO_ROOT / "scripts" / "host-finalize.sh"
 

--- a/tests/test_jq_gate_wiring.py
+++ b/tests/test_jq_gate_wiring.py
@@ -1,0 +1,90 @@
+"""Source-coupling pins for the HAS_JQ gate wiring.
+
+Pins the coupling that makes the 23 host-only tests skip cleanly inside the
+leerie container instead of failing there:
+  1. conftest exposes a module-level HAS_JQ bool, computed from a real PATH
+     lookup (not, say, a platform check — jq's presence is the actual
+     dependency, and it is absent in the image while present on dev hosts
+     and CI runners alike).
+  2. Each of the four host-only test modules imports HAS_JQ from
+     tests.conftest AND gates on it via a module-level skipif.
+
+Why these four are host-only: they source bash the *host* owns —
+`scripts/host-finalize.sh`, `provision.sh`'s `decide_teardown`, and the
+launcher's own `--finalize` / `no_push` paths — all of which parse run.json
+with real `jq`. The harnesses stub `git` and `gh` onto PATH but not `jq`, so
+jq is silently inherited from whichever machine runs pytest. Per DESIGN §6
+*Finalization* those scripts could never succeed in-container anyway (gh
+auth, ssh-agent, and Keychain are host-side), so skipping is honest rather
+than lossy.
+
+A silent regression here — dropping the skipif from one file — re-introduces
+that file's failures inside the container with no other signal. This trap is
+not hypothetical: the HAS_TREESITTER gate exists because exactly that
+happened to 19 tree-sitter tests, and `test_host_finalize_sh.py` alone
+accounts for 19 of the 23 here.
+
+Mirrors tests/test_repo_map_gate_wiring.py.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import tests.conftest as conftest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+TESTS_DIR = REPO_ROOT / "tests"
+
+# Measured, not inferred: these are the modules that fail inside
+# leerie:<version> with "jq: command not found". A grep for "jq" does NOT
+# reproduce this list — test_decide_teardown_auto_finalize.py and
+# test_launcher_finalize_no_work.py never mention jq themselves; they fail
+# because the script under test shells out to it.
+GATED_MODULES = [
+    "test_host_finalize_sh.py",
+    "test_decide_teardown_auto_finalize.py",
+    "test_launcher_finalize_no_work.py",
+    "test_launcher_no_push_skips.py",
+]
+
+
+def test_conftest_exposes_has_jq_bool():
+    """The flag must exist and be a plain bool evaluated at import time, so
+    modules can use it in a module-level skipif at collection."""
+    assert hasattr(conftest, "HAS_JQ"), (
+        "tests/conftest.py must expose a module-level HAS_JQ")
+    assert isinstance(conftest.HAS_JQ, bool)
+
+
+def test_has_jq_reflects_a_real_path_lookup():
+    """HAS_JQ must be derived from an actual PATH probe.
+
+    Pinning the mechanism, not the value: the value legitimately differs by
+    machine (True on a dev host and in CI, False in the leerie image), which
+    is the entire point of the gate."""
+    import shutil
+
+    assert conftest.HAS_JQ == (shutil.which("jq") is not None), (
+        "HAS_JQ must agree with a live `shutil.which('jq')` lookup")
+
+
+def test_gated_modules_import_and_use_has_jq():
+    """Each host-only module must BOTH import HAS_JQ and gate on it.
+
+    Importing without gating, or gating on a locally-recomputed flag, both
+    silently re-open the container failures this exists to prevent."""
+    for name in GATED_MODULES:
+        src = (TESTS_DIR / name).read_text()
+        assert "from tests.conftest import HAS_JQ" in src, (
+            f"{name} must import HAS_JQ from tests.conftest")
+        assert "skipif" in src and "HAS_JQ" in src.split("skipif", 1)[1][:200], (
+            f"{name} must carry a skipif referencing HAS_JQ")
+
+
+def test_gated_modules_exist():
+    """Guard the guard: a renamed or deleted module must not silently drop
+    out of GATED_MODULES coverage."""
+    for name in GATED_MODULES:
+        assert (TESTS_DIR / name).is_file(), (
+            f"{name} is listed in GATED_MODULES but does not exist — update "
+            "this list if the module was renamed")

--- a/tests/test_launcher_finalize_no_work.py
+++ b/tests/test_launcher_finalize_no_work.py
@@ -28,6 +28,19 @@ import os
 import subprocess
 from pathlib import Path
 
+import pytest
+
+from tests.conftest import HAS_JQ
+
+# Exercises the launcher's own `--finalize` path, which is host-side and reads
+# run.json with real `jq` — the launcher in fact hard-fails at preflight when
+# jq is missing. See `tests/conftest.py`'s HAS_JQ.
+pytestmark = pytest.mark.skipif(
+    not HAS_JQ,
+    reason="host-only script: needs real `jq`, which the launcher guarantees "
+           "on the host and the leerie image deliberately omits",
+)
+
 REPO_ROOT = Path(__file__).resolve().parent.parent
 LEERIE = REPO_ROOT / "leerie"
 

--- a/tests/test_launcher_no_push_skips.py
+++ b/tests/test_launcher_no_push_skips.py
@@ -20,6 +20,19 @@ import json
 import subprocess
 from pathlib import Path
 
+import pytest
+
+from tests.conftest import HAS_JQ
+
+# The harness below mirrors a host-side launcher block that reads run.json
+# with real `jq` (see the _HARNESS comment). Host-only; see
+# `tests/conftest.py`'s HAS_JQ.
+pytestmark = pytest.mark.skipif(
+    not HAS_JQ,
+    reason="host-only script: needs real `jq`, which the launcher guarantees "
+           "on the host and the leerie image deliberately omits",
+)
+
 REPO_ROOT = Path(__file__).resolve().parent.parent
 
 # Minimal bash harness mirroring the `leerie:1207-1216` block. The


### PR DESCRIPTION
## The symptom

23 tests fail inside the leerie container. Zero fail on macOS. Zero fail in CI.

These are the trigger for the whole PR #74 episode: run `879defae`'s integrator hit them, couldn't tell whether its own merge had caused them, and burned its process budget building a baseline to find out.

## Root cause (measured)

**`jq` is not installed in the leerie image.** Installing it takes the affected files from **23 failed → 0 failed, 106 passed**. Single cause, no residue.

It's none of the obvious candidates: not Linux (CI runs Linux and passes), not git identity (two of the four files never commit), not the merge.

## The absence is deliberate — and the repo says so

My first read was "live production bug: four production files call `jq` against an image that lacks it." That was **wrong**, and the codebase documents why:

- `scripts/remote/seed-auth.sh` — *"python3 over jq because jq isn't in the leerie image (see Dockerfile)"*. The one script that must parse JSON **inside** the container correctly uses python3.
- The launcher **hard-fails on the host** when jq is missing (`jq not found on PATH` → `brew install jq`). The host is where jq is guaranteed.
- `scripts/host-finalize.sh` — *"The host owns this step because gh auth, ssh-agent, and Keychain are host-side; the Fly Machine cannot push."*

**Host bash uses `jq`; container code uses `python3`.** Applied consistently. `gh` is in the image for the mirror-image reason — Python *inside* the container preflights for it.

## The real defect

An **undeclared environment dependency**. These four modules source host-owned bash — `host-finalize.sh`, `provision.sh`'s `decide_teardown`, the launcher's `--finalize` / `no_push` paths — and stub `git` and `gh` onto PATH but not `jq`. So jq is silently inherited from whichever machine runs pytest.

| File | Failures |
|---|---|
| `tests/test_host_finalize_sh.py` | 19 |
| `tests/test_decide_teardown_auto_finalize.py` | 2 |
| `tests/test_launcher_finalize_no_work.py` | 1 |
| `tests/test_launcher_no_push_skips.py` | 1 |

⚠️ A `grep jq` does **not** reproduce that list — two of the four never mention jq and fail only because the script under test shells out to it. The list is measured from a real in-container run.

## Why gating, not `apt install jq`

Adding jq to the Dockerfile would make the container able to run code that **per DESIGN §6 can never succeed there anyway** — no gh auth, no ssh-agent, no Keychain. It buys a green tick, not working code, and erodes a boundary the codebase deliberately maintains.

So: reuse the existing `HAS_TREESITTER` pattern — a `conftest.py` capability flag consumers import, plus a module-level `skipif`. Skips explain themselves and point at the reasoning so nobody re-litigates it.

Also adds `tests/test_jq_gate_wiring.py`, the guard-the-guard, mirroring `test_repo_map_gate_wiring.py`. That trap isn't hypothetical: the `HAS_TREESITTER` gate exists **because** dropping a skipif once silently re-broke 19 tests — and `test_host_finalize_sh.py` alone is 19 of the 23 here.

## Verification

- **Container:** `23 failed, 3711 passed` → **`3720 passed, 46 skipped, 0 failed`**
- **macOS:** `3687 passed, 79 skipped` — identical skip count to baseline, so the gate is **inert wherever jq exists**
- **Falsified both ways:** hiding `jq` from PATH makes the 24 tests **skip**, not fail; dropping one file's skipif **fails** the wiring test
- **No production code touched** — tests + docs only, purely additive (108 insertions, 0 deletions)

## Relationship to #74

Independent. #74 fixes the PID-reaper/integrator root cause of run `879defae`; this fixes the pre-existing test-environment defect that sent its integrator hunting in the first place. Both touch CLAUDE.md's Testing section, so merge #74 first to avoid a conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)