### PR TITLE
fix(retry): back off transient "Connection closed mid-response" drops

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -287,11 +287,20 @@ RUN set -eux; \
 #      binary. Pinned by tests/test_dockerfile_path.py.
 ENV PATH=/usr/local/share/mise/shims:/usr/local/share/mise/installs/node/lts-current/bin:/home/leerie/.local/share/mise/shims:$PATH:/home/leerie/.local/bin
 
-# Claude Code CLI. Leerie enforces ≥ 2.1.22 at runtime (leerie.py:1245).
+# Claude Code CLI. Leerie enforces ≥ 2.1.22 at runtime (leerie.py:1245) for
+# --json-schema. The install is pinned ≥ 2.1.219: that release fixed `claude
+# -p` dropping already-produced text when a turn dies on a mid-stream API
+# error ("Connection closed mid-response"), which is exactly the transport
+# drop leerie's own backoff retry now recovers from (DESIGN §6 *Cleanup on
+# abnormal exit*, IMPLEMENTATION §3 "Transient transport disconnect"). The
+# image should carry the CLI-side in-session fix so leerie's fresh-session
+# backoff is the second line of defense, not the only one. The runtime floor
+# is deliberately NOT bumped to 219 — a resilience nicety must not hard-die a
+# valid older host CLI the way the --json-schema hard requirement does.
 # Installs globally against the LTS Node — lands at
 # /usr/local/share/mise/installs/node/lts-current/lib/node_modules
 # with a bin shim at .../bin/claude (on PATH via the line above).
-RUN npm install -g @anthropic-ai/claude-code
+RUN npm install -g '@anthropic-ai/claude-code@>=2.1.219'
 
 # Non-root user matching the host UID/GID so bind-mounted files keep their
 # host ownership. Defaults are macOS-typical; the launcher overrides them

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -865,6 +865,24 @@ split mechanism therefore separates by structural type:
   1,733-vs-≤474 span separation, not telemetry-calibrated like the 0.70 fit
   threshold).
 
+  - **Oversized-file peel (a dense file bundled with a few others).** The tier-1/2
+    tiling above operates only on a subtask whose `files_likely_touched` is
+    *exactly one* file — a single region can be tiled, a set of files cannot. But
+    the dominant real shape of a dense-file subtask is the file **plus its test
+    file** (measured: 382 two-file subtasks across run history, 244 of them
+    impl+test; feat-005 itself was `[flow-runner.ts, flow-runner.test.ts]`, which
+    is *why* its first fix never engaged the sub-file split). For a small file-set
+    (`1 < len(files) ≤ chunk_size`) where **exactly one** file exceeds
+    `subfile_split_max_span` lines, the mechanism first *peels*: it splits the
+    subtask into a single-file child scoped to the dense file — which re-enters the
+    tier-1/2 tiling above — and a sibling child owning the remaining file(s). The
+    peel is deterministic (a line-count probe, no worker) and generalizes past
+    impl+test. It fires only when exactly one file is oversized: zero oversized
+    files is nothing to peel, and ≥2 oversized files is genuinely coupled
+    multi-file work the LLM splitter should own — both fall through unchanged. The
+    peeled children inherit the parent's edges exactly as the migration/tier
+    children do, so `schedule()`/overlap/integration are unaffected.
+
 **`recursive_decompose(subtask, depth) → list[leaf_subtasks]`** is the loop:
 
 ```
@@ -1761,6 +1779,38 @@ transient classifier and routed straight to the same resumable pause
 (`EXIT_LOCKED`, exit 75) used for out-of-credits below — worktree-only
 cleanup, state and branches preserved, `--resume` picks back up once
 the operator re-authenticates.
+
+**A mid-stream transport disconnect is a third transient class, and it
+gets the same backoff.** When the network connection carrying a worker's
+streaming response drops mid-answer, `claude -p` surfaces a result
+envelope with `is_error` set, `terminal_reason` = `"api_error"`, a *null*
+`api_error_status` (the connection died before any HTTP status returned),
+and result text `"API Error: Connection closed mid-response. The response
+above may be incomplete."` This is the same *family* as the 529 overload
+case — the session is fine, the request just never completed — so a fresh
+session after backoff has a real chance of succeeding. It is distinct from
+a schema mistake, which is what the immediate corrective-note retry exists
+for; routing a transport drop through that path retries once against the
+same bad network window with a nonsensical "conform to the schema" nudge,
+then fails the subtask. `_is_transient_transport_failure` classifies it
+(keyed on `terminal_reason == "api_error"` with no numeric
+`api_error_status`, or — as a secondary catch — a narrow connection-drop
+text-marker set) and
+routes it through the *same* `_is_auth_or_quota_failure` tenacity backoff
+loop, checked after the terminal-auth classifier so an expired session is
+never mistaken for a transport blip. The measured basis (a scan of 9,020
+worker logs): 58 sids hit this drop; isolating the 56 that did **not** also
+hit `max_turns` (the pure-transport population), **83% recovered on a later
+attempt and 73% on the very next one** — a network transient, not context
+exhaustion (a third of drops fire at ≤3 turns, before any context
+accumulates). The two `max_turns`-coupled sids recovered 0% — an oversized
+subtask that also drops is a *decomposition* problem (see §5½ P1
+*Sub-file*), not one backoff can fix, and `auth_retry_max_sec` correctly
+gives up on that tail. This transient path is upstream-corroborated:
+Claude Code's own remedy for a mid-stream drop is an automatic retry
+(the `claude -p` text-preservation fix landed in CLI v2.1.219); leerie's
+backoff is the fresh-session complement for when the CLI's in-session
+retries are exhausted.
 
 **Worktree-only cleanup, always.** Whether triggered by Ctrl-C,
 SIGTERM, SIGHUP, WorkerError, or any other exception:

--- a/docs/IMPLEMENTATION.md
+++ b/docs/IMPLEMENTATION.md
@@ -330,9 +330,12 @@ Base layers (top-down):
   its own (DESIGN §6½).
 - corepack activated via `MISE_NODE_COREPACK=true`, so a repo's
   `package.json` `packageManager` field selects its own pnpm/yarn version —
