### PR TITLE
chore(release): 0.9.81

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "leerie",
       "source": ".",
-      "version": "0.9.80",
+      "version": "0.9.81",
       "description": "Deterministic, headless task orchestrator for Claude Code. Classifies a task, decomposes it into dependency-ordered waves, and executes each subtask in an isolated git worktree under an evidence-gated implement/validate loop. Runs entirely on the Claude Code CLI/subscription via `claude -p` workers."
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "leerie",
   "displayName": "Leerie",
-  "version": "0.9.80",
+  "version": "0.9.81",
   "description": "Deterministic, headless task orchestrator for Claude Code. Classifies a task, decomposes it into granular subtasks, schedules them into dependency-ordered waves, and executes each in an isolated git worktree under an evidence-gated implement/validate loop. Runs entirely on the Claude Code CLI/subscription via `claude -p` workers.",
   "author": { "name": "Andres Restrepo", "email": "andres@enricai.com", "url": "https://enricai.com" },
   "license": "MIT",


### PR DESCRIPTION
Version bump **0.9.80 → 0.9.81** in both plugin manifests. On squash-merge to `main`, `release.yml` auto-creates the `v0.9.81` tag + GitHub Release (the `chore(release): X.Y.Z (#N)` subject matches its parse regex).

Ships since 0.9.80:
- **#106** — transient "Connection closed mid-response" transport-drop backoff (routes mid-stream connection drops into the existing tenacity backoff instead of failing them as schema errors) + oversized-file peel (a dense file bundled with its test file now sub-file-splits) + CLI pin `@anthropic-ai/claude-code@>=2.1.219`.
- **#107** — peel regression tests (id-prefix, `schedule()`/`validate_plan` end-to-end, grandchild dep-remap) + `api_error:transport` `failure_kind` telemetry sub-tag.
- **#108** — list `api_error:transport` in the calls.ndjson `failure_kind` schema enumeration.

**Manifest-only** (+2/−2). Both manifests agree at 0.9.81; `leerie --version` prints `leerie 0.9.81`; `test_version_flag.py` + `test_release_workflow.py` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)