### PR TITLE
chore(release): 0.9.78

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "leerie",
       "source": ".",
-      "version": "0.9.77",
+      "version": "0.9.78",
       "description": "Deterministic, headless task orchestrator for Claude Code. Classifies a task, decomposes it into dependency-ordered waves, and executes each subtask in an isolated git worktree under an evidence-gated implement/validate loop. Runs entirely on the Claude Code CLI/subscription via `claude -p` workers."
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "leerie",
   "displayName": "Leerie",
-  "version": "0.9.77",
+  "version": "0.9.78",
   "description": "Deterministic, headless task orchestrator for Claude Code. Classifies a task, decomposes it into granular subtasks, schedules them into dependency-ordered waves, and executes each in an isolated git worktree under an evidence-gated implement/validate loop. Runs entirely on the Claude Code CLI/subscription via `claude -p` workers.",
   "author": { "name": "Andres Restrepo", "email": "andres@enricai.com", "url": "https://enricai.com" },
   "license": "MIT",


### PR DESCRIPTION
## Summary

Release bump `0.9.77` → `0.9.78`. Ships the empty-run-branch finalize fixes merged in #97:

- **phase_finalize** stamps `current_phase="phase 6: finalize"` only after `finalize.sh` succeeds → a died finalize stays resumable instead of masquerading as complete.
- **host-finalize.sh** refuses to push a run branch with no commits beyond the working branch.
- **Integration-integrity gate**: `phase_execute` die()s if a wave settles with no failures but integration merged fewer subtasks than settled complete — a wave can no longer certify itself complete with an un-integrated branch.
- **Diagnostics**: distinct `phase 5: integrating wave N` stamp + `integrated N of M` log, and orchestrator stdout/stderr now persisted to `<run_dir>/orchestrator.log` on the local runtime.

## What this PR changes

Bumps the `version` field to `0.9.78` in both `.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json` (kept in sync per `test_version_flag.py`). The `chore(release): 0.9.78` subject triggers the release workflow to tag `v0.9.78` and cut a GitHub Release once merged to main.

## Checklist

- [x] Both `.claude-plugin/*.json` manifests valid JSON, versions synced at `0.9.78`
- [x] `leerie --version` reports `0.9.78`
- [x] `pytest tests/test_version_flag.py tests/test_release_workflow.py` passes
- [x] Diff scoped to the two manifest version fields only

🤖 Generated with [Claude Code](https://claude.com/claude-code)