### PR TITLE
chore(release): 0.9.80

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "leerie",
       "source": ".",
-      "version": "0.9.79",
+      "version": "0.9.80",
       "description": "Deterministic, headless task orchestrator for Claude Code. Classifies a task, decomposes it into dependency-ordered waves, and executes each subtask in an isolated git worktree under an evidence-gated implement/validate loop. Runs entirely on the Claude Code CLI/subscription via `claude -p` workers."
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "leerie",
   "displayName": "Leerie",
-  "version": "0.9.79",
+  "version": "0.9.80",
   "description": "Deterministic, headless task orchestrator for Claude Code. Classifies a task, decomposes it into granular subtasks, schedules them into dependency-ordered waves, and executes each in an isolated git worktree under an evidence-gated implement/validate loop. Runs entirely on the Claude Code CLI/subscription via `claude -p` workers.",
   "author": { "name": "Andres Restrepo", "email": "andres@enricai.com", "url": "https://enricai.com" },
   "license": "MIT",


### PR DESCRIPTION
Version bump 0.9.79 → 0.9.80.

Bumps `.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json` in lockstep (guarded by `tests/test_version_flag.py`). On merge to `main`, the `release` workflow parses the `chore(release):` subject and creates the `v0.9.80` tag + GitHub Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)