### PR TITLE
docs(plan-overlap): scope the last unqualified anchor-absorption claim

### DIFF
--- a/orchestrator/leerie.py
+++ b/orchestrator/leerie.py
@@ -15082,11 +15082,15 @@ def _apply_overlap_merge(plans: list[dict], a_sid: str, b_sid: str,
       merged plans. It carries no semantic content.
     - With `survivor_hint`: the named sid wins, overriding the lex
       rule. Used by `_apply_overlap_collisions` for the anchor case:
-      when one sid appears in multiple non-`unresolvable` collisions,
-      it is the structural anchor of the cluster (by construction the
-      subtask that overlaps with every partner) and must survive each
-      merge so its partners are absorbed into it. The hint must equal
-      either `a_sid` or `b_sid`; passing any other value die()s.
+      when one sid appears in multiple non-`unresolvable` collisions
+      it is the anchor of that cluster, and the caller keeps it as the
+      survivor of each merge it participates in. In the motivating
+      all-merge cluster the anchor is the broader subtask, so absorbing
+      its partners matches what the judge described — but that is a
+      property of the merge/merge shape, not of anchor membership,
+      which is bare appearance count (see `_compute_overlap_anchors`).
+      The hint must equal either `a_sid` or `b_sid`; passing any other
+      value die()s.
 
     Field semantics — mirrors `_apply_reconciler_output`'s
     `merged_subtasks` apply step but uses the judge's


### PR DESCRIPTION
## Summary

One docstring correction. `_apply_overlap_merge`'s docstring described anchor membership as *"the structural anchor of the cluster (by construction the subtask that overlaps with every partner)"* — the seventh instance of a rationale that measurement falsifies on **20 of 64** two-collision combinations.

Anchor membership is bare appearance count in 2+ non-`unresolvable` collisions, either side, any resolution. A sid the judge *dropped* twice is an anchor too, and absorbs nothing. In the motivating all-merge cluster the anchor genuinely is the broader subtask — but that is a property of the merge/merge shape, not of membership, and this was the last site still asserting it unqualified.

**No behavioral change.**

## Why a seventh time

Three prior commits each claimed to finish this correction. The most recent one grepped for the phrasings already encountered — `by construction the broader`, `structurally the broader`, `absorbing each partner into the anchor` — and that grep did find a fifth site the plan had missed. This site says *"by construction the subtask that overlaps with every partner"*: same claim, wording not on the list.

A phrase search is only as complete as the phrasings already seen. This time the search enumerated **paraphrases** instead:

```
by construction|structurally the|broader (subtask|scope)|overlaps with (each|every)
```

Every hit across all five layers was classified. This was the only remaining unqualified instance; the rest are scoped to the all-merge shape, explicit refutations, or unrelated uses of "by construction" elsewhere in the codebase.

## Which layer(s) does this PR touch?

- [ ] `docs/DESIGN.md` (architecture)
- [ ] `docs/IMPLEMENTATION.md` (code surface)
- [x] `orchestrator/leerie.py` (code) — docstring only
- [ ] docs (`README.md`, `docs/USAGE.md`, `CONTRIBUTING.md`, etc.)
- [ ] tests (`tests/`)
- [ ] CI / repo meta (`.github/`)

If multiple, has the change propagated **top-down** per the three-layer rule (DESIGN → IMPLEMENTATION → code)?

- [x] not applicable (single layer)

DESIGN §5 and IMPLEMENTATION `:3194`/`:3456` already carry the corrected rule from #87. This aligns the last code-level docstring to them.

## Task-completion checklist

- [x] `docs/IMPLEMENTATION.md` updated if code surface changed — n/a, no surface change
- [x] `docs/DESIGN.md` updated if architecture changed — n/a
- [x] `pytest tests/` passes
- [x] `python3 -c "import ast; ast.parse(open('orchestrator/leerie.py').read())"` passes
- [x] `git diff --stat` reviewed for scope — 1 file, 9 insertions, 5 deletions

**Full-suite result stated plainly: 3933 passed, 6 failed.** The 6 are `ModuleNotFoundError: No module named 'tenacity'` in `test_terminal_auth_{failure,routing}`; `tenacity==9.1.4` is pinned in `requirements.txt` but absent from this dev shell, and they fail identically on the parent commit.

I am reporting the failures rather than deselecting them because my earlier PRs in this chain used `--deselect` flags for exactly these cases and reported only "3933 passing" — accurate, but I had never observed a clean run and shouldn't have implied otherwise.

## Testing notes

No new tests. This is a comment-level correction to already-merged code with no behavioral surface, and the claim it corrects is already pinned by `test_anchor_membership_is_appearance_not_survivorship` (added in #87), which fails if `_compute_overlap_anchors` is reverted to survivorship counting.

Re-verified against this branch:

| check | result |
|---|---|
| Mutation killcheck over the region | 5/7 (N12/N4 are documented equivalent mutants) |
| Anchor claim, 64 combinations | 0 violations |
| `tests/test_phase_overlap_judge.py` | 84 passed |
| Unqualified absorption claims remaining | 0 across all five layers |

## Related issue

Follow-up to #87.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
