### PR TITLE
fix: close the three gaps left by #85

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,6 +118,20 @@ orchestrator and not used anywhere in this repo.
   orchestrator writes to the state root (default: `$HOME/.leerie/<basename>/`,
   at `/leerie-state` inside the container); workers commit code to their
   worktree branch only.
+- **Evaluate every ownership/permission change against all three runtimes
+  separately** — local rootless containerd, local rootful (Colima/macOS),
+  and Fly/EC2. A change can be correct on one and break another, and CI
+  (`ubuntu-latest`, rootful) structurally cannot catch a rootless-only
+  regression. The specific trap, documented at `Dockerfile:235-241`:
+  rootless drops privilege via `unshare --user --map-user=$(id -u leerie)`,
+  a single-entry map (outer UID 0 → inner leerie) that leaves outer leerie
+  *unmapped*. So an image-layer dir **chowned to leerie is unwritable**
+  (appears as nobody/65534) while a **root-owned dir is writable** — the
+  inverse of normal Docker intuition. Rootful `runuser -u leerie` is a
+  real uid switch with no remap, so it needs the opposite: literal leerie
+  ownership, applied at runtime in `container-entry.sh`'s rootful guard.
+  See `tests/test_tmp_cache_writable.py` and
+  `tests/test_home_leerie_ownership.py` for the pinned form.
 
 ## Code style
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,8 @@ opening a PR that touches more than a single layer.
 ```bash
 git clone https://github.com/enricai/leerie.git
 cd leerie
-pip install pytest         # the only dev (host-side) dependency
+pip install -r requirements.txt   # runtime deps — the test suite imports them
+pip install pytest jsonschema     # pytest is the only dev (host-side) dependency
 ./leerie --version           # smoke-check; uses the launcher's fast path —
                            # does NOT require the container runtime, so
                            # it works on a fresh clone with no Colima.
@@ -39,7 +40,10 @@ Running leerie against a real task (`./leerie "..."` rather than `--version`)
 requires the container runtime to be installed and started — see
 [`docs/INSTALL.md`](docs/INSTALL.md). Iterating on
 `orchestrator/leerie.py` and running `pytest tests/` is possible without
-it; the test suite runs on the host Python.
+it; the test suite runs on the host Python. Because it imports the
+orchestrator directly, the pinned runtime deps in `requirements.txt` must
+be installed on that host Python as well — `pytest` is the only *dev*
+dependency, not the only dependency the suite needs.
 
 There is no `pyproject.toml`; contributors develop out of the checkout.
 End-users get a one-command install via the Claude Code plugin marketplace

--- a/Dockerfile
+++ b/Dockerfile
@@ -269,6 +269,10 @@ RUN set -eux; \
 #   1. mise's system shims (mise install --system populates these).
 #   2. LTS Node bin (image-baked claude lives here).
 #   3. (then the pre-existing PATH)
+#   4. /home/leerie/.local/bin — where `pip install --user` puts console
+#      scripts (e.g. pre-commit). Deliberately LAST: image-baked tooling
+#      must win, so a user-installed package can never shadow a baked-in
+#      binary. Pinned by tests/test_dockerfile_path.py.
 # At runtime the user dir's shims at /home/leerie/.local/share/mise/shims
 # don't appear here because they're added by `mise activate` or by
 # wrapping commands with `mise exec --` — both of which the

--- a/README.md
+++ b/README.md
@@ -566,9 +566,16 @@ itself):
 Tests:
 
 ```bash