-  no globally pinned pnpm is baked. `npm install -g @anthropic-ai/claude-code`
-  installs the `claude` CLI workers invoke (against the LTS Node above; leerie
-  enforces ≥ 2.1.22 at runtime).
+  no globally pinned pnpm is baked. `npm install -g
+  '@anthropic-ai/claude-code@>=2.1.219'` installs the `claude` CLI workers
+  invoke (against the LTS Node above; leerie enforces ≥ 2.1.22 at runtime for
+  `--json-schema`, and the image install is pinned ≥ 2.1.219 for the `claude
+  -p` mid-stream-drop fix — see the Dockerfile comment and IMPLEMENTATION §3
+  "Transient transport disconnect").
 - `ENV PATH` is set to
   `<system mise shims>:<LTS Node bin>:<MISE_DATA_DIR/shims>:$PATH:/home/leerie/.local/bin`
   (concretely `/usr/local/share/mise/shims` :
@@ -3288,6 +3291,36 @@ The classifier and the budget constant (`auth_retry_max_sec`) live in
 `leerie.py`; the budget is in §6 *Code-enforced caps*. The non-auth
 `is_error` path is unchanged — schema parse failures stay immediate.
 
+#### Transient transport disconnect
+
+The same backoff loop also handles a **mid-stream transport disconnect**:
+the network connection carrying a worker's streaming response drops
+mid-answer, and `claude -p` surfaces a result envelope with `is_error`
+set, `terminal_reason == "api_error"`, a **null** `api_error_status` (the
+connection died before any HTTP status returned, so no numeric category
+applies), and result text `"API Error: Connection closed mid-response. The
+response above may be incomplete."` `_is_transient_transport_failure(envelope)`
+classifies this on the same `is_error`-gated, `_leerie_synthetic`-exempt
+discipline as the two auth classifiers, matching when `terminal_reason ==
+"api_error"` and `_api_error_category(api_error_status)` is `None`
+(401/429/529 keep the auth/quota path above), **or** the result text
+carries a narrow connection-drop marker (`connection closed`, `connection
+reset`, `connection error`, `mid-response`, `timeout while waiting for
+response`). A matching envelope enters the *same* `tenacity.AsyncRetrying`
+loop as `_is_auth_or_quota_failure` (they are OR'd into one branch
+condition, so the backoff mechanics, budget, and per-iteration logging are
+shared — not duplicated). It is checked **after** `_is_terminal_auth_failure`
+so an expired session is never mistaken for a transport blip, and before
+the generic `is_error` corrective-retry arm, which otherwise retries a
+network drop once against the same bad window with a nonsensical "conform
+to the schema" nudge and then fails the subtask. On budget exhaustion the
+raised `WorkerError` names the transport disconnect (not a subscription
+cap) and points at `--resume`. This is the fresh-session complement to the
+CLI's own in-session retry (the `claude -p` mid-stream fix landed in CLI
+v2.1.219); leerie sees the drop only once the CLI's retries are exhausted.
+Measured basis and rationale: DESIGN §6 *Cleanup on abnormal exit* (56 of
+58 dropped sids were pure-transport, 83% recovering on a later attempt).
+
 #### Terminal auth failure
 
 `_is_terminal_auth_failure(envelope)` is checked in `claude_p()` **before**
@@ -4489,6 +4522,21 @@ accept the subtask as leaf); then splits via either:
     downstream (schedule ignores `files_likely_touched`; overlap judge excludes
     same-file/different-region; `git merge` reconciles); `check_planner_output`'s
     `INTRA_DOMAIN_OVERLAP` advisory is suppressed for `_cofile_cluster` children.
