### PR TITLE
chore(release): 0.9.79

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "leerie",
       "source": ".",
-      "version": "0.9.78",
+      "version": "0.9.79",
       "description": "Deterministic, headless task orchestrator for Claude Code. Classifies a task, decomposes it into dependency-ordered waves, and executes each subtask in an isolated git worktree under an evidence-gated implement/validate loop. Runs entirely on the Claude Code CLI/subscription via `claude -p` workers."
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "leerie",
   "displayName": "Leerie",
-  "version": "0.9.78",
+  "version": "0.9.79",
   "description": "Deterministic, headless task orchestrator for Claude Code. Classifies a task, decomposes it into granular subtasks, schedules them into dependency-ordered waves, and executes each in an isolated git worktree under an evidence-gated implement/validate loop. Runs entirely on the Claude Code CLI/subscription via `claude -p` workers.",
   "author": { "name": "Andres Restrepo", "email": "andres@enricai.com", "url": "https://enricai.com" },
   "license": "MIT",


### PR DESCRIPTION
## Summary

Version bump 0.9.78 → 0.9.79. Cuts a release of the unreleased work on `main`
since 0.9.78 — notably #99 (run-scope worker cgroup names to stop cross-run
SIGKILL). Version-only change to the two `.claude-plugin/` manifests, following
the `chore(release): X.Y.Z` subject convention that triggers the release
workflow (tag `v0.9.79` + GitHub Release) when this lands on `main`.

## Which layer(s) does this PR touch?

- [ ] `docs/DESIGN.md` (architecture)
- [ ] `docs/IMPLEMENTATION.md` (code surface)
- [ ] `orchestrator/leerie.py` (code)
- [ ] docs
- [ ] tests (`tests/`)
- [x] CI / repo meta (`.claude-plugin/` manifests — release bump)

- [x] not applicable (single layer)

## Task-completion checklist

- [x] both `.claude-plugin/*.json` manifests valid JSON and version fields in
      sync at 0.9.79 (guarded by `tests/test_version_flag.py`)
- [x] `pytest tests/test_version_flag.py tests/test_release_workflow.py` passes
- [x] `git diff --stat` reviewed for scope — only the two manifest version lines

## Testing notes

No code change. Ran the two guards that cover this change:
`tests/test_version_flag.py` (version-drift between the two manifests) and
`tests/test_release_workflow.py` (the `chore(release):` subject convention the
release workflow keys on) — both green.