-pip install pytest    # only dev dependency
-pytest tests/         # from the repo root
+pip install -r requirements.txt   # runtime deps — the suite imports them
+pip install pytest jsonschema     # pytest is the only dev dependency
+pytest tests/                     # from the repo root
 ```
+
+The suite runs on the host Python and imports the orchestrator directly,
+so the pinned *runtime* deps must be installed too — without them, tests
+that exercise the auth/quota backoff fail with `ModuleNotFoundError: No
+module named 'tenacity'`. This mirrors what CI installs
+(`.github/workflows/test.yml`).
 
 The suite covers the deterministic enforcement functions, including a
 coupling test that the retry-policy markers match the live check-function

--- a/tests/test_dockerfile_path.py
+++ b/tests/test_dockerfile_path.py
@@ -1,0 +1,59 @@
+"""Regression pins for /home/leerie/.local/bin on the image's PATH.
+
+`pip install --user` lands console scripts (e.g. `pre-commit`) in
+/home/leerie/.local/bin. Without that dir on PATH they are unreachable
+whenever a caller doesn't resolve them through an absolute path — the
+observed case being a git hook whose embedded interpreter path points at
+a Python that doesn't have the package installed.
+
+Position is load-bearing, not incidental: the entry sits *after* $PATH so
+image-baked tooling (the mise shims and the LTS Node bin that carry
+`claude` itself — see the PATH comment in the Dockerfile) always wins
+over anything a repo's setup step later `pip install --user`s. Moving it
+ahead of $PATH would let a user-installed package silently shadow a baked-in
+binary, which is why the ordering is pinned here rather than just membership.
+
+Source-coupling tests (mirroring tests/test_tmp_cache_writable.py and
+tests/test_home_leerie_ownership.py): the real container behavior needs a
+built image, which the plain pytest suite doesn't exercise.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DOCKERFILE = REPO_ROOT / "Dockerfile"
+
+
+def _env_path_line() -> str:
+    """The image's `ENV PATH=...` line (the one that sets the base PATH).
+
+    Matched on the `ENV PATH=` prefix rather than any single entry so the
+    extractor doesn't bake in the very value the tests below assert on.
+    """
+    for line in DOCKERFILE.read_text().splitlines():
+        if line.startswith("ENV PATH="):
+            return line
+    raise AssertionError("no `ENV PATH=` line found in Dockerfile")
+
+
+def test_user_local_bin_is_on_path():
+    """`pip install --user` console scripts must be reachable by name."""
+    assert "/home/leerie/.local/bin" in _env_path_line()
+
+
+def test_user_local_bin_comes_after_inherited_path():
+    """Image-baked tooling must win over user-installed packages.
+
+    A `pip install --user` package that happens to ship a binary named
+    like a baked-in one (or like `claude` itself) must not shadow it, so
+    the user bin dir has to sit after $PATH, never before.
+    """
+    line = _env_path_line()
+    assert line.index("$PATH") < line.index("/home/leerie/.local/bin")
+
+
+def test_user_local_bin_is_last_entry():
+    """Pin the strongest form of the ordering above: nothing follows it."""
+    value = _env_path_line().split("=", 1)[1]
+    assert value.split(":")[-1] == "/home/leerie/.local/bin"


### PR DESCRIPTION
Follow-up to #92 (which merged #85). Three gaps that PR left open.

## 1. PATH regression test

#85 appended `/home/leerie/.local/bin` to the image `PATH` so
`pip install --user` console scripts (e.g. `pre-commit`) resolve — but
shipped no test for it. It was the one change in that PR with zero
coverage, and it alters `PATH` for every worker on every runtime.

`tests/test_dockerfile_path.py` pins membership **and position**. The
position is the load-bearing part: the entry must stay **last**, after
`$PATH`, so image-baked tooling always wins and a user-installed package
can never shadow a baked-in binary (including `claude` itself).

Falsified during development — reordering the entry ahead of `$PATH`
fails 2 of the 3 tests, so the ordering pin is real rather than vacuous.
The Dockerfile's own PATH-order comment listed only three entries; it now
describes the fourth.

## 2. Dev-setup instructions were wrong

`README.md` and `CONTRIBUTING.md` both said:

```
pip install pytest    # only dev dependency
```

That reproducibly breaks a fresh checkout. The suite imports the
orchestrator directly, so it needs the pinned **runtime** deps too.
Following the documented steps yields 6 failures in
`test_terminal_auth_failure.py` / `test_terminal_auth_routing.py` with
`ModuleNotFoundError: No module named 'tenacity'` — which reads as a code
defect rather than a setup gap. (This is exactly what happened while
reviewing #85; it cost real time to rule out as a regression.)

Both docs now mirror what CI already installs
(`.github/workflows/test.yml`). The "pytest is the only *dev* dependency"
distinction is kept — it is true and load-bearing in CLAUDE.md — but no
longer implies it is the only dependency the suite needs.

## 3. Reviewer note on the rootless-remap trap

`Dockerfile:235-241` documents the mechanism, but nothing told a
*reviewer* that ownership/permission changes must be evaluated against
all three runtimes separately (local rootless, local rootful/Colima,
Fly/EC2), or that CI — `ubuntu-latest`, rootful — structurally cannot
catch a rootless-only regression.

The trap: rootless drops privilege via
`unshare --user --map-user=$(id -u leerie)`, a single-entry map that
leaves outer leerie unmapped. An image-layer dir **chowned to leerie is
unwritable**; a **root-owned dir is writable** — the inverse of normal
Docker intuition. Rootful `runuser` needs the opposite. Added to
CLAUDE.md's mandatory requirements, cross-referencing the two test files
#85 added.

## Verification

- `pytest tests/` — **4102 passed, 9 skipped, 0 failed** (12m54s)
- New test falsified by deliberate regression (see item 1)
- Diff is additive: 4 files, +33/-4, plus the new test file

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