+  - **Oversized-file peel** (`1 < len(files) ≤ chunk_size`, exactly one file over
+    `subfile_split_max_span` lines): checked in the split step **before**
+    `_subfile_split()`'s single-file tiling, since that tiling's `len(files) == 1`
+    guard skips the dominant dense-file shape — the file bundled with its test
+    file (`_subfile_split()` returns `[]` for `[impl.ts, impl.test.ts]`, which then
+    falls to the coupled LLM splitter that may not isolate the dense file). The
+    peel (`_peel_oversized_file()`, deterministic — a `read_text().count("\n")`
+    probe per file, no worker) splits the subtask into a single-file child scoped
+    to the one oversized file (which re-enters recursion and hits the sub-file
+    tiling above) and a sibling child owning the remaining file(s). Both children
+    inherit the parent's `depends_on`/`requires`/`provides` verbatim (same
+    deep-copy edge discipline as `_migration_child`). Guard: if **zero** or **≥2**
+    files exceed the cap it returns `[]` and the split falls through unchanged —
+    zero is nothing to peel; ≥2 is genuinely coupled multi-file work the LLM
+    splitter owns.
 
 Both the `fit_judge` call and the coupled-path `splitter` call are wrapped in
 `try/except WorkerError`, degrading the node to a leaf (`[subtask]`

--- a/orchestrator/leerie.py
+++ b/orchestrator/leerie.py
@@ -5439,6 +5439,62 @@ def _subfile_split(subtask: dict, repo_root: Path,
     ]
 
 
+def _peel_oversized_file(subtask: dict, repo_root: Path,
+                         max_span: int, chunk_size: int) -> list[dict]:
+    """Peel a single oversized file out of a small multi-file subtask so it can
+    reach `_subfile_split`'s intra-file tiling (DESIGN §5½ (P1) *Sub-file*).
+
+    `_subfile_split` only tiles a subtask whose `files_likely_touched` is exactly
+    one file. But the dominant real shape of a dense-file subtask is the file
+    bundled with its test file (`[flow-runner.ts, flow-runner.test.ts]` — the
+    exact shape of feat-005, which is why its first sub-file fix never engaged).
+    For such a subtask this peels it into two children: a single-file child
+    scoped to the oversized file (which re-enters recursion and gets tiled) and a
+    sibling owning the remaining file(s).
+
+    Fires only when **exactly one** file exceeds `max_span` lines and the set is
+    small (`1 < len(files) <= chunk_size`). Returns `[]` (fall through unchanged)
+    when: the set is a single file (`_subfile_split` already handles it) or too
+    large (a migration sweep the file-count fork owns); zero files are oversized
+    (nothing to peel); or >=2 are oversized (genuinely coupled multi-file work the
+    LLM splitter should own). A file whose line count can't be read is treated as
+    not-oversized (a leaf-safe default), mirroring `_subfile_split`.
+
+    Children are built with `_migration_child` (same edge-copy discipline; the
+    dense-file child re-enters `_subfile_split` on recursion, so it needs no
+    `owned_region` here — the tiling assigns regions)."""
+    files = subtask.get("files_likely_touched") or []
+    if not (1 < len(files) <= chunk_size):
+        return []
+
+    def _line_count(f: str) -> int:
+        try:
+            return (repo_root / f).read_text(errors="replace").count("\n") + 1
+        except OSError:
+            return 0  # unreadable → treat as not-oversized (leaf-safe)
+
+    oversized = [f for f in files if _line_count(f) > max_span]
+    if len(oversized) != 1:
+        return []  # nothing to peel, or genuinely coupled — LLM splitter owns it
+
+    dense = oversized[0]
+    rest = [f for f in files if f != dense]
+    base_id = subtask.get("id", "split")
+    parent_title = subtask.get("title", "file change")
+    seed = subtask.get("success_criteria_seed", "")
+    dense_child = _migration_child(
+        subtask, [dense], f"{base_id}-f1",
+        f"{parent_title} (dense file: {dense})",
+        (f"{seed}\nScope: only {dense}. A sibling subtask owns the "
+         f"remaining file(s).").strip())
+    rest_child = _migration_child(
+        subtask, rest, f"{base_id}-f2",
+        f"{parent_title} (remaining: {', '.join(rest)})",
+        (f"{seed}\nScope: only these files — {', '.join(rest)}. A sibling "
+         f"subtask owns {dense}.").strip())
+    return [dense_child, rest_child]
+
+
 async def recursive_decompose(
     subtask: dict,
     depth: int,
@@ -5582,6 +5638,20 @@ async def recursive_decompose(
 
     # --- split step ----------------------------------------------------------
     files = subtask.get("files_likely_touched") or []
+    chunk_size = 8
+    # Oversized-file peel (DESIGN §5½ (P1) *Sub-file* → *Oversized-file peel*):
+    # a small multi-file subtask (e.g. a dense file + its test file) where
+    # exactly one file is over the span cap is peeled into a single-file child
+    # (which re-enters _subfile_split on recursion below and gets tiled) and a
+    # sibling owning the rest. Checked before _subfile_split because that
+    # function's len(files)==1 guard skips the dominant impl+test shape.
+    # Deterministic — no worker spawn. Returns [] (falls through) when not a
+    # peel candidate.
+    peeled_children = _peel_oversized_file(
+        subtask, repo_root,
+        caps.get("subfile_split_max_span",
+                 DEFAULT_CAPS["subfile_split_max_span"]),
+        chunk_size)
     # Sub-file path (DESIGN §5½ (P1) *Sub-file*): a single dense file (or a
     # single oversized region re-entering) is split WITHIN the file, since the
     # whole-file splitter below cannot break one file. Checked first; falls
@@ -5591,8 +5661,9 @@ async def recursive_decompose(
         subtask, repo_root,
         caps.get("subfile_split_max_span",
                  DEFAULT_CAPS["subfile_split_max_span"]))
-    chunk_size = 8
-    if subfile_children:
+    if peeled_children:
+        children = peeled_children
+    elif subfile_children:
         children = subfile_children
     # Migration path (dominant case, ~84%): code-partitions, LLM only labels.
     # Coupled-minority path: LLM-splitter decides the partition.
@@ -9234,6 +9305,66 @@ def _is_auth_or_quota_failure(envelope: dict) -> bool:
             or "rate-limit" in msg)
 
 
+# Connection-drop markers for _is_transient_transport_failure. Kept narrow
+# and specific to a *transport-level* disconnect (the connection carrying the
+# stream dropped), not a generic "error" — a broad match would false-positive
+# on a worker legitimately discussing networking in its own output, which the
+# is_error gate mostly but not perfectly guards against. "connection reset" /
+# "timeout while waiting for response" are the sibling shapes already
+# enumerated as non-terminal-auth in tests/test_terminal_auth_failure.py.
+_TRANSPORT_DROP_MARKERS = (
+    "connection closed",
+    "connection reset",
+    "connection error",
+    "mid-response",
+    "timeout while waiting for response",
+)
+
+
+def _is_transient_transport_failure(envelope: dict) -> bool:
+    """True when the `claude -p` envelope is a mid-stream **transport
+    disconnect** — the network connection carrying the streaming response
+    dropped mid-answer, e.g. "API Error: Connection closed mid-response."
+
+    Same family as the 529 overload case `_is_auth_or_quota_failure` covers:
+    the session is fine, the request just never completed, so a fresh session
+    after backoff has a real chance of succeeding. Distinct from a schema
+    mistake (the immediate corrective-note retry) and from an expired session
+    (terminal auth). Routed through the *same* auth/quota tenacity backoff loop,
+    checked AFTER `_is_terminal_auth_failure` so an expired session is never
+    mistaken for a transport blip.
+
+    The measured envelope shape (from a real drop): `is_error: true`,
+    `subtype: "success"` (misleading — do NOT key on subtype), `terminal_reason:
+    "api_error"`, `api_error_status: null` (the drop preceded any HTTP status),
+    result text "API Error: Connection closed mid-response. …". So the primary
+    signal is `terminal_reason == "api_error"` with no numeric `api_error_status`
+    (401/429/529 keep the auth/quota path); the text markers are a secondary
+    catch for drop shapes that arrive without that terminal_reason.
+
+    Gating discipline mirrors the two auth classifiers verbatim (see their
+    docstrings): gated on `is_error` — a successful, schema-valid envelope must
+    never match no matter what its `result` text says — and `_leerie_synthetic`
+    envelopes are exempt, since the no-result envelope interpolates the worker's
+    raw stderr into `result`, which can legitimately contain these markers
+    without a real transport drop. A numeric 401/429/529 status also excludes
+    the envelope here (it belongs to `_is_auth_or_quota_failure`), keeping the
+    two classifiers cleanly partitioned."""
+    if not envelope.get("is_error"):
+        return False
+    if envelope.get("_leerie_synthetic"):
+        return False
+    # 401/429/529 are auth/quota, not a transport drop — let that classifier
+    # own them so the two partition cleanly.
+    if _api_error_category(envelope.get("api_error_status")) is not None:
+        return False
+    if (envelope.get("terminal_reason") == "api_error"
+            and envelope.get("api_error_status") is None):
+        return True
+    msg = str(envelope.get("result") or "").lower()
+    return any(m in msg for m in _TRANSPORT_DROP_MARKERS)
+
+
 def _classify_failure_kind(envelope: dict, parsed_ok: bool) -> str | None:
     """Categorize *why* a captured `claude -p` call failed, for the
     `failure_kind` field on the calls.ndjson record. Returns None on
@@ -11100,16 +11231,29 @@ async def claude_p(user_prompt: str, system_prompt: str, *, schema_key: str,
             if _is_terminal_auth_failure(envelope):
                 raise TerminalAuthFailure(str(envelope.get("result") or ""))
 
-            # Auth/quota backoff: 401/429/529/auth-message envelopes need
-            # waiting, not the immediate corrective retry below. The gateway
-            # has already rejected the request and a fresh request will be
-            # rejected too until the user's Claude Code subscription window
-            # clears (401/429) or the transient overload (529) subsides. Run
-            # tenacity's exponential-backoff-with-jitter loop, capped at
-            # `auth_retry_max_sec` cumulative seconds. The loop exits when an
-            # invocation returns a non-auth envelope (success or a different
-            # error class) or when the budget is exhausted.
-            if _is_auth_or_quota_failure(envelope):
+            # Backoff (not immediate corrective retry) is needed for two
+            # envelope classes that share the same remedy — a fresh session
+            # after a short wait:
+            #   (a) auth/quota — 401/429/529/auth-message: the gateway rejected
+            #       the request; it will reject a fresh one too until the rolling
+            #       usage window clears (401/429) or the transient overload (529)
+            #       subsides.
+            #   (b) transport disconnect — the connection carrying the stream
+            #       dropped mid-response (`terminal_reason=api_error`, null
+            #       status, "Connection closed mid-response"). Same family as
+            #       529: the session is fine, the request just never completed.
+            # Both run the SAME tenacity exponential-backoff-with-jitter loop,
+            # capped at `auth_retry_max_sec` cumulative seconds. The loop exits
+            # when an invocation returns an envelope in neither class (success
+            # or a different error) or when the budget is exhausted. Routing a
+            # transport drop here (rather than the immediate `is_error` arm
+            # below) avoids retrying once against the same bad network window
+            # with a nonsensical "conform to the schema" nudge.
+            def _needs_backoff(env: dict) -> bool:
+                return (_is_auth_or_quota_failure(env)
+                        or _is_transient_transport_failure(env))
+
+            if _needs_backoff(envelope):
                 # Lazy import (not module-scope) so this file loads on a bare host
                 # python3 lacking requirements.txt deps — see the module-top note.
                 from tenacity import (
@@ -11123,7 +11267,10 @@ async def claude_p(user_prompt: str, system_prompt: str, *, schema_key: str,
 
                 def _log_before_sleep(rs: RetryCallState) -> None:
                     env = rs.outcome.result()
-                    marker = (env.get("api_error_status") or "auth/quota")
+                    marker = (env.get("api_error_status")
+                              or ("transport disconnect"
+                                  if _is_transient_transport_failure(env)
+                                  else "auth/quota"))
                     log(f"  worker hit {marker} — retrying in "
                         f"{rs.next_action.sleep:.0f}s "
                         f"(elapsed {rs.seconds_since_start:.0f}s of "
@@ -11140,20 +11287,30 @@ async def claude_p(user_prompt: str, system_prompt: str, *, schema_key: str,
                         wait=wait_exponential_jitter(
                             initial=15, max=120, jitter=5),
                         stop=stop_after_delay(auth_retry_max_sec),
-                        retry=retry_if_result(_is_auth_or_quota_failure),
+                        retry=retry_if_result(_needs_backoff),
                         reraise=False,
                         before_sleep=_log_before_sleep,
                     )(_spawn, retry_note)
                 except RetryError as e:
-                    # Budget exhausted with the envelope still auth/quota.
-                    # Surface the last attempt's envelope so the
-                    # subscription-cap WorkerError below fires with
-                    # accurate context. retry_if_result only filters
-                    # results (not exceptions), so last_attempt holds a
-                    # result Future — .result() returns the envelope.
+                    # Budget exhausted with the envelope still in a backoff
+                    # class. Surface the last attempt's envelope so the
+                    # WorkerError below fires with accurate context.
+                    # retry_if_result only filters results (not exceptions), so
+                    # last_attempt holds a result Future — .result() returns the
+                    # envelope.
                     envelope = e.last_attempt.result()
 
-                if _is_auth_or_quota_failure(envelope):
+                if _needs_backoff(envelope):
+                    # Name the actual cause so the user isn't told to wait for a
+                    # usage window that isn't the problem. Transport drops are
+                    # checked first: they carry no numeric status, so the 529 /
+                    # auth branches below would otherwise mislabel them.
+                    if _is_transient_transport_failure(envelope):
+                        raise WorkerError(
+                            "Claude API connection dropped mid-response "
+                            f"after ~{auth_retry_max_sec}s of retries — a "
+                            "transient network/gateway transport error. Run "
+                            "--resume to retry.")
                     # A 529 is transient gateway overload, not a subscription
                     # cap — don't misattribute it. 401/429 (and the text-marker
                     # path) stay on the rolling-usage-cap message.

--- a/tests/test_recursive_decompose.py
+++ b/tests/test_recursive_decompose.py
@@ -872,3 +872,111 @@ def test_subfile_bump_workers_not_called_for_region_children(leerie, tmp_path):
 
     # Exactly one worker call: the parent fit_judge. Region children add none.
     assert st.bump_workers.call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# oversized-file peel (DESIGN §5½ (P1) *Sub-file* → *Oversized-file peel*):
+# a small multi-file subtask (impl + test) where exactly one file is over the
+# span cap is peeled so the dense file reaches _subfile_split's tiling.
+# ---------------------------------------------------------------------------
+
+def test_peel_unit_two_file_impl_test(leerie, tmp_path):
+    """`_peel_oversized_file` on the measured feat-005 shape (dense impl +
+    small test) → a single-file dense child + a sibling owning the test file,
+    both inheriting the parent's edges."""
+    _write_lines(tmp_path / "flow-runner.ts", 2000)     # oversized
+    _write_lines(tmp_path / "flow-runner.test.ts", 50)  # small
+    parent = {
+        "id": "feat-005", "title": "Thread FrameTarget",
+        "success_criteria_seed": "all sites routed",
+        "files_likely_touched": ["flow-runner.ts", "flow-runner.test.ts"],
+        "depends_on": ["feat-004"],
+        "provides": ["frame-target"],
+    }
+    children = leerie._peel_oversized_file(parent, tmp_path, 700, 8)
+    assert len(children) == 2
+    by_files = {tuple(c["files_likely_touched"]): c for c in children}
+    assert ("flow-runner.ts",) in by_files          # dense peeled to its own child
+    assert ("flow-runner.test.ts",) in by_files      # test file is the sibling
+    for c in children:
+        # edges inherited verbatim (copied, not aliased)
+        assert c["depends_on"] == ["feat-004"]
+        assert c["provides"] == ["frame-target"]
+        assert c["depends_on"] is not parent["depends_on"]
+
+
+def test_peel_unit_no_oversized_file_falls_through(leerie, tmp_path):
+    """Two files, neither over the cap → nothing to peel, returns []."""
+    _write_lines(tmp_path / "a.ts", 100)
+    _write_lines(tmp_path / "b.ts", 120)
+    parent = {"id": "feat-001", "title": "t", "success_criteria_seed": "c",
+              "files_likely_touched": ["a.ts", "b.ts"]}
+    assert leerie._peel_oversized_file(parent, tmp_path, 700, 8) == []
+
+
+def test_peel_unit_two_oversized_files_falls_through(leerie, tmp_path):
+    """Two files, BOTH over the cap → genuinely coupled multi-file work; the
+    peel declines (returns []) so the LLM splitter owns it."""
+    _write_lines(tmp_path / "a.ts", 2000)
+    _write_lines(tmp_path / "b.ts", 2000)
+    parent = {"id": "feat-001", "title": "t", "success_criteria_seed": "c",
+              "files_likely_touched": ["a.ts", "b.ts"]}
+    assert leerie._peel_oversized_file(parent, tmp_path, 700, 8) == []
+
+
+def test_peel_unit_single_file_declines(leerie, tmp_path):
+    """A single-file subtask is _subfile_split's job, not the peel's."""
+    _write_lines(tmp_path / "a.ts", 2000)
+    parent = {"id": "feat-001", "title": "t", "success_criteria_seed": "c",
+              "files_likely_touched": ["a.ts"]}
+    assert leerie._peel_oversized_file(parent, tmp_path, 700, 8) == []
+
+
+def test_peel_end_to_end_dense_file_tiles(leerie, tmp_path):
+    """Full recursive_decompose on the impl+test shape: the dense file peels
+    then tiles into region leaves; the test file survives as its own leaf.
+    Uses the tier-2 line-window fallback (no tree-sitter ranges needed)."""
+    _write_lines(tmp_path / "flow-runner.ts", 2000)
+    _write_lines(tmp_path / "flow-runner.test.ts", 50)
+    parent = {
+        "id": "feat-005", "title": "Thread FrameTarget",
+        "success_criteria_seed": "all sites routed",
+        "files_likely_touched": ["flow-runner.ts", "flow-runner.test.ts"],
+    }
+    caps = _make_caps(leerie, subfile_split_max_span=700)
+    st = _make_state(leerie, caps)
+    models = {"fit_judge": "opus", "splitter": "opus"}
+    efforts = {"fit_judge": "high", "splitter": "high"}
+
+    async def fake_claude_p(*args, schema_key, sid="", **kwargs):
+        if schema_key == "fit_judge":
+            # The parent (both files) scores low → peel. The peeled test-file
+            # sibling (id feat-005-f2) is a small focused file → well-fit leaf,
+            # so it never reaches the splitter. The dense-file child (feat-005-f1)
+            # carries an owned_region and is decided mechanically (no fit call).
+            # `sid` is fit-judge-<subtask-id>-d<depth>.
+            if "feat-005-f2" in sid:
+                return _fit_response(0.90)  # test-file sibling: well-fit leaf
+            return _fit_response(0.30)      # parent: low fit → peel
+        pytest.fail(f"peel/tiling is code-owned; no {schema_key!r} worker")
+
+    # No tree-sitter ranges → tier-2 line-window fallback tiles the dense file.
+    with patch.object(leerie, "_extract_symbol_ranges", return_value=[]), \
+         patch.object(leerie, "claude_p", new=fake_claude_p):
+        leaves = _run(leerie.recursive_decompose(
+            parent, 0, st, caps, models, efforts, tmp_path))
+
+    # The dense file produced >=2 region leaves (each owning only flow-runner.ts
+    # with an owned_region); the test file is exactly one leaf, un-tiled.
+    dense_leaves = [l for l in leaves
+                    if l["files_likely_touched"] == ["flow-runner.ts"]]
+    test_leaves = [l for l in leaves
+                   if l["files_likely_touched"] == ["flow-runner.test.ts"]]
+    assert len(dense_leaves) >= 2, "dense file was not tiled after the peel"
+    assert all(l.get("owned_region") for l in dense_leaves)
+    assert len(test_leaves) == 1, "test file should be one untiled sibling leaf"
+    assert test_leaves[0].get("owned_region") is None
+    # dense regions each within the cap
+    for l in dense_leaves:
+        r = l["owned_region"]
+        assert (r["end"] - r["start"] + 1) <= 700

--- a/tests/test_terminal_auth_failure.py
+++ b/tests/test_terminal_auth_failure.py
@@ -365,13 +365,15 @@ def test_exit_locked_is_75(leerie):
 
 def test_terminal_auth_failure_checked_before_auth_or_quota_in_claude_p(leerie):
     """Source-coupling guard: _is_terminal_auth_failure must be checked
-    before _is_auth_or_quota_failure inside claude_p's retry loop, else
-    the terminal case falls into the tenacity backoff first."""
+    before the backoff branch inside claude_p's retry loop, else the terminal
+    case falls into the tenacity backoff first. The backoff branch is now
+    guarded by the combined `_needs_backoff(envelope)` predicate (which ORs
+    `_is_auth_or_quota_failure` and `_is_transient_transport_failure`)."""
     import inspect
     src = inspect.getsource(leerie.claude_p)
     terminal_idx = src.index("_is_terminal_auth_failure(envelope)")
-    quota_idx = src.index("_is_auth_or_quota_failure(envelope)")
-    assert terminal_idx < quota_idx
+    backoff_idx = src.index("_needs_backoff(envelope)")
+    assert terminal_idx < backoff_idx
 
 
 def test_terminal_auth_failure_is_a_base_exception(leerie):

--- a/tests/test_terminal_auth_routing.py
+++ b/tests/test_terminal_auth_routing.py
@@ -261,5 +261,10 @@ def test_terminal_auth_checked_before_auth_or_quota_in_claude_p(leerie):
     import inspect
     src = inspect.getsource(leerie.claude_p)
     terminal_idx = src.index("_is_terminal_auth_failure(envelope)")
-    quota_idx = src.index("_is_auth_or_quota_failure(envelope)")
-    assert terminal_idx < quota_idx
+    # The auth/quota + transport-drop backoff branch is now guarded by the
+    # combined `_needs_backoff(envelope)` predicate (which ORs
+    # `_is_auth_or_quota_failure` and `_is_transient_transport_failure`).
+    # Terminal auth must still be checked before it — an expired session must
+    # never be routed into the backoff loop.
+    backoff_idx = src.index("_needs_backoff(envelope)")
+    assert terminal_idx < backoff_idx

--- a/tests/test_transient_transport_retry.py
+++ b/tests/test_transient_transport_retry.py
@@ -1,0 +1,262 @@
+"""Tests for the transient-transport-disconnect backoff path (DESIGN §6
+*Cleanup on abnormal exit*, IMPLEMENTATION §3 "Transient transport
+disconnect").
+
+When the network connection carrying a worker's streaming response drops
+mid-answer, `claude -p` surfaces a result envelope with `is_error` set,
+`terminal_reason == "api_error"`, a *null* `api_error_status` (the drop
+preceded any HTTP status), and result text "API Error: Connection closed
+mid-response. The response above may be incomplete." (measured verbatim
+from a real feat-005 worker log).
+
+leerie used to fall this through the generic `is_error` arm — an immediate
+corrective-note retry with a nonsensical "conform to the schema" nudge,
+then a terminal `WorkerError("worker failed schema-valid output twice")`.
+It is now classified by `_is_transient_transport_failure` and routed
+through the SAME auth/quota tenacity backoff loop (a fresh session after a
+short wait — the same remedy 529 already gets).
+
+Covers, mirroring test_auth_backoff.py (classifier corpus) and
+test_terminal_auth_routing.py (stubbed-_invoke routing + ast coupling):
+  - classifier positive/negative corpus (the measured envelope + siblings;
+    successful / synthetic / 401-429-529 / prose-only negatives)
+  - a drop envelope enters the backoff loop, not the immediate schema loop
+  - budget exhaustion raises a transport-named WorkerError with --resume
+  - the two backoff classes partition cleanly (401/429/529 stay auth/quota)
+  - source-coupling: the transport classifier is consulted in claude_p
+    after terminal-auth, via the combined `_needs_backoff` predicate
+"""
+from __future__ import annotations
+
+import asyncio
+import time
+
+import pytest
+
+
+# The measured envelope shape from a real drop (feat-005.log). subtype is
+# "success" on purpose — the classifier must NOT key on it.
+_DROP = {
+    "type": "result",
+    "subtype": "success",
+    "is_error": True,
+    "terminal_reason": "api_error",
+    "api_error_status": None,
+    "result": ("API Error: Connection closed mid-response. "
+               "The response above may be incomplete."),
+    "structured_output": None,
+}
+
+_VALID = {
+    "type": "result",
+    "subtype": "success",
+    "is_error": False,
+    "result": "{}",
+    "structured_output": {"score": 0.9, "rationale": "ok",
+                          "diffuse": False,
+                          "confidence": {"fit": "high"}},
+}
+
+
+# ---------------------------------------------------------------------------
+# classifier corpus  (template: tests/test_auth_backoff.py)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("envelope", [
+    _DROP,
+    # terminal_reason api_error + null status, no text marker at all
+    {"is_error": True, "terminal_reason": "api_error",
+     "api_error_status": None, "result": ""},
+    # text-marker path (no terminal_reason): sibling transport shapes
+    {"is_error": True, "result": "API Error: connection reset by peer"},
+    {"is_error": True, "result": "connection error while streaming"},
+    {"is_error": True, "result": "timeout while waiting for response"},
+    {"is_error": True,
+     "result": "the stream died mid-response unexpectedly"},
+])
+def test_transport_envelopes_match(leerie, envelope):
+    assert leerie._is_transient_transport_failure(envelope) is True
+
+
+@pytest.mark.parametrize("envelope", [
+    # a successful, schema-valid envelope never matches, whatever its text
+    {"is_error": False,
+     "result": "I closed the connection and reset the mid-response buffer"},
+    # synthetic no-result envelope is exempt (raw stderr in `result`)
+    {"is_error": True, "_leerie_synthetic": "no_result_event",
+     "result": "claude -p produced no result event "
+               "(stderr: connection closed mid-response)"},
+    # 401/429/529 belong to _is_auth_or_quota_failure, not here
+    {"is_error": True, "api_error_status": 401, "terminal_reason": "api_error",
+     "result": "connection closed"},
+    {"is_error": True, "api_error_status": 429, "terminal_reason": "api_error"},
+    {"is_error": True, "api_error_status": 529, "terminal_reason": "api_error"},
+    # a genuine schema failure — no transport marker, no api_error reason
+    {"is_error": True, "terminal_reason": "completed",
+     "result": "output did not match schema"},
+    # is_error false but text mentions a marker (the exact false-positive
+    # the is_error gate exists to prevent)
+    {"is_error": False, "result": "connection closed mid-response"},
+    # empty / non-string result, no api_error terminal_reason
+    {"is_error": True, "result": None},
+])
+def test_non_transport_envelopes_do_not_match(leerie, envelope):
+    assert leerie._is_transient_transport_failure(envelope) is False
+
+
+def test_transport_and_auth_quota_partition_cleanly(leerie):
+    """A drop envelope is transport-not-auth; a 401 is auth-not-transport;
+    a 529 is auth-not-transport. The two classifiers never both fire."""
+    assert leerie._is_transient_transport_failure(_DROP) is True
+    assert leerie._is_auth_or_quota_failure(_DROP) is False
+    for status in (401, 429, 529):
+        env = {"is_error": True, "api_error_status": status,
+               "terminal_reason": "api_error"}
+        assert leerie._is_auth_or_quota_failure(env) is True
+        assert leerie._is_transient_transport_failure(env) is False
+
+
+def test_marker_set_is_narrow(leerie):
+    """A generic 'error' must not match — only transport-level markers."""
+    assert leerie._is_transient_transport_failure(
+        {"is_error": True, "result": "some unrelated error occurred"}) is False
+
+
+# ---------------------------------------------------------------------------
+# routing  (template: tests/test_terminal_auth_routing.py)
+# ---------------------------------------------------------------------------
+
+class _FakeState:
+    """Minimal State stand-in for claude_p (see test_no_result_event_retry.py)."""
+
+    def __init__(self, tmp_path):
+        self.path = tmp_path / "runs" / "r1" / "state.json"
+        self.run_dir = self.path.parent
+        self.run_dir.mkdir(parents=True, exist_ok=True)
+        self.run_id = "r1"
+        self.data = {"verbosity": "quiet"}
+        self.bumped = 0
+
+    def bump_workers(self, *a, **k):
+        self.bumped += 1
+
+    def add_telemetry(self, *a, **k):
+        pass
+
+
+def _call_claude_p(leerie, monkeypatch, envelopes, tmp_path, caps=None):
+    """Drive claude_p with a stubbed _invoke yielding `envelopes` in order.
+
+    Returns (result, exc, elapsed_seconds, invoke_call_count)."""
+    seq = list(envelopes)
+    calls = {"n": 0}
+
+    async def fake_invoke(cmd, cwd, timeout, sid, leerie_dir, verbosity,
+                          **kwargs):
+        calls["n"] += 1
+        return seq.pop(0) if seq else envelopes[-1]
+
+    monkeypatch.setattr(leerie, "_invoke", fake_invoke)
+    monkeypatch.setattr(leerie, "_capture_call", lambda *a, **k: None)
+
+    async def run():
+        return await leerie.claude_p(
+            "do the task",
+            "you are a fit judge",
+            schema_key="fit_judge",
+            cwd="/work",
+            allowed_tools="Read",
+            max_turns=60,
+            autonomous=False,
+            caps=caps or dict(leerie.DEFAULT_CAPS),
+            st=_FakeState(tmp_path),
+            model="opus",
+            sid="fit-judge-transport-routing",
+        )
+
+    start = time.monotonic()
+    try:
+        result = asyncio.run(run())
+        exc = None
+    except BaseException as e:  # noqa: BLE001
+        result = None
+        exc = e
+    elapsed = time.monotonic() - start
+    return result, exc, elapsed, calls["n"]
+
+
+def test_drop_enters_backoff_then_recovers(leerie, monkeypatch, tmp_path):
+    """A transport drop followed by a valid envelope: claude_p must retry
+    (more than one _invoke) and return the recovered structured output.
+
+    tenacity does not sleep before its first iteration, so a drop→valid
+    sequence exits the loop before any wait — the test stays sub-second
+    while still proving the loop was entered (invoke count > 1, and the
+    result is the recovered one)."""
+    result, exc, elapsed, n = _call_claude_p(
+        leerie, monkeypatch, [_DROP, _VALID], tmp_path)
+    assert exc is None, f"unexpected exception: {exc!r}"
+    assert result == _VALID["structured_output"]
+    assert n > 1, "claude_p did not retry the transport drop"
+    assert elapsed < 5.0, (
+        f"took {elapsed:.3f}s — a drop→recover sequence must not sleep")
+
+
+def test_drop_does_not_fail_as_schema_error(leerie, monkeypatch, tmp_path):
+    """The whole point: a drop must NOT reach the generic is_error arm and
+    raise 'worker failed schema-valid output twice'. Two drops then a valid
+    recovery proves the backoff loop (not the 2-attempt schema loop) owns
+    it — the 2-attempt schema loop would have raised after the 2nd drop."""
+    result, exc, _, n = _call_claude_p(
+        leerie, monkeypatch, [_DROP, _DROP, _VALID], tmp_path)
+    assert exc is None, f"drop was treated as a terminal schema error: {exc!r}"
+    assert result == _VALID["structured_output"]
+    assert n >= 3
+
+
+def test_drop_budget_exhaustion_raises_transport_worker_error(
+        leerie, monkeypatch, tmp_path):
+    """When the drop persists past the backoff budget, claude_p raises a
+    WorkerError that names the transport disconnect (not a subscription cap)
+    and points at --resume. Uses auth_retry_max_sec=1 to exhaust after one
+    ~15s sleep (same convention as test_terminal_auth_routing.py)."""
+    tiny_caps = dict(leerie.DEFAULT_CAPS)
+    tiny_caps["auth_retry_max_sec"] = 1
+    result, exc, _, n = _call_claude_p(
+        leerie, monkeypatch, [_DROP] * 4, tmp_path, caps=tiny_caps)
+    assert result is None
+    assert isinstance(exc, leerie.WorkerError)
+    assert not isinstance(exc, leerie.TerminalAuthFailure)
+    msg = str(exc).lower()
+    assert "connection" in msg or "transport" in msg, (
+        f"exhaustion message must name the transport cause, got: {exc!r}")
+    assert "subscription" not in msg, (
+        f"a transport drop must not be labeled a subscription cap: {exc!r}")
+    assert "--resume" in str(exc)
+    assert n > 1, "must have retried before exhausting"
+
+
+# ---------------------------------------------------------------------------
+# source-coupling
+# ---------------------------------------------------------------------------
+
+def test_transport_checked_after_terminal_auth_in_claude_p(leerie):
+    """Terminal auth (expired session) must be checked before the backoff
+    branch, so an expired session is never mistaken for a transport blip."""
+    import inspect
+    src = inspect.getsource(leerie.claude_p)
+    terminal_idx = src.index("_is_terminal_auth_failure(envelope)")
+    backoff_idx = src.index("_needs_backoff(envelope)")
+    assert terminal_idx < backoff_idx
+
+
+def test_needs_backoff_ors_both_classifiers(leerie):
+    """The combined predicate must consult BOTH the auth/quota and the
+    transport classifier — the fix is inert if it drops either."""
+    import inspect
+    src = inspect.getsource(leerie.claude_p)
+    # locate the nested _needs_backoff definition body
+    start = src.index("def _needs_backoff(")
+    body = src[start:start + 300]
+    assert "_is_auth_or_quota_failure" in body
+    assert "_is_transient_transport_failure" in body


### PR DESCRIPTION
## Problem

A mid-stream **transport disconnect** — the network connection carrying a worker's streaming response drops mid-answer — was misclassified as a schema error and failed the subtask. The `claude -p` result envelope for this case is:

```
is_error: true, subtype: "success", terminal_reason: "api_error",
api_error_status: null,
result: "API Error: Connection closed mid-response. The response above may be incomplete."
```

In `claude_p`'s classification chain, this envelope matches neither `_is_terminal_auth_failure` nor `_is_auth_or_quota_failure` (no numeric 401/429/529 status, no auth text markers), so it fell to the generic `is_error` arm: retried **once immediately** against the same bad network window with a nonsensical "conform to the schema" nudge, then raised `WorkerError("worker failed schema-valid output twice")`. That became an `empty_handoff`, burned the single `failed_retries` subtask retry, and terminated. Two real runs (barnacle `feat-005`, cruiselines `config-002`) died this way today.

## Evidence

A run-history scan (9,020 worker logs) shows the drop is a transient in the same family as the 529 overload leerie already backs off:

- **56 sids** hit the drop *without* also exhausting the turn cap → **83% recovered** on a later attempt, **73% on the very next one**.
- A third of drops fire at **≤3 turns** — before any context accumulates — the fingerprint of a network/gateway transient, not context exhaustion.
- The 2 sids that also hit `max_turns` (feat-005, config-002) recovered 0% — an oversized subtask that *also* drops is a decomposition problem backoff can't fix.

Upstream corroboration: this is a known Claude Code bug whose own remedy is retry-with-backoff; the `claude -p` text-preservation fix landed in **CLI v2.1.219**.

## Changes (three-layer rule: DESIGN → IMPLEMENTATION → code)

1. **Transport-drop backoff.** `_is_transient_transport_failure` classifies the drop on the same `is_error`-gated, `_leerie_synthetic`-exempt discipline as the two auth classifiers. `claude_p` routes it through the **same** tenacity backoff loop as auth/quota (combined `_needs_backoff` predicate), checked after terminal-auth and before the generic `is_error` arm. Budget exhaustion raises a transport-named `WorkerError` pointing at `--resume`. Reuses `auth_retry_max_sec` (no new cap).

2. **Oversized-file peel** (`_peel_oversized_file`). A small multi-file subtask (a dense file **+** its test file) with exactly one file over `subfile_split_max_span` is peeled so the dense file reaches `_subfile_split`'s intra-file tiling — closing the gap where the `len(files)==1` guard skipped the dominant impl+test shape (**382 such subtasks in history**, including the feat-005 monolith that motivated the P1 sub-file work but never engaged it). Deterministic; reuses `_migration_child` edge discipline.

3. **CLI pin.** `Dockerfile` pins `@anthropic-ai/claude-code@>=2.1.219` for the CLI-side in-session fix (runtime floor deliberately left at 2.1.22 — a resilience nicety must not hard-die a valid older host CLI).

## Tests

- New `tests/test_transient_transport_retry.py`: classifier corpus (positive/negative, including the exact measured envelope) + stubbed-`_invoke` routing (enters backoff, recovers, exhaustion raises transport error) + `ast`/`inspect` source-coupling.
- New peel tests in `tests/test_recursive_decompose.py`: peel+tile, no-oversized untouched, both-oversized fall-through, single-file declines.
- Updated two source-coupling tests that anchored on the now-`_needs_backoff` call site.

Full suite: **4334 passed, 62 skipped, 0 failed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)