### PR TITLE
feat(decompose): sub-file splitting for dense single-file subtasks

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -820,6 +820,50 @@ split mechanism therefore separates by structural type:
   that the repo-map exposes, backstopped by the existing `UNCOVERED_MIGRATION_SURFACE`
   check (`_check_migration_surface`) which already rejects any split that fails to
   cover every file.
+- **Sub-file (a single dense file):** the mirror image of the many-file migration
+  sweep. Both whole-file mechanisms above operate at file granularity, so neither
+  can help a subtask whose entire scope is *one* very large, edit-dense file — and
+  the coupled-minority LLM splitter, asked to split one file, can only return it
+  unchanged. That leaves such a subtask with exactly one representation: a
+  monolithic unit too large to hold in one implementer context, finish before a
+  transport blip, or checkpoint before dying. Measured failure (run `5d488583`,
+  subtask feat-005): a 7,041-line file with ~85 edit sites failed 9 times across
+  three runs, each attempt restarting from scratch because it died before writing
+  a checkpoint. leerie's telemetry already grounds the many-file case (§5½: 20% of
+  runs exhaust the budget, 84% in migration sweeps of 30–65 files); the single
+  dense file is the un-covered variant. The mechanism decomposes *within* the
+  file, deterministically, in two tiers:
+  - **Tier 1 — function boundaries.** Tree-sitter symbol spans
+    (`_extract_symbol_ranges`, reading `item.span.start_line`/`end_line`) tile
+    `[1, EOF]` with no gaps or overlap by construction — the `partition_files`
+    guarantee applied to ordered line spans (inter-symbol gaps attach to the
+    preceding region so the union stays exhaustive). Adjacent functions group
+    until a region approaches `subfile_split_max_span`.
+  - **Tier 2 — line windows.** A *single function* can itself exceed the span cap
+    (measured: `executeStepWithHealing` is 1,733 lines — 25% of the file and 34%
+    of feat-005's edit sites — 3.7× the largest function in any sibling file).
+    Function boundaries cannot break it, so that one region is sub-split into
+    contiguous line-windows via the same tiling. This tier needs no range data and
+    is also the whole-file fallback when tree-sitter yields no ranges.
+
+  Each child owns a region of the same file, so N children co-own it. This is
+  already legitimate everywhere downstream: `schedule()` derives waves only from
+  `depends_on`/`requires` (never `files_likely_touched`), so co-owners run the
+  same wave in parallel; the phase 2¾ overlap judge's charter is *same exported
+  artifact with incompatible APIs* and it explicitly excludes "multiple primitive
+  extractions in the same parent file"; and integration is a plain `git merge`
+  whose 3-way merge clean-merges non-overlapping regions, escalating to the
+  integrator worker only on a true textual conflict. The one deliberate
+  interaction: `check_planner_output`'s advisory `INTRA_DOMAIN_OVERLAP` warning
+  ("consider merging or splitting") is suppressed for children tagged with a
+  co-ownership cluster marker, since the overlap is intentional — an accidental
+  same-file overlap between unrelated subtasks still warns. `_check_intra_file_surface`
+  is the zero-tolerance analog of `_check_migration_surface`: the child regions'
+  union must equal `[1, EOF]` and be pairwise-disjoint. Bound:
+  `DEFAULT_CAPS["subfile_split_max_span"]` (line-span above which a file or region
+  is split rather than left a leaf — a heuristic anchored to the measured
+  1,733-vs-≤474 span separation, not telemetry-calibrated like the 0.70 fit
+  threshold).
 
 **`recursive_decompose(subtask, depth) → list[leaf_subtasks]`** is the loop:
 

--- a/docs/IMPLEMENTATION.md
+++ b/docs/IMPLEMENTATION.md
@@ -4308,6 +4308,7 @@ Defaults in `DEFAULT_CAPS` and the per-worker `claude_p` call sites.
 | P1 recursive decompose max depth (`decompose_max_depth`) | 5 | Maximum recursion depth for `recursive_decompose()` (DESIGN §5½ (P1) *Recursive judge + splitter*). Recursion terminates at depth ≥ 5 even if `fit_judge` still scores below `decompose_fit_threshold`. A depth-5 tree can represent up to 32 leaves from one subtask. Not user-tunable via CLI / env / toml. |
 | P1 fit-judge pass threshold (`decompose_fit_threshold`) | 0.70 | `fit_judge` confidence score at or above which a subtask is accepted as a leaf (well-fit). MEASURED on n=24 telemetry-labeled subtasks: oversized mean 0.26 vs well-fit mean 0.84 — 0.57 separation, 88% accuracy at 0.70. Not user-tunable via CLI / env / toml. |
 | P1 no-progress guard (`decompose_noprogress_rounds`) | 2 | Consecutive recursion rounds that produce no child with a fit score above the parent's before the subtask is accepted as a leaf with a warning. Prevents a degenerate splitter from looping to `decompose_max_depth`. Not user-tunable via CLI / env / toml. |
+| P1 sub-file split span (`subfile_split_max_span`) | 700 | Line-span above which a single-file subtask (tier 1) or a single region (tier 2) is split intra-file rather than left a leaf (DESIGN §5½ (P1) *Sub-file*). Heuristic anchored to the measured span separation in run `5d488583` — the 1,733-line `executeStepWithHealing` vs ≤474-line largest functions in sibling files — **not** telemetry-calibrated like `decompose_fit_threshold`. Not user-tunable via CLI / env / toml. |
 
 ### P1 recursive decomposition surface (DESIGN §5½ (P1))
 
@@ -4366,6 +4367,22 @@ accept the subtask as leaf); then splits via either:
     mismatched label set, every chunk falls back to a distinct deterministic
     label (`_deterministic_chunk_label()`), never an identical parent-copy.
   - **Coupled path** (≤ 8 files): `splitter` LLM worker — structural seam detection
