### PR TITLE
docs(implementation): document image ENV PATH construction in §0.5

### DIFF
--- a/docs/IMPLEMENTATION.md
+++ b/docs/IMPLEMENTATION.md
@@ -326,6 +326,21 @@ Base layers (top-down):
   `ARG NODE_VERSION` so the version is reproducible across builds.
 - `pnpm` (pinned), `npm install -g @anthropic-ai/claude-code` (the
   `claude` CLI workers invoke; leerie enforces ≥ 2.1.22 at runtime).
+- `ENV PATH` is set to
+  `<system mise shims>:<LTS Node bin>:<MISE_DATA_DIR/shims>:$PATH:/home/leerie/.local/bin`
+  (concretely `/usr/local/share/mise/shims` :
+  `/usr/local/share/mise/installs/node/lts-current/bin` :
+  `/home/leerie/.local/share/mise/shims` : `$PATH` :
+  `/home/leerie/.local/bin`). The ordering is load-bearing: image-baked
+  tooling (the LTS Node that hosts `claude` itself) comes first, so a repo
+  pinning its own Node/Python version can never shadow it; the per-repo
+  `MISE_DATA_DIR/shims` (populated at runtime by `phase_provision`'s
+  `mise install` — DESIGN §6½ *Worker-driven install*) comes next, so a
+  worker's own ad-hoc Bash commands (e.g. `bin/rails test`) reach a
+  repo-pinned runtime by name without an explicit `mise exec --`; and
+  `/home/leerie/.local/bin` (where `pip install --user` lands console
+  scripts) is deliberately **last**, so a user-installed package can never
+  shadow a baked-in binary. Pinned by `tests/test_dockerfile_path.py`.
 - Non-root `leerie` user created with `--build-arg HOST_UID/HOST_GID`
   matching the host user. This is what makes files the container
   writes into `/work` (worktrees) and `/leerie-state` (run state) keep

--- a/docs/IMPLEMENTATION.md
+++ b/docs/IMPLEMENTATION.md
@@ -321,11 +321,18 @@ Base layers (top-down):
   in this container configuration; the required flags are baked in via
   `/etc/chromium.d/leerie-container-flags` (see *Browser-based testing* note
   below).
-- Node.js LTS, arch-aware via `TARGETARCH` / `dpkg --print-architecture`
-  → `arm64` → `linux-arm64` tarball, `amd64` → `linux-x64`. Pinned via
-  `ARG NODE_VERSION` so the version is reproducible across builds.
-- `pnpm` (pinned), `npm install -g @anthropic-ai/claude-code` (the
-  `claude` CLI workers invoke; leerie enforces ≥ 2.1.22 at runtime).
+- LTS Node **and** Python 3.12 baked via a single
+  `mise install --system node@lts python@3.12` (`Dockerfile`), landing under
+  `/usr/local/share/mise/installs/<tool>/<version>/`; a stable
+  `.../installs/node/lts-current` symlink is then created so `ENV PATH` and the
+  `claude` global-install don't need to know the concrete version. These are
+  the LTS fallback mise's resolver drops to when a repo declares no version of
+  its own (DESIGN §6½).
+- corepack activated via `MISE_NODE_COREPACK=true`, so a repo's
+  `package.json` `packageManager` field selects its own pnpm/yarn version —
+  no globally pinned pnpm is baked. `npm install -g @anthropic-ai/claude-code`
+  installs the `claude` CLI workers invoke (against the LTS Node above; leerie
+  enforces ≥ 2.1.22 at runtime).
 - `ENV PATH` is set to
   `<system mise shims>:<LTS Node bin>:<MISE_DATA_DIR/shims>:$PATH:/home/leerie/.local/bin`
   (concretely `/usr/local/share/mise/shims` :


### PR DESCRIPTION
## Summary

Follow-up to the review of #101. Two small **docs-only** fixes to
`docs/IMPLEMENTATION.md` §0.5 ("Image build"), both correcting spec/code drift
against the Dockerfile.

### 1. Document the image `ENV PATH` construction (the #101 review nit)

#101 added a line to §0.5's bind-mount table (the `mise-data` row) pointing
readers at *"§0.5 'Image build'"* for the detail that `MISE_DATA_DIR/shims` is on
the image's `ENV PATH` — but §0.5's base-layer list never actually documented
the `ENV PATH` construction, so the cross-reference landed on a section lacking
the detail. Adds a base-layer bullet spelling out the full PATH and its
load-bearing ordering:

- image-baked tooling first (the LTS Node that hosts `claude` — a repo pinning
  its own Node/Python can never shadow it),
- the per-repo `MISE_DATA_DIR/shims` next (runtime-populated by
  `phase_provision`'s `mise install`, DESIGN §6½ *Worker-driven install*),
- `/home/leerie/.local/bin` **last** (so a `pip install --user` script can't
  shadow a baked-in binary).

Mirrors `Dockerfile:268-288`; cites `tests/test_dockerfile_path.py` as the pin.
The bind-mount table's "see §0.5 'Image build'" cross-reference now resolves.

### 2. Correct the stale Node/pnpm install bullets (found while verifying #1)

The adjacent bullets were inaccurate against the Dockerfile:

- *"Node.js LTS … arch-aware tarball … pinned via `ARG NODE_VERSION`"* — there is
  no `ARG NODE_VERSION` and no arch-aware Node tarball. Node LTS **and** Python
  3.12 are installed together via `mise install --system node@lts python@3.12`,
  landing under `/usr/local/share/mise/installs/<tool>/<version>/` with a stable
  `lts-current` symlink (`Dockerfile:252-266`).
- *"`pnpm` (pinned)"* — pnpm is **not** globally pinned; `MISE_NODE_COREPACK=true`
  activates corepack so the repo's `packageManager` field wins, no global pin
  (`Dockerfile:217-231`).

Rewrites both to match the real mise-based install; keeps the correct
`npm install -g @anthropic-ai/claude-code` clause.

## Note on the review's other nit (tenacity test failures)

The review also flagged that a bare-host `pytest` shows `ModuleNotFoundError:
No module named 'tenacity'` in `tests/test_terminal_auth_routing.py`. That is
**not a codebase defect** and needs no change: CI installs `requirements.txt`
before pytest (`.github/workflows/test.yml`), and `README.md` / `CONTRIBUTING.md`
already document that the runtime deps must be installed on the host Python for
the suite. It was purely a local dev-host env gap — `pip install -r
requirements.txt` (or a venv) makes those 3 tests pass locally as they already
do in CI. No repo change made for it.

## Test plan

- [x] `pytest tests/test_dockerfile_path.py` — 6/6 pass (unchanged; doc edits don't touch it)
- [x] Every doc claim verified character-exact against the live Dockerfile (PATH string, mise install line, corepack env, symlink)
- [x] No test reads/parses `IMPLEMENTATION.md`, so additive doc edits can't break the suite
- [x] `python3 -c "import ast; ast.parse(open('orchestrator/leerie.py').read())"` — OK (no code touched)
- [x] `git diff --stat` — scoped to `docs/IMPLEMENTATION.md` only

🤖 Generated with [Claude Code](https://claude.com/claude-code)
