### PR TITLE
chore(release): 0.9.77

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "leerie",
       "source": ".",
-      "version": "0.9.76",
+      "version": "0.9.77",
       "description": "Deterministic, headless task orchestrator for Claude Code. Classifies a task, decomposes it into dependency-ordered waves, and executes each subtask in an isolated git worktree under an evidence-gated implement/validate loop. Runs entirely on the Claude Code CLI/subscription via `claude -p` workers."
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "leerie",
   "displayName": "Leerie",
-  "version": "0.9.76",
+  "version": "0.9.77",
   "description": "Deterministic, headless task orchestrator for Claude Code. Classifies a task, decomposes it into granular subtasks, schedules them into dependency-ordered waves, and executes each in an isolated git worktree under an evidence-gated implement/validate loop. Runs entirely on the Claude Code CLI/subscription via `claude -p` workers.",
   "author": { "name": "Andres Restrepo", "email": "andres@enricai.com", "url": "https://enricai.com" },
   "license": "MIT",


### PR DESCRIPTION
Bump plugin/marketplace manifests to 0.9.77.

Squash-merging this with the `chore(release): 0.9.77` subject triggers the release workflow, which tags `v0.9.77` and cuts the GitHub Release.

- `.claude-plugin/plugin.json` → 0.9.77
- `.claude-plugin/marketplace.json` → 0.9.77

`pytest tests/test_version_flag.py` passes; both manifests validate as JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)