+  - **Sub-file path** (exactly 1 file, low fit, file/region span > `subfile_split_max_span`):
+    checked **before** the file-count fork, since a single dense file falls into
+    the coupled path today where the LLM splitter cannot break one file. Splits
+    the file *intra*-file in two tiers (both deterministic, no LLM decides
+    membership): tier 1 tiles `[1, EOF]` on tree-sitter function-boundary spans
+    (`_extract_symbol_ranges()` → `partition_symbols_by_line()`); a tier-1 region
+    that is itself still over the cap re-enters recursion and gets tier-2
+    contiguous line-windows (`partition_lines()`), which also serves as the
+    whole-file fallback when no ranges are available. Children are built by
+    `_subfile_child()` (analog of `_migration_child()`), each listing the same
+    single file plus an `owned_region` field and a `_cofile_cluster` marker.
+    `_check_intra_file_surface()` is the zero-tolerance coverage/overlap backstop
+    (union == `[1, EOF]`, pairwise-disjoint). Same-file co-ownership is legitimate
+    downstream (schedule ignores `files_likely_touched`; overlap judge excludes
+    same-file/different-region; `git merge` reconciles); `check_planner_output`'s
+    `INTRA_DOMAIN_OVERLAP` advisory is suppressed for `_cofile_cluster` children.
 
 Both the `fit_judge` call and the coupled-path `splitter` call are wrapped in
 `try/except WorkerError`, degrading the node to a leaf (`[subtask]`

--- a/orchestrator/leerie.py
+++ b/orchestrator/leerie.py
@@ -237,6 +237,20 @@ DEFAULT_CAPS = {
     # indefinitely. Prevents a degenerate splitter output from looping to
     # decompose_max_depth.
     "decompose_noprogress_rounds": 2,
+    # Sub-file split span for recursive_decompose() (DESIGN §5½ (P1) *Sub-file*).
+    # A single-file subtask (or a single intra-file region) whose line span
+    # exceeds this is split *within* the file — tier 1 on tree-sitter
+    # function-boundary spans, tier 2 on contiguous line-windows for a function
+    # that alone exceeds the cap. This is the un-covered mirror of the many-file
+    # migration sweep: the whole-file splitter cannot break one dense file, so
+    # such a subtask would otherwise be an unwinnable monolith (run 5d488583,
+    # feat-005 — a 7041-line file failed 9 times). HEURISTIC, not
+    # telemetry-calibrated like decompose_fit_threshold: anchored to that run's
+    # measured span separation — the 1733-line executeStepWithHealing (25% of
+    # the file, 34% of its edit sites) vs a largest-function span of ≤474 in
+    # every sibling file. ~700 splits the giant into 2–3 windows and leaves a
+    # normal function whole.
+    "subfile_split_max_span": 700,
 }
 
 # Every key the orchestrator writes to `st.data`. Canonical alongside the
@@ -4952,6 +4966,119 @@ def partition_files(files: list[str], chunk_size: int) -> list[list[str]]:
     return chunks
 
 
+def partition_lines(lo: int, hi: int, max_span: int) -> list[tuple[int, int]]:
+    """Tile the inclusive line range ``[lo, hi]`` into contiguous windows of at
+    most *max_span* lines each (DESIGN §5½ (P1) *Sub-file* — tier 2).
+
+    100% coverage + 0 overlap by construction (the ``partition_files`` guarantee
+    on line numbers instead of files): every line in ``[lo, hi]`` falls in exactly
+    one window, the last window may be shorter. Used to sub-split a single
+    function whose span alone exceeds the cap (function boundaries can't break it)
+    and as the whole-file fallback when tree-sitter yields no symbol ranges.
+    Degenerate guards mirror ``partition_files``: an empty range (``hi < lo``)
+    returns ``[]``; ``max_span < 1`` returns the whole range as one window."""
+    if hi < lo:
+        return []
+    if max_span < 1:
+        return [(lo, hi)]
+    windows: list[tuple[int, int]] = []
+    start = lo
+    while start <= hi:
+        windows.append((start, min(start + max_span - 1, hi)))
+        start += max_span
+    return windows
+
+
+def partition_symbols_by_line(
+    ranges: list[tuple[str, int, int]], total_lines: int, max_span: int,
+) -> list[tuple[int, int]]:
+    """Tile ``[1, total_lines]`` into contiguous regions on function boundaries
+    (DESIGN §5½ (P1) *Sub-file* — tier 1).
+
+    *ranges* is ``_extract_symbol_ranges``' output: ``(name, start, end)`` for the
+    file's top-level symbols, sorted by start line. Regions are built so that:
+
+    - the union is exactly ``[1, total_lines]`` with no gaps or overlap — an
+      inter-symbol gap (blank lines, imports, a comment block) attaches to the
+      *preceding* region, and the final region extends to ``total_lines``, so the
+      tiling stays exhaustive by construction (the ``partition_files`` guarantee);
+    - a region grows by absorbing whole adjacent symbols until adding the next
+      would push it past *max_span*, then a new region starts;
+    - a **single symbol whose own span exceeds *max_span*** still becomes its own
+      region rather than being force-merged — function boundaries cannot break it,
+      so it is handed back oversized on purpose. ``recursive_decompose`` re-enters
+      that region and tier 2 (``partition_lines``) sub-splits it. This is the
+      1,733-line-function case (run 5d488583).
+
+    Returns ``[(1, total_lines)]`` when there are no usable ranges — the caller
+    then falls back to tier-2 line-windows over the whole file."""
+    if total_lines < 1:
+        return []
+    usable = [r for r in ranges if 1 <= r[1] <= r[2] <= total_lines]
+    if not usable:
+        return [(1, total_lines)]
+
+    regions: list[tuple[int, int]] = []
+    cur_start = 1
+    cur_end = 0  # exclusive-of-nothing sentinel; first symbol sets the real end
+    for _name, _s, e in usable:
+        if cur_end == 0:
+            # First symbol: region opened at line 1 absorbs any leading gap.
+            cur_end = e
+            continue
+        # Would absorbing this symbol keep the region within the cap? The region
+        # spans cur_start..e if we absorb. A region already at/over the cap, or
+        # one that would exceed it, closes first — unless it holds a single
+        # oversized symbol, which we intentionally let stand alone (handled by
+        # the close-then-open below producing a >max_span region for tier 2).
+        if (e - cur_start + 1) > max_span and (cur_end - cur_start + 1) > 0:
+            regions.append((cur_start, cur_end))
+            cur_start = cur_end + 1
+        cur_end = e
+    # Final region extends to EOF so the union is exhaustive.
+    regions.append((cur_start, total_lines))
+    return regions
+
+
+def _check_intra_file_surface(
+    regions: list[tuple[int, int]], total_lines: int,
+) -> list[str]:
+    """Zero-tolerance coverage/overlap backstop for an intra-file partition
+    (DESIGN §5½ (P1) *Sub-file*) — the analog of ``_check_migration_surface``.
+
+    Returns a list of issue strings (empty when the partition is exact). The
+    tiling helpers guarantee this by construction, so a non-empty result means a
+    real bug in the partitioner, not a tolerable slack — unlike the file-level
+    check's slack of 5, this demands the region union equal ``[1, total_lines]``
+    exactly and be pairwise-disjoint."""
+    issues: list[str] = []
+    if total_lines < 1:
+        return issues
+    covered: set[int] = set()
+    overlaps = 0
+    for lo, hi in regions:
+        for ln in range(lo, hi + 1):
+            if ln in covered:
+                overlaps += 1
+            covered.add(ln)
+    expected = set(range(1, total_lines + 1))
+    missing = expected - covered
+    extra = covered - expected
+    if missing:
+        issues.append(
+            f"INTRA_FILE_UNCOVERED: {len(missing)} line(s) not owned by any "
+            f"region (e.g. {sorted(missing)[:10]})")
+    if extra:
+        issues.append(
+            f"INTRA_FILE_OUT_OF_RANGE: {len(extra)} region line(s) outside "
+            f"[1, {total_lines}] (e.g. {sorted(extra)[:10]})")
+    if overlaps:
+        issues.append(
+            f"INTRA_FILE_OVERLAP: {overlaps} line(s) owned by more than one "
+            "region")
+    return issues
+
+
 def _migration_child(subtask: dict, chunk: list[str], cid: str,
                      title: str, criteria: str) -> dict:
     """Build one migration-chunk child subtask from its (code-fixed) file
@@ -4996,6 +5123,57 @@ def _deterministic_chunk_label(subtask: dict, chunk: list[str],
         f"Scope: only these files — {files_txt}."
     ).strip()
     return title, criteria
+
+
+def _subfile_child(subtask: dict, file: str, region: tuple[int, int],
+                   symbols: list[str], cid: str, cluster: str,
+                   idx: int, total: int) -> dict:
+    """Build one sub-file child owning a *region* (``(start, end)`` lines) of a
+    single *file* (DESIGN §5½ (P1) *Sub-file*). The analog of ``_migration_child``
+    for intra-file splitting.
+
+    Same deep-copy edge discipline as ``_migration_child`` (see its docstring —
+    aliased lists leak dependencies via `_apply_overlap_drop`). Differences:
+
+    - ``files_likely_touched`` is the *single* parent file — every region child
+      co-owns it, which is legitimate downstream (schedule ignores files; the
+      overlap judge excludes same-file/different-region; `git merge` reconciles).
+    - ``owned_region`` records the code-computed line range + the symbols it
+      contains, so the implementer's prompt scopes it to that span.
+    - ``_cofile_cluster`` marks the child as part of an *intentional* same-file
+      cluster, so ``check_planner_output`` suppresses its advisory
+      INTRA_DOMAIN_OVERLAP warning ("consider merging or splitting" — the opposite
+      of what we want here).
+    - No sibling ``depends_on``: region children edit disjoint line ranges of one
+      file and are independently implementable, so they stay in the same wave
+      (the parent's own inbound/outbound edges are inherited by every child, as on
+      the migration path)."""
+    lo, hi = region
+    parent_title = subtask.get("title", "file change")
+    sym_txt = ", ".join(symbols) if symbols else "(no named symbols in range)"
+    title = f"{parent_title} (region {idx + 1}/{total}: lines {lo}-{hi})"
+    criteria = (
+        f"{subtask.get('success_criteria_seed', '')}\n"
+        f"Scope: only lines {lo}-{hi} of {file} "
+        f"(symbols: {sym_txt}). Do not edit outside this range; a sibling "
+        f"subtask owns the rest of the file."
+    ).strip()
+    return {
+        "id": cid,
+        "title": title,
+        "success_criteria_seed": criteria,
+        "files_likely_touched": [file],
+        "owned_region": {"file": file, "start": lo, "end": hi,
+                         "symbols": list(symbols)},
+        "_cofile_cluster": cluster,
+        "intent": subtask.get("intent", ""),
+        "scope_note": subtask.get("scope_note", ""),
+        "depends_on": list(subtask.get("depends_on", []) or []),
+        "requires": copy.deepcopy(subtask.get("requires", []) or []),
+        "provides": list(subtask.get("provides", []) or []),
+        "size": "medium",
+        "investigation_notes": subtask.get("investigation_notes", ""),
+    }
 
 
 async def _label_migration_chunks(
@@ -5067,6 +5245,84 @@ async def _label_migration_chunks(
     ]
 
 
+def _subfile_split(subtask: dict, repo_root: Path,
+                   max_span: int) -> list[dict]:
+    """Split a single-file subtask *within* the file into region-owning children
+    (DESIGN §5½ (P1) *Sub-file*). Pure + deterministic — no LLM decides
+    membership. Returns ``[]`` when the subtask is not a sub-file split candidate
+    or cannot be split further (the caller then treats the node as a leaf).
+
+    Two entry shapes, both routed here from ``recursive_decompose``:
+
+    - **First entry** — a whole single-file subtask with no ``owned_region``. Tier
+      1: tile the file on function-boundary spans (`partition_symbols_by_line`).
+      A region that is itself over the cap comes back oversized and re-enters
+      recursion, hitting the second shape below.
+    - **Re-entry** — a child carrying ``owned_region`` whose span still exceeds the
+      cap (a single function larger than the cap, e.g. the 1,733-line
+      `executeStepWithHealing`). Tier 2: contiguous line-windows over that region
+      (`partition_lines`), which needs no symbol ranges.
+
+    Coverage/overlap is guaranteed by construction and re-asserted by
+    `_check_intra_file_surface`; a backstop failure logs and returns ``[]`` (fall
+    back to a leaf) rather than emitting a broken partition."""
+    files = subtask.get("files_likely_touched") or []
+    if len(files) != 1:
+        return []
+    file = files[0]
+    base_id = subtask.get("id", "split")
+    cluster = subtask.get("_cofile_cluster") or base_id
+    owned = subtask.get("owned_region")
+
+    if owned:
+        # Re-entry: tier-2 line-windows over the already-owned region.
+        lo, hi = owned.get("start", 1), owned.get("end", 1)
+        if (hi - lo + 1) <= max_span:
+            return []  # small enough — leaf
+        windows = partition_lines(lo, hi, max_span)
+        surface_total = hi - lo + 1
+        # shift windows into a 1-based frame only for the backstop check
+        shifted = [(w0 - lo + 1, w1 - lo + 1) for w0, w1 in windows]
+        issues = _check_intra_file_surface(shifted, surface_total)
+        regions = windows
+        symbols_per = [[] for _ in regions]
+    else:
+        # First entry: tier-1 function-boundary tiling of the whole file.
+        abs_path = repo_root / file
+        try:
+            total_lines = abs_path.read_text(errors="replace").count("\n") + 1
+        except OSError:
+            return []  # file unreadable — can't region-split; leave as leaf
+        if total_lines <= max_span:
+            return []  # whole file already within the cap — leaf
+        ranges = _extract_symbol_ranges(abs_path)
+        regions = partition_symbols_by_line(ranges, total_lines, max_span)
+        if len(regions) <= 1:
+            # No usable boundaries (or one span covers the file): tier-2 fallback
+            # over the whole file so a range-less large file still gets split.
+            regions = partition_lines(1, total_lines, max_span)
+        issues = _check_intra_file_surface(regions, total_lines)
+        # Attach the symbols that fall inside each region for the child's prompt.
+        symbols_per = []
+        for lo, hi in regions:
+            symbols_per.append(
+                [n for (n, s, e) in ranges if lo <= s and e <= hi])
+
+    if issues:
+        log(f"recursive_decompose: intra-file partition of {file!r} failed its "
+            f"coverage backstop ({issues}); accepting as leaf")
+        return []
+    if len(regions) <= 1:
+        return []  # nothing gained — leaf
+
+    total = len(regions)
+    return [
+        _subfile_child(subtask, file, region, symbols_per[i],
+                       f"{base_id}-r{i + 1}", cluster, i, total)
+        for i, region in enumerate(regions)
+    ]
+
+
 async def recursive_decompose(
     subtask: dict,
     depth: int,
@@ -5107,6 +5363,27 @@ async def recursive_decompose(
                          DEFAULT_CAPS["decompose_fit_threshold"])
     noprogress_max = caps.get("decompose_noprogress_rounds",
                               DEFAULT_CAPS["decompose_noprogress_rounds"])
+    max_span = caps.get("subfile_split_max_span",
+                        DEFAULT_CAPS["subfile_split_max_span"])
+
+    # Sub-file region re-entry (DESIGN §5½ (P1) *Sub-file*, tier 2): a child that
+    # already owns a code-computed line region needs no fit_judge — the split
+    # decision is mechanical (its span vs the cap), and an LLM cannot sub-split a
+    # single region anyway. Deciding here, before the worker spawn, both keeps the
+    # decision code-enforced (§12) and saves a fit_judge call per region. A region
+    # over the cap (a single function larger than the cap, e.g. the 1,733-line
+    # executeStepWithHealing) is tier-2 line-window split even if it would have
+    # scored well-fit; one within the cap is a leaf. Depth cap still bounds it.
+    if subtask.get("owned_region") and depth < max_depth:
+        region_children = _subfile_split(subtask, repo_root, max_span)
+        if region_children:
+            leaves: list[dict] = []
+            for child in region_children:
+                leaves.extend(await recursive_decompose(
+                    child, depth + 1, st, caps, models, efforts, repo_root,
+                    repo_map=repo_map))
+            return leaves
+        return [subtask]  # region within span (or unsplittable) → leaf
 
     # Per-node P6 grounding: re-rank the global repo-map to this subtask's
     # files so the fit_judge/splitter see the local structural neighborhood
@@ -5189,10 +5466,21 @@ async def recursive_decompose(
 
     # --- split step ----------------------------------------------------------
     files = subtask.get("files_likely_touched") or []
+    # Sub-file path (DESIGN §5½ (P1) *Sub-file*): a single dense file (or a
+    # single oversized region re-entering) is split WITHIN the file, since the
+    # whole-file splitter below cannot break one file. Checked first; falls
+    # through to the file-count fork when it returns no children (not a
+    # candidate, or already small enough). Deterministic — no worker spawn.
+    subfile_children = _subfile_split(
+        subtask, repo_root,
+        caps.get("subfile_split_max_span",
+                 DEFAULT_CAPS["subfile_split_max_span"]))
+    chunk_size = 8
+    if subfile_children:
+        children = subfile_children
     # Migration path (dominant case, ~84%): code-partitions, LLM only labels.
     # Coupled-minority path: LLM-splitter decides the partition.
-    chunk_size = 8
-    if len(files) > chunk_size:
+    elif len(files) > chunk_size:
         # Migration sweep: partition_files guarantees 100% coverage + 0 overlap
         # BY CONSTRUCTION (the code owns the partition — DESIGN §5½). The
         # splitter worker is then invoked in LABEL-ONLY mode: it titles and
@@ -5409,15 +5697,28 @@ def check_planner_output(
                 f"OVERSIZED: {s.get('id', '?')} has size='large' "
                 "— split it")
 
-    file_owners: dict[str, list[str]] = {}
+    # Track each file's owners as (id, cofile_cluster) so a *deliberate* sub-file
+    # split (DESIGN §5½ (P1) *Sub-file*) does not trip the advisory: region
+    # children of one file all carry the same `_cofile_cluster` marker, and their
+    # same-file overlap is intentional co-ownership, not a planning smell. The
+    # warning still fires when the owners are NOT a single coherent cluster — an
+    # accidental overlap between unrelated subtasks, or two different clusters on
+    # one file.
+    file_owners: dict[str, list[tuple[str, str | None]]] = {}
     for s in subtasks:
         for f in s.get("files_likely_touched", []):
-            file_owners.setdefault(f, []).append(s.get("id", "?"))
+            file_owners.setdefault(f, []).append(
+                (s.get("id", "?"), s.get("_cofile_cluster")))
     for f, owners in file_owners.items():
-        if len(owners) > 1:
-            issues.append(
-                f"INTRA_DOMAIN_OVERLAP: {f!r} touched by "
-                f"{owners} — consider merging or splitting")
+        if len(owners) <= 1:
+            continue
+        clusters = {c for (_sid, c) in owners}
+        # A single non-None cluster shared by every owner is a deliberate split.
+        if len(clusters) == 1 and None not in clusters:
+            continue
+        issues.append(
+            f"INTRA_DOMAIN_OVERLAP: {f!r} touched by "
+            f"{[sid for (sid, _c) in owners]} — consider merging or splitting")
 
     for s in subtasks:
         bad = [f for f in (s.get("files_likely_touched") or [])
@@ -5982,6 +6283,52 @@ def _parse_repo_file(path: Path) -> tuple[list[str], list[str]]:
     except Exception as e:  # graceful degrade; tree-sitter parse errors, IO, etc.
         _last_parse_error = f"{type(e).__name__}: {e}"
         return [], []
+
+
+def _extract_symbol_ranges(path: Path) -> list[tuple[str, int, int]]:
+    """Return the top-level symbols of *path* as ``(name, start_line, end_line)``,
+    sorted by ``start_line`` — the ordered, exhaustive span sequence the sub-file
+    splitter tiles into regions (DESIGN §5½ (P1) *Sub-file*).
+
+    Deliberately separate from ``_parse_repo_file`` / ``build_repo_map``: the
+    repo-map graph stores bare symbol *names* (no positions) and is pinned by
+    ~10 tests plus an mtime cache whose shape those tests fix. Reading ranges
+    through a dedicated function keeps that contract — and its cache — untouched,
+    at the cost of a second ``tslp.process`` call on the one file being split
+    (rare, and only when a single-file subtask is over-scoped).
+
+    Only **top-level** symbols are tiled: nested defs live inside their parent's
+    span, so including them would double-count lines. ``item.span`` is a ``Span``
+    whose ``start_line``/``end_line`` are **0-based**; this function normalizes to
+    the 1-based, inclusive line numbers the partitioner, prompts, and editors use.
+    Returns ``[]`` when the language is unsupported or extraction fails — the
+    caller falls back to tier-2 line-windows over the whole file
+    (``partition_lines``)."""
+    try:
+        import tree_sitter_language_pack as tslp  # noqa: PLC0415
+    except ImportError:
+        return []
+    try:
+        lang = tslp.detect_language(str(path))
+        if not lang:
+            return []
+        source = path.read_text(errors="replace")
+        proc_result = tslp.process(
+            source,
+            tslp.ProcessConfig(language=lang, structure=True, imports=False),
+        )
+        ranges: list[tuple[str, int, int]] = []
+        for item in proc_result.structure:
+            span = getattr(item, "span", None)
+            if item.name and span is not None:
+                # tree-sitter Span line numbers are 0-based; normalize to the
+                # 1-based line numbers the partitioner, prompts, and editors use.
+                ranges.append(
+                    (item.name, span.start_line + 1, span.end_line + 1))
+        ranges.sort(key=lambda r: r[1])
+        return ranges
+    except Exception:  # graceful degrade — caller uses the line-window fallback
+        return []
 
 
 # Source-code extensions used only to detect the G6 "repo has code but the
@@ -16573,6 +16920,40 @@ def _read_upstream_artifacts(leerie_dir: Path,
     return out
 
 
+def _format_owned_region_section(leerie_dir: Path, sid: str) -> str | None:
+    """Render the sub-file region-ownership prompt section for `sid`, or None
+    when the subtask owns no region (the common case — only sub-file split
+    children carry `owned_region`; DESIGN §5½ (P1) *Sub-file*).
+
+    Read from the on-disk spec so the resume path is identical to the fresh
+    path (mirrors `_format_upstream_artifacts_for_sid`)."""
+    spec_path = leerie_dir / "subtasks" / f"{sid}.json"
+    if not spec_path.exists():
+        return None
+    try:
+        spec = json.loads(spec_path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return None
+    region = spec.get("owned_region")
+    if not region:
+        return None
+    file = region.get("file", "?")
+    lo, hi = region.get("start", "?"), region.get("end", "?")
+    symbols = region.get("symbols") or []
+    sym_txt = ", ".join(symbols) if symbols else "(no named symbols in range)"
+    return (
+        "\nOWNED_REGION:\n"
+        f"  This subtask owns ONLY lines {lo}-{hi} of {file} "
+        f"(symbols: {sym_txt}).\n"
+        "  A sibling subtask owns the rest of the same file and runs in "
+        "parallel. Confine your edits to this line range: edits outside it "
+        "risk an integration merge conflict the sibling would otherwise "
+        "resolve cleanly. If the change genuinely requires touching a "
+        "shared declaration outside your range (e.g. a type used by several "
+        "regions), make the minimal edit and note it in your summary."
+    )
+
+
 def _format_upstream_artifacts_for_sid(leerie_dir: Path,
                                         sid: str) -> str | None:
     """End-to-end helper: load the persisted plan, recompute the
@@ -16783,6 +17164,15 @@ async def run_implementer(sid: str, leerie_dir: Path, caps: dict, st: State,
     convention_docs_section = _format_convention_docs_section(st.repo_root)
     if convention_docs_section is not None:
         up.append(convention_docs_section)
+    # DESIGN §5½ (P1) *Sub-file*: a region child owns only a line range of a
+    # shared file. Surface the range explicitly so the implementer stays inside
+    # it — a sibling owns the rest of the same file, and edits outside the range
+    # risk an integration conflict the sibling would otherwise own cleanly. Read
+    # from the on-disk spec (same source the worker reads) so --resume is
+    # identical to a fresh run.
+    region_section = _format_owned_region_section(leerie_dir, sid)
+    if region_section is not None:
+        up.append(region_section)
     if continuation:
         up.append(f"This is a CONTINUATION. Read the checkpoint at "
                   f"{leerie_dir}/checkpoints/{sid}.md, validate it against the "

--- a/prompts/fit_judge.md
+++ b/prompts/fit_judge.md
@@ -27,7 +27,18 @@ A subtask is **well-fit** when ALL of the following hold:
    well-fit if the *cognitive* scope is minimal — judge cognitive scope,
    not raw file count.
 
-4. **No hidden broad surface.** The subtask's intent does not implicitly
+4. **Bounded edit-site density within a file.** Low file count is *not* on
+   its own evidence of good fit. A subtask touching **one** file but with
+   many edit sites spread across thousands of lines (e.g., "route every
+   call through a new guard" across a 7,000-line file) is over-scoped for a
+   single session even though it lists one file — the mirror image of a
+   many-file sweep. Score such a subtask **under-fit** (below 0.70). You do
+   not need to devise the split yourself: the orchestrator region-splits an
+   over-scoped single file deterministically once you score it under the
+   threshold. Judge honestly — a large, dense single file is a split
+   candidate, not an automatic leaf.
+
+5. **No hidden broad surface.** The subtask's intent does not implicitly
    require touching broad surfaces (e.g., "update all callers of foo()")
    without those surfaces being explicitly enumerated and bounded.
 

--- a/prompts/planner.md
+++ b/prompts/planner.md
@@ -79,6 +79,18 @@ The orchestrator gives you, in your prompt:
    much thinking this unit demands," not "how many files it edits." A single
    dense file can be dominant; a 20-file rename is not.
 
+   You do **not** need to worry about a single file being *too large to edit in
+   one session*. If a subtask's whole scope is one very large, edit-dense file
+   (many edit sites across thousands of lines), the orchestrator splits it
+   *within* the file — on function boundaries, and by line-window when a single
+   function is itself enormous — into region-scoped subtasks that each own part
+   of the file and run in parallel. So keep such a change as one coherent
+   subtask scoped to that file; note the density in `investigation_notes`. Do
+   **not** hand-split it into artificial "part 1 / part 2" subtasks or pad
+   `files_likely_touched` with unrelated files to make it look smaller — the
+   code-owned region split does this correctly and completely, and a manual
+   split only corrupts the partition.
+
    **Migration sweep.** When a subtask introduces a new pattern replacing
    an old one (a new accessor, a new seam, a new abstraction), quantify
    the migration surface:

--- a/prompts/splitter.md
+++ b/prompts/splitter.md
@@ -6,6 +6,15 @@ Your job: split an over-scoped subtask into smaller child subtasks that each
 have high P1 Task-Context Fit. You operate in two modes depending on what
 the orchestrator provides:
 
+> **Not your job: a single over-scoped file.** When a subtask's whole scope is
+> one large, edit-dense file, the orchestrator splits it *within* the file —
+> deterministically, on function boundaries and line-windows — into
+> region-owning children, without invoking you. You will never be asked to
+> break one file into sub-file pieces; if you receive a subtask listing a
+> single file, treat it under Mode B (a genuine multi-file seam split does not
+> apply) and, if it truly cannot be split across files, return no children so
+> the orchestrator accepts it as-is.
+
 ## Mode A — Migration sweep (pre-partitioned chunks)
 
 When `files_likely_touched` has already been partitioned into per-chunk

--- a/tests/test_check_functions.py
+++ b/tests/test_check_functions.py
@@ -185,6 +185,46 @@ class TestCheckPlannerOutput:
         issues = leerie.check_planner_output(plan, tmp_path, "testing")
         assert any("INTRA_DOMAIN_OVERLAP" in i for i in issues)
 
+    def test_intra_domain_overlap_suppressed_for_cofile_cluster(self, leerie, tmp_path):
+        # Deliberate sub-file split (DESIGN §5½ (P1) *Sub-file*): region children
+        # of one file share a _cofile_cluster marker — their same-file overlap is
+        # intentional and must NOT trip the advisory.
+        (tmp_path / "src").mkdir()
+        (tmp_path / "src" / "big.ts").touch()
+        plan = self._plan([
+            {"id": "test-001-r1", "title": "region 1",
+             "success_criteria_seed": "x",
+             "files_likely_touched": ["src/big.ts"],
+             "_cofile_cluster": "test-001",
+             "depends_on": [], "size": "small"},
+            {"id": "test-001-r2", "title": "region 2",
+             "success_criteria_seed": "y",
+             "files_likely_touched": ["src/big.ts"],
+             "_cofile_cluster": "test-001",
+             "depends_on": [], "size": "small"},
+        ])
+        issues = leerie.check_planner_output(plan, tmp_path, "testing")
+        assert not any("INTRA_DOMAIN_OVERLAP" in i for i in issues)
+
+    def test_intra_domain_overlap_still_warns_on_mixed_cluster(self, leerie, tmp_path):
+        # A cluster child plus an UNRELATED subtask on the same file is an
+        # accidental overlap, not a coherent cluster — the advisory still fires.
+        (tmp_path / "src").mkdir()
+        (tmp_path / "src" / "big.ts").touch()
+        plan = self._plan([
+            {"id": "test-001-r1", "title": "region 1",
+             "success_criteria_seed": "x",
+             "files_likely_touched": ["src/big.ts"],
+             "_cofile_cluster": "test-001",
+             "depends_on": [], "size": "small"},
+            {"id": "test-009", "title": "unrelated",
+             "success_criteria_seed": "z",
+             "files_likely_touched": ["src/big.ts"],
+             "depends_on": [], "size": "small"},
+        ])
+        issues = leerie.check_planner_output(plan, tmp_path, "testing")
+        assert any("INTRA_DOMAIN_OVERLAP" in i for i in issues)
+
     def test_protected_path(self, leerie, tmp_path):
         plan = self._plan([{
             "id": "test-001", "title": "t",

--- a/tests/test_decompose_caps.py
+++ b/tests/test_decompose_caps.py
@@ -27,3 +27,14 @@ def test_decompose_fit_threshold(leerie):
 
 def test_decompose_noprogress_rounds(leerie):
     assert leerie.DEFAULT_CAPS["decompose_noprogress_rounds"] == 2
+
+
+def test_subfile_split_max_span(leerie):
+    # Line-span above which a single-file subtask (or region) is split
+    # intra-file (DESIGN §5½ (P1) *Sub-file*). HEURISTIC, not
+    # telemetry-calibrated like decompose_fit_threshold: anchored to run
+    # 5d488583's measured span separation — the 1733-line
+    # executeStepWithHealing vs a largest-function span of <=474 in every
+    # sibling file. ~700 splits the giant into 2-3 windows and leaves a
+    # normal function whole.
+    assert leerie.DEFAULT_CAPS["subfile_split_max_span"] == 700

--- a/tests/test_extract_symbol_ranges.py
+++ b/tests/test_extract_symbol_ranges.py
@@ -1,0 +1,75 @@
+"""Tests for _extract_symbol_ranges() (DESIGN §5½ (P1) *Sub-file*).
+
+The tier-1 function-boundary partition reads per-symbol line ranges from
+tree-sitter's structure API (`item.span.start_line`/`end_line`) — the data the
+repo-map's `_parse_repo_file` deliberately discards. These tests verify the
+dedicated extractor returns sane, ordered, in-bounds ranges on a real file.
+
+Gated on the shared HAS_TREESITTER functional probe (conftest), mirroring
+test_build_repo_map.py: an absent/incompatible parser skips cleanly rather than
+failing (the sub-file splitter itself falls back to tier-2 line-windows in that
+case, covered host-independently in test_recursive_decompose.py).
+"""
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+from tests.conftest import HAS_TREESITTER
+
+pytestmark = pytest.mark.skipif(
+    not HAS_TREESITTER,
+    reason="tree-sitter parser unavailable or incompatible (no ranges)",
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+LEERIE_PY = REPO_ROOT / "orchestrator" / "leerie.py"
+
+
+@pytest.fixture(scope="session")
+def leerie():
+    spec = importlib.util.spec_from_file_location("leerie", LEERIE_PY)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_extracts_ordered_in_bounds_ranges(leerie, tmp_path):
+    f = tmp_path / "mod.py"
+    f.write_text(
+        "def first():\n"        # line 1
+        "    return 1\n"        # line 2
+        "\n"                    # line 3
+        "def second():\n"       # line 4
+        "    x = 1\n"           # line 5
+        "    return x\n"        # line 6
+        "\n"                    # line 7
+        "def third():\n"        # line 8
+        "    return 3\n"        # line 9
+    )
+    total = f.read_text().count("\n") + 1
+    ranges = leerie._extract_symbol_ranges(f)
+
+    names = [r[0] for r in ranges]
+    assert "first" in names and "second" in names and "third" in names
+    # Sorted by start line, and every range is within [1, total].
+    starts = [r[1] for r in ranges]
+    assert starts == sorted(starts)
+    for _name, s, e in ranges:
+        assert 1 <= s <= e <= total
+    # `second` spans more than one line (a multi-line body).
+    second = next(r for r in ranges if r[0] == "second")
+    assert second[2] > second[1]
+
+
+def test_unsupported_extension_returns_empty(leerie, tmp_path):
+    f = tmp_path / "data.unknownext"
+    f.write_text("nothing parseable here\n")
+    assert leerie._extract_symbol_ranges(f) == []
+
+
+def test_missing_file_returns_empty(leerie, tmp_path):
+    assert leerie._extract_symbol_ranges(tmp_path / "nope.py") == []

--- a/tests/test_owned_region_section.py
+++ b/tests/test_owned_region_section.py
@@ -1,0 +1,70 @@
+"""Tests for _format_owned_region_section() (DESIGN §5½ (P1) *Sub-file*).
+
+The sub-file splitter gives each region child an `owned_region` field on its
+on-disk spec; run_implementer surfaces it as an OWNED_REGION prompt section so
+the implementer stays inside its line range. These tests cover the deterministic
+render: None when there is no region, the rendered section when there is, and
+graceful degrade on a missing/corrupt spec (mirrors test_artifact_passing.py's
+coverage of the sibling _format_upstream_artifacts_for_sid helper).
+"""
+from __future__ import annotations
+
+import json
+
+
+def _write_spec(leerie_dir, sid, spec):
+    sub = leerie_dir / "subtasks"
+    sub.mkdir(parents=True, exist_ok=True)
+    (sub / f"{sid}.json").write_text(json.dumps(spec))
+
+
+def test_none_when_no_owned_region(leerie, tmp_path):
+    """A normal subtask (no owned_region) yields no section — the common case."""
+    _write_spec(tmp_path, "feat-001", {
+        "id": "feat-001", "title": "t", "success_criteria_seed": "c",
+        "files_likely_touched": ["a.ts"],
+    })
+    assert leerie._format_owned_region_section(tmp_path, "feat-001") is None
+
+
+def test_renders_section_with_lines_and_symbols(leerie, tmp_path):
+    _write_spec(tmp_path, "feat-005-r1", {
+        "id": "feat-005-r1", "title": "region 1",
+        "success_criteria_seed": "c",
+        "files_likely_touched": ["src/big.ts"],
+        "owned_region": {"file": "src/big.ts", "start": 1, "end": 700,
+                         "symbols": ["foo", "bar"]},
+    })
+    section = leerie._format_owned_region_section(tmp_path, "feat-005-r1")
+    assert section is not None
+    assert "OWNED_REGION:" in section
+    assert "lines 1-700 of src/big.ts" in section
+    assert "foo, bar" in section
+    # No mid-sentence hard break (D2 regression guard): the flowing sentence
+    # about the sibling stays on one logical line.
+    assert "otherwise\n" not in section
+
+
+def test_renders_placeholder_when_no_symbols(leerie, tmp_path):
+    _write_spec(tmp_path, "feat-005-r2", {
+        "id": "feat-005-r2", "title": "region 2",
+        "success_criteria_seed": "c",
+        "files_likely_touched": ["src/big.ts"],
+        "owned_region": {"file": "src/big.ts", "start": 701, "end": 1400,
+                         "symbols": []},
+    })
+    section = leerie._format_owned_region_section(tmp_path, "feat-005-r2")
+    assert section is not None
+    assert "(no named symbols in range)" in section
+
+
+def test_none_when_spec_missing(leerie, tmp_path):
+    # No spec file on disk (subtasks/ dir absent) → graceful None, no crash.
+    assert leerie._format_owned_region_section(tmp_path, "nope") is None
+
+
+def test_none_on_corrupt_spec(leerie, tmp_path):
+    sub = tmp_path / "subtasks"
+    sub.mkdir(parents=True, exist_ok=True)
+    (sub / "feat-009.json").write_text("{ not valid json")
+    assert leerie._format_owned_region_section(tmp_path, "feat-009") is None

--- a/tests/test_partition_symbols.py
+++ b/tests/test_partition_symbols.py
@@ -1,0 +1,190 @@
+"""Tests for the sub-file partition helpers (DESIGN §5½ (P1) *Sub-file*).
+
+Covers the two deterministic tiers and the coverage backstop:
+  - partition_lines()            — tier 2: contiguous line-window tiling
+  - partition_symbols_by_line()  — tier 1: function-boundary tiling of [1, EOF]
+  - _check_intra_file_surface()  — zero-tolerance coverage/overlap backstop
+
+Pure functions, no LLM, no tree-sitter (ranges are passed in directly), so these
+run on any host. The by-construction guarantee (100% coverage, 0 overlap) is the
+whole point — every test asserts the union tiles the range exactly.
+"""
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+LEERIE_PY = REPO_ROOT / "orchestrator" / "leerie.py"
+
+
+@pytest.fixture(scope="session")
+def leerie():
+    spec = importlib.util.spec_from_file_location("leerie", LEERIE_PY)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _tiles_exactly(regions, lo, hi):
+    """True iff `regions` cover [lo, hi] with no gap and no overlap."""
+    covered = set()
+    for a, b in regions:
+        for ln in range(a, b + 1):
+            if ln in covered:
+                return False  # overlap
+            covered.add(ln)
+    return covered == set(range(lo, hi + 1))
+
+
+# ---------------------------------------------------------------------------
+# partition_lines — tier 2
+# ---------------------------------------------------------------------------
+
+def test_partition_lines_exact_multiple(leerie):
+    w = leerie.partition_lines(1, 600, 200)
+    assert w == [(1, 200), (201, 400), (401, 600)]
+    assert _tiles_exactly(w, 1, 600)
+
+
+def test_partition_lines_partial_last(leerie):
+    w = leerie.partition_lines(1, 500, 200)
+    assert w == [(1, 200), (201, 400), (401, 500)]
+    assert _tiles_exactly(w, 1, 500)
+
+
+def test_partition_lines_offset_range(leerie):
+    # A region not starting at line 1 (the tier-2 re-entry case).
+    w = leerie.partition_lines(5113, 6846, 700)
+    assert _tiles_exactly(w, 5113, 6846)
+    assert all((b - a + 1) <= 700 for a, b in w)
+
+
+def test_partition_lines_single_window(leerie):
+    assert leerie.partition_lines(1, 100, 500) == [(1, 100)]
+
+
+def test_partition_lines_empty_range(leerie):
+    assert leerie.partition_lines(10, 5, 200) == []
+
+
+def test_partition_lines_degenerate_span(leerie):
+    # max_span < 1 → whole range as one window (mirrors partition_files guard).
+    assert leerie.partition_lines(1, 100, 0) == [(1, 100)]
+
+
+def test_partition_lines_span_one(leerie):
+    w = leerie.partition_lines(1, 3, 1)
+    assert w == [(1, 1), (2, 2), (3, 3)]
+    assert _tiles_exactly(w, 1, 3)
+
+
+# ---------------------------------------------------------------------------
+# partition_symbols_by_line — tier 1
+# ---------------------------------------------------------------------------
+
+def test_symbols_tile_whole_file(leerie):
+    # Three small functions in a 300-line file, cap comfortably above total.
+    ranges = [("a", 10, 40), ("b", 100, 150), ("c", 200, 260)]
+    regions = leerie.partition_symbols_by_line(ranges, 300, 700)
+    assert regions == [(1, 300)]  # all fit in one region
+    assert _tiles_exactly(regions, 1, 300)
+
+
+def test_symbols_split_when_over_cap(leerie):
+    # Functions that force >1 region when max_span is small.
+    ranges = [("a", 1, 100), ("b", 101, 200), ("c", 201, 300),
+              ("d", 301, 400)]
+    regions = leerie.partition_symbols_by_line(ranges, 400, 150)
+    assert len(regions) >= 2
+    assert _tiles_exactly(regions, 1, 400)
+    # Leading region absorbs the file start; final region reaches EOF.
+    assert regions[0][0] == 1
+    assert regions[-1][1] == 400
+
+
+def test_symbols_gap_attaches_to_preceding(leerie):
+    # A large inter-symbol gap must not create an uncovered hole.
+    ranges = [("a", 10, 20), ("b", 500, 520)]
+    regions = leerie.partition_symbols_by_line(ranges, 600, 700)
+    assert _tiles_exactly(regions, 1, 600)
+
+
+def test_symbols_giant_function_is_own_region(leerie):
+    # The 1,733-line-function case: one symbol whose span alone exceeds the cap
+    # must come back as its own (oversized) region — tier 2 handles it later.
+    ranges = [("small1", 1, 100), ("giant", 200, 1900), ("small2", 1901, 1950)]
+    regions = leerie.partition_symbols_by_line(ranges, 2000, 700)
+    assert _tiles_exactly(regions, 1, 2000)
+    # Exactly one region should exceed the cap (the giant), proving function
+    # boundaries were respected rather than force-merged.
+    oversized = [(a, b) for a, b in regions if (b - a + 1) > 700]
+    assert len(oversized) == 1
+
+
+def test_symbols_no_ranges_returns_whole_file(leerie):
+    # No usable ranges → single whole-file region (caller falls back to tier 2).
+    assert leerie.partition_symbols_by_line([], 500, 700) == [(1, 500)]
+
+
+def test_symbols_ignores_out_of_bounds_ranges(leerie):
+    # A range past EOF (stale/garbage) is dropped, not trusted.
+    ranges = [("ok", 1, 50), ("bad", 900, 1200)]
+    regions = leerie.partition_symbols_by_line(ranges, 500, 700)
+    assert _tiles_exactly(regions, 1, 500)
+
+
+def test_symbols_empty_file(leerie):
+    assert leerie.partition_symbols_by_line([], 0, 700) == []
+
+
+# ---------------------------------------------------------------------------
+# compose: tier 1 then tier 2 on the oversized region
+# ---------------------------------------------------------------------------
+
+def test_compose_tier1_then_tier2_tiles_file(leerie):
+    """A file with one giant function among small ones: tier-1 isolates the
+    giant as its own region, tier-2 splits THAT region, and the full set of
+    final windows still tiles [1, EOF] exactly — the end-to-end guarantee."""
+    total = 2000
+    ranges = [("s1", 1, 100), ("giant", 200, 1900), ("s2", 1901, 1950)]
+    cap = 700
+    tier1 = leerie.partition_symbols_by_line(ranges, total, cap)
+    final = []
+    for lo, hi in tier1:
+        if (hi - lo + 1) > cap:
+            final.extend(leerie.partition_lines(lo, hi, cap))
+        else:
+            final.append((lo, hi))
+    assert _tiles_exactly(final, 1, total)
+    assert all((b - a + 1) <= cap for a, b in final)
+
+
+# ---------------------------------------------------------------------------
+# _check_intra_file_surface — zero-tolerance backstop
+# ---------------------------------------------------------------------------
+
+def test_surface_ok_on_exact_tiling(leerie):
+    assert leerie._check_intra_file_surface([(1, 200), (201, 400)], 400) == []
+
+
+def test_surface_flags_gap(leerie):
+    issues = leerie._check_intra_file_surface([(1, 100), (201, 400)], 400)
+    assert any("INTRA_FILE_UNCOVERED" in i for i in issues)
+
+
+def test_surface_flags_overlap(leerie):
+    issues = leerie._check_intra_file_surface([(1, 250), (200, 400)], 400)
+    assert any("INTRA_FILE_OVERLAP" in i for i in issues)
+
+
+def test_surface_flags_out_of_range(leerie):
+    issues = leerie._check_intra_file_surface([(1, 500)], 400)
+    assert any("INTRA_FILE_OUT_OF_RANGE" in i for i in issues)
+
+
+def test_surface_empty_file_no_issues(leerie):
+    assert leerie._check_intra_file_surface([], 0) == []

--- a/tests/test_recursive_decompose.py
+++ b/tests/test_recursive_decompose.py
@@ -131,6 +131,7 @@ def _make_caps(leerie, **overrides):
         "decompose_max_depth": leerie.DEFAULT_CAPS["decompose_max_depth"],
         "decompose_fit_threshold": leerie.DEFAULT_CAPS["decompose_fit_threshold"],
         "decompose_noprogress_rounds": leerie.DEFAULT_CAPS["decompose_noprogress_rounds"],
+        "subfile_split_max_span": leerie.DEFAULT_CAPS["subfile_split_max_span"],
     }
     caps.update(overrides)
     return caps
@@ -678,3 +679,196 @@ def test_recursive_decompose_migration_remap_is_a_noop(leerie):
         assert leaf["provides"] == ["cfg"]
         # No child names a sibling, so nothing to remap.
         assert not [d for d in leaf["depends_on"] if d in ids]
+
+
+# ---------------------------------------------------------------------------
+# recursive_decompose — sub-file split (DESIGN §5½ (P1) *Sub-file*)
+# ---------------------------------------------------------------------------
+
+def _write_lines(path: Path, n: int) -> None:
+    path.write_text("\n".join(f"line {i}" for i in range(1, n + 1)))
+
+
+def test_subfile_oversized_single_file_region_splits(leerie, tmp_path):
+    """A low-fit single-file subtask over the span cap is region-split into
+    children that each own the same file, tile it exactly, and pass as leaves —
+    with NO splitter worker call (the split is fully code-owned)."""
+    f = tmp_path / "big.ts"
+    _write_lines(f, 2000)
+    parent = {
+        "id": "feat-005",
+        "title": "Route everything through the guard",
+        "success_criteria_seed": "all sites routed",
+        "files_likely_touched": ["big.ts"],
+    }
+    caps = _make_caps(leerie, subfile_split_max_span=700)
+    st = _make_state(leerie, caps)
+    models = {"fit_judge": "opus", "splitter": "opus"}
+    efforts = {"fit_judge": "high", "splitter": "high"}
+
+    # Deterministic ranges: two normal functions + one giant (>cap).
+    ranges = [("small1", 1, 100), ("giant", 200, 1900), ("small2", 1901, 1950)]
+
+    async def fake_claude_p(*args, schema_key, sid="", **kwargs):
+        if schema_key == "fit_judge":
+            # Parent scores low → split. Region children never reach fit_judge
+            # (the owned_region early path is mechanical), so any fit call here
+            # is the parent.
+            return _fit_response(0.30)
+        pytest.fail(f"no worker expected for a sub-file split, got {schema_key!r}")
+
+    with patch.object(leerie, "_extract_symbol_ranges", return_value=ranges), \
+         patch.object(leerie, "claude_p", new=fake_claude_p):
+        leaves = _run(leerie.recursive_decompose(
+            parent, 0, st, caps, models, efforts, tmp_path))
+
+    # Every leaf owns the same single file with an owned_region + cluster marker.
+    assert len(leaves) >= 2
+    for leaf in leaves:
+        assert leaf["files_likely_touched"] == ["big.ts"]
+        assert leaf["owned_region"]["file"] == "big.ts"
+        assert leaf["_cofile_cluster"] == "feat-005"
+        # every region within the cap after the two tiers composed
+        r = leaf["owned_region"]
+        assert (r["end"] - r["start"] + 1) <= 700
+    # Regions tile [1, 2000] exactly (100% coverage, 0 overlap).
+    spans = sorted((l["owned_region"]["start"], l["owned_region"]["end"])
+                   for l in leaves)
+    covered = set()
+    for a, b in spans:
+        rng = set(range(a, b + 1))
+        assert not (rng & covered), "regions overlap"
+        covered |= rng
+    assert covered == set(range(1, 2001))
+
+
+def test_subfile_ids_carry_domain_prefix(leerie, tmp_path):
+    """Region-child ids keep the parent's domain prefix so validate_plan's
+    id-prefix check and schedule() cross-domain wiring still pass."""
+    f = tmp_path / "big.ts"
+    _write_lines(f, 2000)
+    parent = {"id": "feat-005", "title": "t", "success_criteria_seed": "c",
+              "files_likely_touched": ["big.ts"]}
+    caps = _make_caps(leerie, subfile_split_max_span=700)
+    st = _make_state(leerie, caps)
+    models = {"fit_judge": "opus", "splitter": "opus"}
+    efforts = {"fit_judge": "high", "splitter": "high"}
+    ranges = [("a", 1, 900), ("b", 901, 1950)]
+
+    async def fake_claude_p(*args, schema_key, sid="", **kwargs):
+        return _fit_response(0.30)
+
+    with patch.object(leerie, "_extract_symbol_ranges", return_value=ranges), \
+         patch.object(leerie, "claude_p", new=fake_claude_p):
+        leaves = _run(leerie.recursive_decompose(
+            parent, 0, st, caps, models, efforts, tmp_path))
+
+    for leaf in leaves:
+        assert leaf["id"].startswith("feat-")
+
+
+def test_subfile_no_ranges_uses_line_window_fallback(leerie, tmp_path):
+    """When tree-sitter yields no ranges (unparseable / absent), a large single
+    file still splits via tier-2 line-windows over the whole file."""
+    f = tmp_path / "big.ts"
+    _write_lines(f, 2000)
+    parent = {"id": "feat-005", "title": "t", "success_criteria_seed": "c",
+              "files_likely_touched": ["big.ts"]}
+    caps = _make_caps(leerie, subfile_split_max_span=700)
+    st = _make_state(leerie, caps)
+    models = {"fit_judge": "opus", "splitter": "opus"}
+    efforts = {"fit_judge": "high", "splitter": "high"}
+
+    async def fake_claude_p(*args, schema_key, sid="", **kwargs):
+        return _fit_response(0.30)
+
+    with patch.object(leerie, "_extract_symbol_ranges", return_value=[]), \
+         patch.object(leerie, "claude_p", new=fake_claude_p):
+        leaves = _run(leerie.recursive_decompose(
+            parent, 0, st, caps, models, efforts, tmp_path))
+
+    assert len(leaves) >= 3  # 2000 / 700 → 3 windows
+    covered = set()
+    for leaf in leaves:
+        r = leaf["owned_region"]
+        covered |= set(range(r["start"], r["end"] + 1))
+    assert covered == set(range(1, 2001))
+
+
+def test_subfile_small_file_not_split(leerie, tmp_path):
+    """A single-file subtask under the span cap is NOT sub-file split — it
+    follows the normal fit-judge path (here scores well-fit → leaf)."""
+    f = tmp_path / "small.ts"
+    _write_lines(f, 120)
+    parent = {"id": "feat-010", "title": "t", "success_criteria_seed": "c",
+              "files_likely_touched": ["small.ts"]}
+    caps = _make_caps(leerie, subfile_split_max_span=700)
+    st = _make_state(leerie, caps)
+    models = {"fit_judge": "opus", "splitter": "opus"}
+    efforts = {"fit_judge": "high", "splitter": "high"}
+
+    async def fake_claude_p(*args, schema_key, sid="", **kwargs):
+        if schema_key == "fit_judge":
+            return _fit_response(0.85)  # well-fit → leaf
+        pytest.fail("no split expected for a small single file")
+
+    with patch.object(leerie, "claude_p", new=fake_claude_p):
+        leaves = _run(leerie.recursive_decompose(
+            parent, 0, st, caps, models, efforts, tmp_path))
+
+    assert leaves == [parent]
+    assert "owned_region" not in parent
+
+
+def test_subfile_unreadable_file_degrades_to_normal_path(leerie, tmp_path):
+    """A single-file subtask whose file does not exist on disk cannot be
+    region-split; it degrades to the normal path (coupled splitter) rather
+    than crashing."""
+    parent = {"id": "feat-020", "title": "t", "success_criteria_seed": "c",
+              "files_likely_touched": ["does-not-exist.ts"]}
+    caps = _make_caps(leerie, subfile_split_max_span=700)
+    st = _make_state(leerie, caps)
+    models = {"fit_judge": "opus", "splitter": "opus"}
+    efforts = {"fit_judge": "high", "splitter": "high"}
+
+    async def fake_claude_p(*args, schema_key, sid="", **kwargs):
+        if schema_key == "fit_judge":
+            if sid.endswith("-d0"):
+                return _fit_response(0.30)  # parent low → try to split
+            return _fit_response(0.85)
+        elif schema_key == "splitter":
+            # coupled path reached (file unreadable → no sub-file split)
+            return {"children": []}  # no children → parent becomes leaf
+        pytest.fail(f"unexpected {schema_key!r}")
+
+    with patch.object(leerie, "claude_p", new=fake_claude_p):
+        leaves = _run(leerie.recursive_decompose(
+            parent, 0, st, caps, models, efforts, tmp_path))
+
+    # Degraded cleanly to a leaf via the coupled path, no crash.
+    assert leaves == [parent]
+
+
+def test_subfile_bump_workers_not_called_for_region_children(leerie, tmp_path):
+    """Region children are decided mechanically (no fit_judge worker), so the
+    only worker spawn is the parent's single fit_judge call."""
+    f = tmp_path / "big.ts"
+    _write_lines(f, 2000)
+    parent = {"id": "feat-005", "title": "t", "success_criteria_seed": "c",
+              "files_likely_touched": ["big.ts"]}
+    caps = _make_caps(leerie, subfile_split_max_span=700)
+    st = _make_state(leerie, caps)
+    models = {"fit_judge": "opus", "splitter": "opus"}
+    efforts = {"fit_judge": "high", "splitter": "high"}
+    ranges = [("a", 1, 900), ("b", 901, 1950)]
+
+    async def fake_claude_p(*args, schema_key, sid="", **kwargs):
+        return _fit_response(0.30)
+
+    with patch.object(leerie, "_extract_symbol_ranges", return_value=ranges), \
+         patch.object(leerie, "claude_p", new=fake_claude_p):
+        _run(leerie.recursive_decompose(
+            parent, 0, st, caps, models, efforts, tmp_path))
+
+    # Exactly one worker call: the parent fit_judge. Region children add none.
+    assert st.bump_workers.call_count == 1


### PR DESCRIPTION
## Summary

leerie could decompose across files but never *within* one, so a subtask whose whole scope is one large, edit-dense file had exactly one representation: an unwinnable monolith (run `5d488583`/feat-005 — a 7,041-line file failed 9 times). This adds a two-tier, deterministic **sub-file split**: a dense single file is region-split on tree-sitter function boundaries, and any single function larger than the cap is sub-split by line-window — so every unit fits one implementer session.

## Which layer(s) does this PR touch?

- [x] `docs/DESIGN.md` (architecture) — new §5½ (P1) *Sub-file* subsection
- [x] `docs/IMPLEMENTATION.md` (code surface) — new cap row + sub-file arm in the recursive-decompose surface
- [x] `orchestrator/leerie.py` (code)
- [x] docs — the three worker prompts (`prompts/{planner,fit_judge,splitter}.md`)
- [x] tests (`tests/`)
- [ ] CI / repo meta (`.github/`)

If multiple, has the change propagated **top-down** per the three-layer rule (DESIGN → IMPLEMENTATION → code)?

- [x] yes

## Task-completion checklist

- [x] `docs/IMPLEMENTATION.md` updated if code surface changed
- [x] `docs/DESIGN.md` updated if architecture changed
- [x] `pytest tests/` passes — **4114 passed, 82 skipped**; the 6 failures are a pre-existing `tenacity` dev-dep gap, proven identical on clean `main` (unrelated to this change)
- [x] `python3 -c "import ast; ast.parse(open('orchestrator/leerie.py').read())"` passes
- [x] `git diff --stat` reviewed for scope — 9 tracked files + 3 new test files, no collateral edits

## What it does (mechanism)

- **Tier 1** (`partition_symbols_by_line`): tile `[1, EOF]` on function-boundary spans from a dedicated `_extract_symbol_ranges` (leaves `build_repo_map`/its cache/~10 pinned tests untouched).
- **Tier 2** (`partition_lines`): a single function over the cap (measured: the 1,733-line `executeStepWithHealing`, 34% of feat-005's edit sites) is sub-split into contiguous line-windows; also the whole-file fallback when no ranges are available.
- Both tiers guarantee **100% coverage + 0 overlap by construction**, re-asserted by `_check_intra_file_surface` (zero-tolerance). Children co-own the file via `_subfile_child` (`owned_region` + `_cofile_cluster`).
- **No downstream changes needed** — same-file co-ownership is already legitimate at every gate (schedule ignores `files_likely_touched`; the overlap judge excludes same-file/different-region; `git merge` reconciles). Only wiring: `INTRA_DOMAIN_OVERLAP` is suppressed for a deliberate cluster (accidental overlap still warns), and `run_implementer` surfaces the owned region.
- Cap: `subfile_split_max_span=700`, a heuristic anchored to the measured 1,733-vs-≤474 span separation (not telemetry-calibrated).

Verified end-to-end on the real feat-005 file: **7,042-line monolith → 12 session-sized regions** (9 function-boundary + 3 line-window), exact tiling.

## Testing notes

New coverage:
- `tests/test_partition_symbols.py` — both tiers + the compose case (giant among small → tier-1 isolates → tier-2 splits → still tiles `[1,EOF]`), backstop, degenerate cases.
- `tests/test_extract_symbol_ranges.py` — HAS_TREESITTER-gated; verifies 0-based→1-based range extraction (this gate caught a real off-by-one during development).
- `tests/test_owned_region_section.py` — the implementer prompt-injection helper.
- Additions to `test_recursive_decompose.py` (sub-file arm: region children, fallback, no-split-for-small, unreadable-file degrade, no wasted worker calls), `test_decompose_caps.py` (cap pin), `test_check_functions.py` (cluster suppression + accidental-overlap-still-warns).

## Related issue

<!-- none filed; motivated by run 5d488583 / feat-005 -->
