### PR TITLE
fix(install): working rootless runtime + auto-install claude on Debian/Ubuntu

### DIFF
--- a/docs/IMPLEMENTATION.md
+++ b/docs/IMPLEMENTATION.md
@@ -26,7 +26,7 @@ inside the container (DESIGN §6 / §0.5 below).
 |------|---------|
 | `.claude-plugin/marketplace.json` | Single-plugin marketplace manifest. Makes the repo itself discoverable via `/plugin marketplace add enricai/leerie` from inside Claude Code. Points at `.` so Claude Code reads the sibling `.claude-plugin/plugin.json`. |
 | `.claude-plugin/plugin.json` | Existing plugin manifest (commands, skills, metadata). The `version` field is the single source of truth for `leerie --version`. |
-| `scripts/install.sh` | The `curl \| bash` shell installer. Preflight (git/claude/curl) → runtime preflight (colima on macOS, nerdctl+containerd on Linux) → clone → symlink → verify. Self-contained bash; deps: `bash`, `curl`, `git`. |
+| `scripts/install.sh` | The `curl \| bash` shell installer. Preflight (git/curl checked; `claude` auto-installed via the official native installer if missing, opt-out `--no-claude-install`) → runtime install (colima on macOS; rootless containerd stack on Debian/Ubuntu — Fedora/Arch fall back to a docs hint) → clone → symlink → verify. Self-contained bash; deps: `bash`, `curl`, `git`. |
 | `leerie` (launcher) | Portable bash. Symlink-walks to its own location, runs the per-OS runtime preflight, builds the leerie image once per version, and execs `nerdctl run` with TTY flags adapted via `[ -t 0 ]` (see §0.5). Passes `--cgroupns=host` so the container shares the host VM's cgroup namespace — required for cgroup v2 process enrollment (nerdctl's default `--cgroupns=private` + `nsdelegate` blocks non-root `cgroup.procs` writes; see DESIGN §6 *Memory containment*). Fast paths for `--version` and `config` skip container startup. Per-run auth/config is staged into a fresh `mktemp -d "$HOME/.cache/leerie/cfg-XXXXXX"` (`$STAGE`); a `rm -rf "$STAGE"` EXIT trap is registered **immediately after the mktemp** (before the ~250-line stage-assembly block, which contains an `exit 1`) so an early exit can't leak the dir, and a best-effort startup sweep (`find "$HOME/.cache/leerie" -maxdepth 1 -type d -name 'cfg-*' -mtime +1 -exec rm -rf`) reclaims dirs leaked by trap-bypassing exits (SIGKILL / OOM / `nerdctl kill`). Because `-mtime` tests the cfg dir's own top-level mtime — which freezes at staging-completion (the running container's writes into `$STAGE/.claude/*` do NOT bump it) — a background keepalive (`while :; do touch "$STAGE"; sleep 3600; done &`, killed by the same EXIT trap) freshens the live dir hourly so a genuinely long-running run (e.g. one auto-resuming across rate-limit backoffs) is never mistaken for stale and deleted by a concurrent launch's sweep. |
 | `Dockerfile` | Image recipe (Debian 13 + Node + pnpm + claude CLI + baked orchestrator source). Built locally on first run, tagged `leerie:<VERSION>`. |
 | `scripts/container-entry.sh` | Container PID 1. Runs as **root** (rootful runtimes) or the **rootlesskit-mapped host UID** (rootless containerd — see DESIGN §6 *Rootless exception*); the Dockerfile intentionally omits `USER leerie` so the entrypoint can set up cgroup containment before privilege drop. It resolves `CGROUP_ROOT` (the literal `/sys/fs/cgroup`, or — rootless — the systemd-delegated `user.slice/user-$HOST_UID.slice/user@$HOST_UID.service` subtree), creates `$CGROUP_ROOT/leerie.slice` and enables the memory+pids controllers (needed for the aggregate `memory.max` cap), then — the load-bearing step — launches the **cgroup broker** (`LEERIE_CGROUP_V2_ROOT="$CGROUP_ROOT" python3 /opt/leerie-image/scripts/cgroup-broker.py &`) at the same identity, before privilege drop, because worker cgroup enrollment and limit-setting cannot be done by the dropped-privilege orchestrator (see `scripts/cgroup-broker.py` below and DESIGN §6). `ulimit -c 0`, the cgroup slice setup, the broker launch, `cd /work`, `chown leerie: /work`, `chown leerie: /home/leerie` + `chown -R leerie: /home/leerie/.local /home/leerie/.cache /home/leerie/.gnupg`, and `chown -R leerie: /tmp/.cache` + `chmod -R a+rwX /tmp/.cache` + `chmod 1777 /tmp/.cache` all run at this pre-drop identity (skipped in rootless mode, along with the `runuser` drop itself). Under rootless containerd's `unshare --user --map-user=<leerie-uid>` privilege drop, only outer UID 0 remaps to inner leerie — a directory chowned to leerie's own (non-zero) UID appears owned by nobody to the remapped process, traversable but not writable. The Dockerfile leaves `/home/leerie`, `.local`, `.cache`, and `.gnupg` root-owned at build time for exactly this reason (outer UID 0 is the one value that does remap correctly, the same mechanism that makes bind-mounted host dirs writable with no chown at all); the rootful path needs literal `leerie` ownership instead (a real `runuser -u leerie` UID switch, no remap involved), which is what the runtime chown here restores. `/tmp/.cache` gets the stronger `chmod 1777` treatment rather than a plain chown-back because arbitrary tools create their own subdirs under `XDG_CACHE_HOME` there at runtime (corepack, `tree-sitter-language-pack`) — a fixed set of pre-created dirs like `.local`/`.cache`/`.gnupg` doesn't need that, a chown-back suffices. The final exec drops to leerie via `runuser -u leerie -- env HOME=/home/leerie USER=leerie LOGNAME=leerie ...`: if invoked with no argv (remote/Fly path — the launcher exec's the orchestrator via `flyctl ssh console -C "python3 -"` separately, which also drops via `Popen(user="leerie")`), the runuser exec wraps `sleep infinity` to keep the namespace alive; otherwise it wraps `python3 /opt/leerie-image/orchestrator/leerie.py "$@"` (local path — nerdctl always passes argv). The explicit `env` form is used instead of `runuser --login` because the login form would chdir to `/home/leerie` and override the `cd /work` invariant. |
@@ -153,14 +153,22 @@ curl -fsSL https://raw.githubusercontent.com/enricai/leerie/main/scripts/install
 
 The script:
 
-1. **Preflight**: verifies `git`, `claude`, and `curl` are on `PATH`.
-   Missing deps print a platform-specific remediation hint and the
-   script exits non-zero.
-2. **Runtime preflight**: per `uname -s`. On macOS: verifies `colima`
-   is installed and the VM is running. On Linux: verifies `nerdctl`
-   is installed and reaches containerd. Prints copy-pasteable install
-   hints on failure (`brew install colima` / distro package commands).
-   Does NOT auto-install brew/apt packages — that's the user's choice.
+1. **Preflight**: verifies `git` and `curl` are on `PATH` (missing → hint +
+   non-zero exit). `claude` is **auto-installed** if missing, via Anthropic's
+   official native installer (`curl -fsSL https://claude.ai/install.sh | bash`
+   — a self-contained binary in `~/.local/bin`, no Node/npm), then re-verified;
+   opt out with `--no-claude-install` / `LEERIE_NO_CLAUDE_INSTALL=1` (falls back
+   to a hint + non-zero exit). Leerie shells out to `claude -p` for every unit
+   of LLM work, so a missing `claude` is a hard stop.
+2. **Runtime install**: per `uname -s`. On macOS: installs Colima via brew (if
+   missing) and starts the VM. On **Debian/Ubuntu**: installs and starts the
+   full **rootless** containerd stack — containerd + rootlesskit/slirp4netns/
+   uidmap (apt), pinned nerdctl, CNI plugins, BuildKit, the rootless setuptool +
+   BuildKit containerd-worker — then verifies reachability (`nerdctl info`); it
+   never reports success on an unreachable runtime. On **Fedora/RHEL and Arch**,
+   auto-install is not wired yet — prints a hint pointing at `docs/INSTALL.md`
+   "Rootless mode" and exits non-zero. Opt out of runtime auto-install entirely
+   with `--no-runtime-install` / `LEERIE_NO_RUNTIME_INSTALL=1`.
 3. **Clones** `enricai/leerie` to `$LEERIE_HOME` (default `~/.leerie`).
    `git clone --depth 1` for fresh installs; `git pull --ff-only` for
    upgrades.
@@ -171,8 +179,10 @@ The script:
 6. **Verifies** by invoking `leerie --version` (the launcher's fast path
    answers without spinning up a container — see below).
 
-Supports `--dry-run` (prints actions without executing) and
-`--prefix DIR` (overrides `LEERIE_HOME`).
+Supports `--dry-run` (prints actions without executing), `--prefix DIR`
+(overrides `LEERIE_HOME`), `--no-runtime-install`
+(`LEERIE_NO_RUNTIME_INSTALL=1`), and `--no-claude-install`
+(`LEERIE_NO_CLAUDE_INSTALL=1`).
 
 ### `--version`
 
@@ -268,15 +278,24 @@ which is the abnormal-exit cleanup guarantee.
 | OS | Container engine | CLI | VM? |
 |----|------------------|-----|-----|
 | macOS (arm64 or x86_64) | containerd inside a Colima-managed Linux VM | `nerdctl` host-side shim (`colima nerdctl install`) | Yes — managed by Colima |
-| Linux (any distro with containerd) | containerd native | `nerdctl` from distro or upstream | No |
+| Linux (Debian/Ubuntu) | rootless containerd (native) | `nerdctl` from upstream (+ CNI/BuildKit/RootlessKit) | No |
+| Linux (Fedora/RHEL, Arch) | rootless containerd (manual) | `nerdctl` — set up by hand per `docs/INSTALL.md` | No |
 
 The launcher detects `uname -s` and runs the right preflight. On macOS:
 require `colima` on `PATH`, check `colima status`, auto-install the
 `nerdctl` shim if missing (via `colima nerdctl install`), then check
-`nerdctl info` reaches the runtime. On Linux: require `nerdctl` on
-`PATH` and `nerdctl info` succeeds. Both paths print a copy-pasteable
-install hint on failure and exit non-zero — leerie does not invoke
-`brew`, `apt`, `dnf`, or `pacman` itself.
+`nerdctl info` reaches the runtime. On Linux: if `nerdctl` is missing and
+runtime auto-install is not opted out, `runtime_install_linux`
+(`scripts/runtime-install.sh`) stands up the full rootless stack on
+**Debian/Ubuntu** — invoking `apt-get` for containerd + the rootless
+prerequisites, downloading nerdctl/CNI/BuildKit, and running the rootless
+setuptool — then verifies `nerdctl info` succeeds. **Fedora/RHEL and Arch**
+are not auto-installed yet: the launcher prints a copy-pasteable hint
+(`docs/INSTALL.md` "Rootless mode") and exits non-zero. On macOS leerie does
+not invoke `brew` for the runtime beyond Colima, and on non-Debian Linux it
+does not invoke `dnf`/`pacman` — those remain the user's choice. Pass
+`--no-runtime-install` (`LEERIE_NO_RUNTIME_INSTALL=1`) to skip the Debian/Ubuntu
+auto-install and fall back to the hint.
 
 `brew install nerdctl` does NOT work on macOS — the Homebrew formula
 has `Requires: Linux` because the nerdctl binary talks directly to a
@@ -1089,11 +1108,11 @@ leerie/
 │   ├── cgroup-broker.py           cgroup broker, runs at the slice-owning identity (create/enroll/destroy over a Unix socket; v1+v2); the dropped-privilege orchestrator drives it
 │   ├── cleanup.sh                 remove worktrees / branches (default: scoped to one run)
 │   ├── container-entry.sh         container PID 1 (root rootful / mapped-UID rootless): create leerie.slice + launch cgroup broker + cd /work + drop to leerie via runuser (rootful)
-│   ├── install.sh                 one-command installer (curl | bash); preflight git/claude/curl +
-│   │                               runtime preflight (colima / nerdctl) + clones + symlinks
+│   ├── install.sh                 one-command installer (curl | bash); preflight git/curl + auto-install
+│   │                               claude + runtime install (colima / rootless containerd) + clones + symlinks
 │   ├── runtime-install.sh         per-OS auto-install of the container runtime (Colima on macOS;
-│   │                              containerd + nerdctl on Debian / Fedora / Arch). Sourced by
-│   │                              install.sh and the launcher.
+│   │                              rootless containerd stack on Debian/Ubuntu — Fedora/Arch: docs hint).
+│   │                              Sourced by install.sh and the launcher.
 │   └── remote/
 │       ├── _log.sh                shared remote_log() helper (timestamped, repo-tagged
 │       │                          stderr) sourced by every other scripts/remote/*.sh file

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -158,15 +158,25 @@ To allow paths outside the default scope: edit
 
 ## Linux
 
-Containerd and nerdctl run natively — no VM needed. The one-line
-installer **auto-installs and starts** the runtime per distro (Debian/
-Ubuntu via `apt-get`, Fedora/RHEL via `dnf`, Arch via `pacman`; nerdctl
-binary pinned to v2.3.1 from upstream). Unknown distros fall back to a
-hint and exit 1 — install manually then re-run with
-`--no-runtime-install`.
+Containerd runs natively — no VM needed. Leerie runs it **rootless**
+(DESIGN §6 *Rootless exception*): the runtime, workers, and cgroup
+containment all live under your user's systemd slice, no root daemon
+required.
+
+On **Debian/Ubuntu**, the one-line installer **auto-installs and starts the
+full rootless stack** — containerd, RootlessKit, slirp4netns, uidmap, the
+pinned nerdctl binary (v2.3.1), CNI plugins, BuildKit, the rootless
+setuptool + BuildKit containerd-worker — and then verifies the runtime is
+reachable (`nerdctl info`). It refuses to report success on a runtime it
+can't reach.
+
+On **Fedora/RHEL and Arch**, auto-install is not wired yet — the installer
+prints a hint pointing here and exits 1. Follow the manual **Rootless mode**
+steps below (they're the same shape, with your distro's package manager),
+then re-run the installer with `--no-runtime-install`.
 
 ```bash
-# One-line installer — auto-installs containerd + nerdctl, then installs leerie.
+# One-line installer — Debian/Ubuntu: auto-installs the rootless stack, then leerie.
 curl -fsSL https://raw.githubusercontent.com/enricai/leerie/main/scripts/install.sh | bash
 ```
 
@@ -178,65 +188,107 @@ commands), then pass `--no-runtime-install`:
 curl -fsSL https://raw.githubusercontent.com/enricai/leerie/main/scripts/install.sh | bash -s -- --no-runtime-install
 ```
 
-### Debian / Ubuntu
+### Debian / Ubuntu (manual)
 
-```bash
-sudo apt-get install -y containerd
-# nerdctl: install the pinned static binary from upstream. Arch is detected
-# so the same line works on x86_64 (amd64) and arm64 (Asahi, Graviton, Pi).
-NERDCTL_VERSION=2.3.1
-ARCH="$(dpkg --print-architecture 2>/dev/null || uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')"
-curl -L "https://github.com/containerd/nerdctl/releases/download/v${NERDCTL_VERSION}/nerdctl-${NERDCTL_VERSION}-linux-${ARCH}.tar.gz" \
-  | sudo tar -C /usr/local/bin -xz nerdctl
-sudo systemctl enable --now containerd
+On Debian/Ubuntu the one-line installer above does all of this for you.
+The manual steps are the **Rootless mode** sequence below — a bare
+`apt-get install containerd` alone is **not** enough: an unprivileged
+`nerdctl` can't reach the rootful socket, and you still need CNI plugins
+(for `nerdctl run`) and BuildKit (for leerie's image build). Follow
+**Rootless mode** directly.
 
-curl -fsSL https://raw.githubusercontent.com/enricai/leerie/main/scripts/install.sh | bash
-```
+### Fedora / RHEL and Arch
 
-### Fedora / RHEL
+Auto-install is Debian/Ubuntu-only for now, so set the rootless stack up by
+hand using the **Rootless mode** sequence below with your package manager in
+place of `apt-get`:
 
-```bash
-sudo dnf install -y containerd
-# nerdctl: install the pinned static binary from upstream (arch-detected).
-NERDCTL_VERSION=2.3.1
-ARCH="$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')"
-curl -L "https://github.com/containerd/nerdctl/releases/download/v${NERDCTL_VERSION}/nerdctl-${NERDCTL_VERSION}-linux-${ARCH}.tar.gz" \
-  | sudo tar -C /usr/local/bin -xz nerdctl
-sudo systemctl enable --now containerd
+- Fedora/RHEL: `sudo dnf install -y containerd rootlesskit slirp4netns shadow-utils`
+- Arch: `sudo pacman -S containerd nerdctl rootlesskit slirp4netns buildkit cni-plugins`
 
-curl -fsSL https://raw.githubusercontent.com/enricai/leerie/main/scripts/install.sh | bash
-```
-
-### Arch
-
-```bash
-sudo pacman -S containerd nerdctl rootlesskit buildkit cni-plugins fuse-overlayfs
-sudo systemctl enable --now containerd
-
-curl -fsSL https://raw.githubusercontent.com/enricai/leerie/main/scripts/install.sh | bash
-```
+Then re-run the installer with `--no-runtime-install`.
 
 ### Rootless mode (recommended)
 
 Running containerd as root is unnecessary for leerie — it doesn't need
-privileged operations. To set up rootless containerd:
+privileged operations. The full sequence below is exactly what the
+Debian/Ubuntu auto-install runs; do it by hand on other distros (swap the
+`apt-get` line for your package manager, per the section above). Versions
+are pinned; bump them together with `scripts/runtime-install.sh`.
+
+**1. Runtime + rootless prerequisites.** RootlessKit needs
+`newuidmap`/`newgidmap` (from `uidmap`), a port driver (`slirp4netns`), and
+a systemd user session (`dbus-user-session`):
+
+```bash
+sudo apt-get update
+sudo apt-get install -y containerd rootlesskit slirp4netns uidmap dbus-user-session
+```
+
+**2. nerdctl** (also ships `containerd-rootless-setuptool.sh` +
+`containerd-rootless.sh`, which step 5 needs on PATH):
+
+```bash
+NERDCTL_VERSION=2.3.1
+ARCH="$(dpkg --print-architecture 2>/dev/null || uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')"
+curl -L "https://github.com/containerd/nerdctl/releases/download/v${NERDCTL_VERSION}/nerdctl-${NERDCTL_VERSION}-linux-${ARCH}.tar.gz" \
+  | sudo tar -C /usr/local/bin -xz
+```
+
+**3. CNI plugins → `/opt/cni/bin`** (the `CNI_PATH` nerdctl looks in; without
+them `nerdctl run` fails with `needs CNI plugin "bridge" to be installed in
+CNI_PATH`):
+
+```bash
+CNI_VERSION=v1.9.1
+curl -L "https://github.com/containernetworking/plugins/releases/download/${CNI_VERSION}/cni-plugins-linux-${ARCH}-${CNI_VERSION}.tgz" \
+  | sudo tar -C /opt/cni/bin -xz   # sudo mkdir -p /opt/cni/bin first if absent
+```
+
+**4. BuildKit → `~/.local`** (puts `buildctl`/`buildkitd` on your PATH). This
+**must** precede step 5: `install-buildkit-containerd` exits with
+`` `buildctl` needs to be installed and `buildkitd` needs to be running ``
+unless `buildkitd` is already on PATH:
+
+```bash
+BUILDKIT_VERSION=v0.31.2
+curl -L "https://github.com/moby/buildkit/releases/download/${BUILDKIT_VERSION}/buildkit-${BUILDKIT_VERSION}.linux-${ARCH}.tar.gz" \
+  | tar -C "$HOME/.local" -xz
+command -v buildkitd   # must print a path before continuing
+```
+
+**5. Subuid/subgid** (RootlessKit prerequisite; idempotent — skip if
+`grep "^$(id -un):" /etc/subuid` already returns a line):
+
+```bash
+sudo usermod --add-subuids 100000-165535 --add-subgids 100000-165535 "$(id -un)"
+```
+
+**6. Rootless containerd + BuildKit worker** (run as your user, **not** sudo).
+`install-buildkit-containerd` is the containerd-worker variant leerie needs —
+its `ensure_base_in_buildkit_ns` copies the base image into the `buildkit`
+containerd namespace, which the OCI-worker variant can't read:
 
 ```bash
 containerd-rootless-setuptool.sh install
+CONTAINERD_NAMESPACE=default containerd-rootless-setuptool.sh install-buildkit-containerd
+sudo loginctl enable-linger "$(id -un)"   # survive logout
 ```
 
-After that, the user's default nerdctl context points at the rootless
-socket (`unix:///run/user/$UID/containerd/containerd.sock`). Leerie's
-launcher uses whatever context nerdctl resolves to, so once rootless is
-set up no extra flags are needed.
+After this, nerdctl's default context points at the rootless socket
+(`unix:///run/user/$UID/containerd/containerd.sock`); leerie's launcher uses
+whatever context nerdctl resolves to, so no extra flags are needed.
 
-Also install BuildKit's containerd-worker variant (needed for repos
-with a custom `.leerie/Dockerfile` or `setup_packages`; see
-`IMPLEMENTATION.md`'s `ensure_base_in_buildkit_ns`):
+**7. Verify:**
 
 ```bash
-containerd-rootless-setuptool.sh install-buildkit-containerd
+nerdctl run --rm hello-world
+# rootless buildkitd listens on its own socket, so point buildctl at it:
+buildctl --addr unix:///run/user/$(id -u)/buildkit-default/buildkitd.sock debug workers
 ```
+
+Both should succeed (a "Hello from Docker!" and a worker row). Then re-run the
+installer with `--no-runtime-install`.
 
 ## Verifying the runtime
 
@@ -502,6 +554,35 @@ manual hint and exits 1 if the runtime is missing. Useful for CI,
 dotfiles managers, or any environment where package installs are
 tracked elsewhere.
 
+**Skip auto-install of the claude CLI** — pass `--no-claude-install` to
+`install.sh`, or set `LEERIE_NO_CLAUDE_INSTALL=1`. By default a missing
+`claude` is installed via Anthropic's official native installer
+(`curl -fsSL https://claude.ai/install.sh | bash` — a self-contained
+binary in `~/.local/bin`, no Node/npm). With the opt-out set, a missing
+`claude` falls back to a hint and exits 1. Leerie shells out to
+`claude -p` for every unit of LLM work, so a missing `claude` is a hard
+stop either way.
+
+**Linux: `` `buildctl` needs to be installed and `buildkitd` needs to be
+running ``** (at `leerie --help` / image build) — the rootless BuildKit
+worker isn't set up. Install the BuildKit binary onto your PATH (step 4 of
+**Rootless mode** above), then
+`CONTAINERD_NAMESPACE=default containerd-rootless-setuptool.sh
+install-buildkit-containerd`. Note the setuptool refuses (exit 1) unless
+`buildkitd` is already on PATH, so the binary install must come first.
+
+**Linux: `needs CNI plugin "bridge" to be installed in CNI_PATH
+("/opt/cni/bin")`** (at `nerdctl run`) — CNI plugins aren't installed. The
+rootless setuptool does not install them; add them explicitly (step 3 of
+**Rootless mode** above).
+
+**Linux: `rootlesskit: not found` / `RootlessKit failed`** (at
+`containerd-rootless-setuptool.sh install`) — a rootless prerequisite is
+missing. Install `rootlesskit slirp4netns uidmap dbus-user-session` (step 1),
+and if `RootlessKit failed` persists, ensure your user has subuid/subgid
+ranges (step 5: `sudo usermod --add-subuids 100000-165535 --add-subgids
+100000-165535 "$(id -un)"`).
+
 **"Colima VM is not running"** (macOS) — start it:
 `colima start --runtime containerd --mount-type virtiofs --cpu 4 --memory 8`
 (pick `--cpu` / `--memory` matching half your host CPU/RAM; see the
@@ -517,7 +598,12 @@ with containerd: `colima stop && colima start --runtime containerd
 sizing through the restart; the bare command would re-default to
 2/2). The swap-provision YAML block in `~/.colima/default/colima.yaml`
 re-applies on every boot, so swap is preserved through this restart.
-On Linux, check `systemctl status containerd`.
+On Linux (rootless), check the *user* service —
+`systemctl --user status containerd` — not the system one, and make sure
+`~/.local/bin` and `/usr/local/bin` are on your PATH so `nerdctl` and the
+rootless helpers resolve. A bare `sudo apt-get install containerd` alone
+leaves a *rootful* daemon an unprivileged `nerdctl` can't reach; follow the
+**Rootless mode** steps above instead.
 
 **`FATA[NNNN] exit status 255` with no orchestrator diagnostic** — the
 leerie run died because Colima's host-side `nerdctl` / `lima-guestagent`

--- a/leerie
+++ b/leerie
@@ -3579,15 +3579,21 @@ EOF
     Linux)
       cat >&2 <<'EOF'
 
-Install on Linux:
-  # Debian/Ubuntu:
-  sudo apt-get install -y containerd
-  # then install nerdctl from upstream:
-  #   https://github.com/containerd/nerdctl/releases
-  # Or distro packages where available (Arch: pacman -S nerdctl).
-  sudo systemctl enable --now containerd
+Install on Linux (rootless containerd):
+  # Debian/Ubuntu: leerie auto-installs the full rootless stack on first run
+  # (containerd + rootlesskit/slirp4netns/uidmap, nerdctl, CNI plugins,
+  #  BuildKit, the rootless setuptool). Just re-run leerie — or, to skip
+  #  auto-install, follow docs/INSTALL.md "Rootless mode" then pass
+  #  --no-runtime-install.
+  #
+  # A bare `apt-get install containerd` is NOT enough: an unprivileged nerdctl
+  # can't reach the rootful socket, and you still need CNI plugins (for
+  # `nerdctl run`) and BuildKit (for the image build).
+  #
+  # Fedora/RHEL and Arch: not auto-installed yet — follow the same
+  # "Rootless mode" sequence with your package manager.
 
-See docs/INSTALL.md for rootless mode and other distros.
+See docs/INSTALL.md "Rootless mode" for the full copy-pasteable sequence.
 EOF
       ;;
     *)
@@ -4215,7 +4221,7 @@ case "$OS" in
         exit 1
       fi
       if [ -t 0 ]; then
-        remote_log "nerdctl is missing — installing containerd + nerdctl (one-time; may prompt for sudo)..."
+        remote_log "nerdctl is missing — installing the rootless containerd stack (one-time; may prompt for sudo)..."
         if ! runtime_install_linux; then
           print_install_hint
           exit 1

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -4,13 +4,22 @@
 #   curl -fsSL https://raw.githubusercontent.com/enricai/leerie/main/scripts/install.sh | bash
 #
 # What this does, in order:
-#   1. Verifies `git`, `claude`, and `curl` are on PATH.
+#   1. Verifies `git` + `curl` are on PATH; auto-installs the `claude` CLI if
+#      missing via Anthropic's official native installer
+#      (`curl -fsSL https://claude.ai/install.sh | bash` — a self-contained
+#      binary in ~/.local/bin, no Node/npm). Pass --no-claude-install (or
+#      LEERIE_NO_CLAUDE_INSTALL=1) to skip — falls back to a hint and exits 1.
+#      Leerie shells out to `claude -p` for every unit of LLM work.
 #   2. Runtime: installs the container runtime if missing AND starts it.
 #      - macOS:    `brew install colima` + `colima start --runtime containerd --mount-type virtiofs --cpu N --memory M`
 #                  (N/M auto-detected: half host CPU/RAM, clamped 2..8 / 4..16 GB — see _runtime_colima_size_flags)
-#      - Debian:   `apt-get install containerd` + pinned nerdctl binary + `systemctl enable --now containerd`
-#      - Fedora:   `dnf install containerd` + pinned nerdctl binary + `systemctl enable --now containerd`
-#      - Arch:     `pacman -S containerd nerdctl` + `systemctl enable --now containerd`
+#      - Debian/Ubuntu: a full rootless containerd stack — containerd +
+#                  rootlesskit/slirp4netns/uidmap (apt), pinned nerdctl, CNI
+#                  plugins, BuildKit, the rootless setuptool + buildkit worker,
+#                  and an end-to-end `nerdctl info` reachability check. See
+#                  runtime_install_linux in runtime-install.sh.
+#      - Fedora/Arch: not auto-installed yet — falls back to a docs hint
+#                  (docs/INSTALL.md "Rootless mode") + exit 1.
 #      Pass --no-runtime-install (or LEERIE_NO_RUNTIME_INSTALL=1) to skip
 #      auto-install — the installer falls back to a hint and exits 1.
 #      Unknown distros always fall back to the hint.
@@ -27,6 +36,8 @@
 #   --dry-run                Print actions without executing.
 #   --no-runtime-install     Skip auto-install of the container runtime;
 #                            print the manual hint and exit 1 if missing.
+#   --no-claude-install      Skip auto-install of the claude CLI;
+#                            print the manual hint and exit 1 if missing.
 #   --prefix DIR             Install Leerie under DIR (default: $LEERIE_HOME or ~/.leerie).
 #   --bin-dir DIR            Symlink dir (default: ~/.local/bin).
 #   --ref REF                Git ref to install (default: main).
@@ -37,6 +48,7 @@
 #   LEERIE_BIN_DIR              Symlink directory (default ~/.local/bin). --bin-dir overrides.
 #   LEERIE_REPO_URL             Repo URL to clone (default https://github.com/enricai/leerie.git).
 #   LEERIE_NO_RUNTIME_INSTALL   Same as --no-runtime-install when truthy ("1", "true", "yes").
+#   LEERIE_NO_CLAUDE_INSTALL    Same as --no-claude-install when truthy ("1", "true", "yes").
 set -euo pipefail
 
 # --- defaults ------------------------------------------------------------
@@ -61,9 +73,17 @@ case "${LEERIE_NO_RUNTIME_INSTALL:-}" in
   1|true|TRUE|yes|YES) NO_RUNTIME_INSTALL=true ;;
   *)                   NO_RUNTIME_INSTALL=false ;;
 esac
-# Pinned nerdctl version used by the Linux Debian/Fedora paths. Matches
-# the version documented in docs/INSTALL.md. Set BEFORE sourcing
-# runtime-install.sh so the helper inherits it.
+# Same detector for LEERIE_NO_CLAUDE_INSTALL — opt out of auto-installing the
+# claude CLI when it's missing (mirrors --no-runtime-install). When true, a
+# missing claude falls back to the printed hint + exit 1 (the pre-auto-install
+# behavior).
+case "${LEERIE_NO_CLAUDE_INSTALL:-}" in
+  1|true|TRUE|yes|YES) NO_CLAUDE_INSTALL=true ;;
+  *)                   NO_CLAUDE_INSTALL=false ;;
+esac
+# Pinned nerdctl version used by the Linux Debian path. Matches the version
+# documented in docs/INSTALL.md. Set BEFORE sourcing runtime-install.sh so the
+# helper inherits it.
 # shellcheck disable=SC2034  # consumed by runtime-install.sh (sourced below)
 NERDCTL_VERSION=2.3.1
 
@@ -76,11 +96,13 @@ install.sh — one-command installer for Leerie.
   curl -fsSL https://raw.githubusercontent.com/enricai/leerie/main/scripts/install.sh | bash
 
 What this does, in order:
-  1. Verifies `git`, `claude`, and `curl` are on PATH.
+  1. Verifies `git` + `curl` are on PATH; auto-installs the `claude` CLI if
+     missing (Anthropic's official native installer). Pass --no-claude-install
+     to skip (fall back to hint + exit 1).
   2. Runtime: installs the container runtime if missing AND starts it
-     (Colima on macOS via brew; containerd + pinned nerdctl on
-     Debian/Fedora/Arch via the distro package manager). Pass
-     --no-runtime-install to skip auto-install (fall back to hint + exit 1).
+     (Colima on macOS via brew; a rootless containerd stack on Debian/Ubuntu.
+     Fedora/Arch fall back to a docs hint). Pass --no-runtime-install to skip
+     auto-install (fall back to hint + exit 1).
   3. Clones (or fast-forwards) enricai/leerie into $LEERIE_HOME (default ~/.leerie).
   4. Symlinks $LEERIE_HOME/leerie into ~/.local/bin/leerie.
   5. Verifies the install with `leerie --version`.
@@ -88,6 +110,7 @@ What this does, in order:
 Flags:
   --dry-run                Print actions without executing.
   --no-runtime-install     Skip auto-install of the container runtime.
+  --no-claude-install      Skip auto-install of the claude CLI.
   --prefix DIR             Install Leerie under DIR (default: $LEERIE_HOME or ~/.leerie).
   --bin-dir DIR            Symlink dir (default: ~/.local/bin).
   --ref REF                Git ref to install (default: main).
@@ -98,6 +121,7 @@ Env vars:
   LEERIE_BIN_DIR              Symlink directory (default ~/.local/bin). --bin-dir overrides.
   LEERIE_REPO_URL             Repo URL to clone (default https://github.com/enricai/leerie.git).
   LEERIE_NO_RUNTIME_INSTALL   Same as --no-runtime-install when truthy ("1", "true", "yes").
+  LEERIE_NO_CLAUDE_INSTALL    Same as --no-claude-install when truthy ("1", "true", "yes").
 EOF
 }
 
@@ -134,6 +158,22 @@ remediate_git() {
 remediate_claude() {
   err "claude CLI is missing. Install Claude Code from https://claude.ai/code"
   err "Leerie shells out to \`claude -p\` for every unit of LLM work; there is no fallback."
+  err "(Auto-install is on by default; this hint prints only when"
+  err " --no-claude-install / LEERIE_NO_CLAUDE_INSTALL=1 is set, or the"
+  err " auto-install itself failed.)"
+}
+
+# Auto-install the claude CLI via Anthropic's official native installer
+# (curl -fsSL https://claude.ai/install.sh | bash). It downloads a
+# self-contained binary — no Node/npm — installs to ~/.local/bin/claude, and
+# registers PATH. It refuses to run under sudo, so we never wrap it in sudo.
+# Mirrors the container-runtime auto-install: leerie shells out to `claude -p`
+# for every unit of LLM work, so a missing claude is a hard stop; installing it
+# for the user removes the single most common first-run wall. Returns the
+# installer's exit code; the caller re-verifies runnability regardless.
+install_claude() {
+  log "installing the claude CLI via the official native installer"
+  run bash -c 'curl -fsSL https://claude.ai/install.sh | bash'
 }
 
 remediate_curl() {
@@ -155,6 +195,7 @@ while [ $# -gt 0 ]; do
   case "$1" in
     --dry-run)              DRY_RUN=true; shift ;;
     --no-runtime-install)   NO_RUNTIME_INSTALL=true; shift ;;
+    --no-claude-install)    NO_CLAUDE_INSTALL=true; shift ;;
     --prefix)               PREFIX="${2:?--prefix needs an argument}"; shift 2 ;;
     --bin-dir)              BIN_DIR="${2:?--bin-dir needs an argument}"; shift 2 ;;
     --ref)                  REF="${2:?--ref needs an argument}"; shift 2 ;;
@@ -210,19 +251,46 @@ _source_runtime_helpers || exit 1
 # curl is required to download the repo (and for the runtime preflight's
 # nerdctl-from-upstream guidance on Linux).
 
-log "preflight: checking git, claude, and curl on PATH"
+log "preflight: checking git + curl on PATH; auto-installing claude if missing"
 missing=0
+# git and curl are OS-package prerequisites leerie doesn't own — check only,
+# with a distro-appropriate hint. curl in particular is needed *by* the claude
+# auto-install below (and by _source_runtime_helpers), so verify it first.
 if ! have_runnable git; then
   remediate_git
-  missing=1
-fi
-if ! have_runnable claude; then
-  remediate_claude
   missing=1
 fi
 if ! have_runnable curl; then
   remediate_curl
   missing=1
+fi
+# claude is leerie-owned in the sense that every unit of work shells out to it,
+# so we auto-install it (like the container runtime) unless the user opted out.
+# The official native installer lands in ~/.local/bin, which may not be on the
+# current PATH yet — re-verify against that path before failing.
+if ! have_runnable claude; then
+  if [ "$NO_CLAUDE_INSTALL" = "true" ]; then
+    remediate_claude
+    missing=1
+  elif ! have_runnable curl; then
+    # curl already failed above; the claude installer needs it. Fall back to
+    # the manual hint rather than attempting an install that can't run.
+    remediate_claude
+    missing=1
+  else
+    install_claude || true
+    # Re-verify. The native installer commonly lands in ~/.local/bin; add it
+    # to PATH for this check so a just-installed claude is found even if the
+    # user's PATH doesn't include it yet (the PATH-check step below hints the
+    # user to add ~/.local/bin permanently). Skipped under --dry-run since
+    # nothing was actually installed.
+    if [ "$DRY_RUN" = "false" ] \
+       && ! PATH="$HOME/.local/bin:$PATH" have_runnable claude; then
+      err "claude auto-install ran but claude is still not runnable."
+      remediate_claude
+      missing=1
+    fi
+  fi
 fi
 if [ "$missing" -ne 0 ]; then
   exit 1
@@ -281,18 +349,25 @@ case "$(uname -s)" in
   Linux)
     if ! have_runnable nerdctl; then
       if [ "$NO_RUNTIME_INSTALL" = "true" ]; then
-        err "nerdctl is missing. Install it from your distro's package manager"
-        err "or from https://github.com/containerd/nerdctl/releases."
-        err "Examples: 'sudo apt-get install -y containerd' + nerdctl binary download;"
-        err "          'sudo pacman -S containerd nerdctl' on Arch."
-        err "See docs/INSTALL.md for rootless mode and other distros."
+        err "nerdctl is missing (auto-install skipped via --no-runtime-install)."
+        err "Set up the rootless containerd stack manually — see docs/INSTALL.md"
+        err "\"Rootless mode\" (containerd + rootlesskit/slirp4netns/uidmap, nerdctl,"
+        err "CNI plugins, BuildKit, the rootless setuptool), then re-run."
         runtime_ok=false
       else
         runtime_install_linux || runtime_ok=false
       fi
     elif [ "$DRY_RUN" = "false" ] && ! nerdctl info >/dev/null 2>&1; then
-      log "enabling + starting containerd via systemd"
-      run sudo systemctl enable --now containerd
+      # nerdctl is present but can't reach containerd. Under leerie's rootless
+      # model this is a misconfigured/stopped user service, NOT a case for
+      # enabling the rootful system daemon (which an unprivileged nerdctl can't
+      # reach anyway). Point at the rootless recovery steps.
+      err "nerdctl is installed but cannot reach containerd."
+      err "For rootless containerd, check the user service:"
+      err "  systemctl --user status containerd"
+      err "and ensure ~/.local/bin + /usr/local/bin are on your PATH."
+      err "See docs/INSTALL.md \"Rootless mode\"."
+      runtime_ok=false
     fi
     ;;
   *)

--- a/scripts/runtime-install.sh
+++ b/scripts/runtime-install.sh
@@ -22,10 +22,18 @@
 
 # --- defaults ------------------------------------------------------------
 
-# Pinned nerdctl version used by the Linux Debian/Fedora paths. Matches
-# the version documented in docs/INSTALL.md and previously hard-coded in
-# install.sh.
+# Pinned nerdctl version used by the Linux Debian path. Matches the version
+# documented in docs/INSTALL.md and previously hard-coded in install.sh.
 NERDCTL_VERSION="${NERDCTL_VERSION:-2.3.1}"
+
+# Pinned CNI plugins + BuildKit versions for the Debian rootless path. The
+# rootless containerd stack these complete (containerd + rootlesskit come from
+# apt; nerdctl from the pinned tarball above) is not fully installed by the
+# rootless setuptool — CNI plugins and BuildKit binaries must be placed on the
+# host separately (see runtime_install_linux). All three release URLs were
+# verified to resolve. Update in lockstep with docs/INSTALL.md.
+CNI_VERSION="${CNI_VERSION:-v1.9.1}"
+BUILDKIT_VERSION="${BUILDKIT_VERSION:-v0.31.2}"
 
 # DRY_RUN may be set by the caller (install.sh's --dry-run). Default off.
 DRY_RUN="${DRY_RUN:-false}"
@@ -277,69 +285,189 @@ runtime_install_macos() {
   return 0
 }
 
-# --- public: Linux install (containerd + nerdctl per distro) ------------
+# --- public: Linux install (rootless containerd, Debian/Ubuntu) ---------
+#
+# Design (DESIGN §6; INSTALL.md "Rootless mode"): stand up a *working,
+# reachable* rootless runtime, not just an enabled rootful daemon. The prior
+# version installed only `containerd` (apt) + the bare `nerdctl` binary and
+# reported success without ever verifying `nerdctl info` — which left a fresh
+# host with an unreachable rootful socket, no CNI plugins (so `nerdctl run`
+# failed on the missing bridge plugin), and no BuildKit (so leerie's image
+# build failed on a missing `buildctl`/`buildkitd`). Those are the three walls
+# a real fresh-Ubuntu install hit, in order.
+#
+# The `containerd-rootless-setuptool.sh install` flow needs a set of host
+# prerequisites it does NOT install itself (it errors and exits if they're
+# absent): rootlesskit + a port driver (slirp4netns), newuidmap/newgidmap
+# (uidmap) plus /etc/subuid+/etc/subgid entries for the user, and a systemd
+# user session (dbus-user-session). And the setuptool never installs CNI
+# plugins or the BuildKit binaries at all. So the Debian path installs all of
+# these explicitly, runs the rootless setup as the non-root user, and verifies
+# reachability end-to-end.
+#
+# Scope: Debian/Ubuntu only. Fedora/Arch are not auto-installed here — their
+# package-name equivalents are unverified, so they fall back to a docs hint
+# rather than a possibly-half-working auto-install that reports false success.
+
+# Install the runtime + rootless prerequisites via apt (the exact package set
+# proven to bring rootless containerd up on Ubuntu):
+#   containerd        — the container runtime (rootless mode reuses the binary)
+#   rootlesskit       — the user-namespace "fake root" the rootless daemon runs in
+#   slirp4netns       — userspace networking for the rootless netns
+#   uidmap            — newuidmap/newgidmap (setuid) for the subuid/subgid map
+#   dbus-user-session — the per-user systemd/D-Bus session `systemctl --user` needs
+_runtime_linux_apt_prereqs() {
+  _runtime_log "installing containerd + rootless prerequisites via apt-get"
+  _runtime_run sudo apt-get update || return 1
+  _runtime_run sudo apt-get install -y \
+    containerd rootlesskit slirp4netns uidmap dbus-user-session || return 1
+  return 0
+}
+
+# Install the pinned upstream nerdctl binary into /usr/local/bin. The tarball
+# also carries containerd-rootless-setuptool.sh + containerd-rootless.sh, which
+# the rootless setup step below needs on PATH.
+_runtime_linux_install_nerdctl() {
+  local arch="$1" url
+  if [ "$arch" = "unknown" ]; then
+    _runtime_err "could not detect host arch for the nerdctl binary download."
+    _runtime_err "Install nerdctl manually from https://github.com/containerd/nerdctl/releases"
+    return 1
+  fi
+  url="https://github.com/containerd/nerdctl/releases/download/v${NERDCTL_VERSION}/nerdctl-${NERDCTL_VERSION}-linux-${arch}.tar.gz"
+  _runtime_log "installing nerdctl ${NERDCTL_VERSION} (linux-${arch}) from upstream"
+  if [ "$DRY_RUN" = "false" ]; then
+    curl -L "$url" | sudo tar -C /usr/local/bin -xz || return 1
+  else
+    printf '  $ curl -L %s | sudo tar -C /usr/local/bin -xz\n' "$url"
+  fi
+  return 0
+}
+
+# Install the CNI plugins into /opt/cni/bin — the CNI_PATH nerdctl looks in.
+# The rootless setuptool never installs these; without them `nerdctl run`
+# fails with `needs CNI plugin "bridge" to be installed in CNI_PATH`.
+_runtime_linux_install_cni() {
+  local arch="$1" url
+  if [ "$arch" = "unknown" ]; then
+    _runtime_err "could not detect host arch for the CNI plugins download."
+    return 1
+  fi
+  url="https://github.com/containernetworking/plugins/releases/download/${CNI_VERSION}/cni-plugins-linux-${arch}-${CNI_VERSION}.tgz"
+  _runtime_log "installing CNI plugins ${CNI_VERSION} (linux-${arch}) into /opt/cni/bin"
+  if [ "$DRY_RUN" = "false" ]; then
+    sudo mkdir -p /opt/cni/bin || return 1
+    curl -L "$url" | sudo tar -C /opt/cni/bin -xz || return 1
+  else
+    printf '  $ sudo mkdir -p /opt/cni/bin\n'
+    printf '  $ curl -L %s | sudo tar -C /opt/cni/bin -xz\n' "$url"
+  fi
+  return 0
+}
+
+# Install the BuildKit binaries into ~/.local (bin/buildctl, bin/buildkitd) so
+# they land on the user's PATH. `containerd-rootless-setuptool.sh
+# install-buildkit-containerd` refuses (exit 1) unless `buildkitd` is already
+# on PATH, so this must precede the rootless-buildkit step.
+_runtime_linux_install_buildkit() {
+  local arch="$1" url
+  if [ "$arch" = "unknown" ]; then
+    _runtime_err "could not detect host arch for the BuildKit download."
+    return 1
+  fi
+  url="https://github.com/moby/buildkit/releases/download/${BUILDKIT_VERSION}/buildkit-${BUILDKIT_VERSION}.linux-${arch}.tar.gz"
+  _runtime_log "installing BuildKit ${BUILDKIT_VERSION} (linux-${arch}) into ~/.local"
+  if [ "$DRY_RUN" = "false" ]; then
+    curl -L "$url" | tar -C "$HOME/.local" -xz || return 1
+  else
+    printf '  $ curl -L %s | tar -C %s/.local -xz\n' "$url" "$HOME"
+  fi
+  return 0
+}
+
+# Ensure the invoking user has subordinate uid/gid ranges. RootlessKit (which
+# the rootless setuptool exercises) needs /etc/subuid + /etc/subgid entries of
+# at least 65536 ids for the user; Ubuntu does not guarantee they're populated
+# on every image. Idempotent: a no-op when an entry already exists.
+_runtime_linux_ensure_subid() {
+  local user
+  user="$(id -un)"
+  if [ "$DRY_RUN" = "false" ] && grep -q "^${user}:" /etc/subuid 2>/dev/null; then
+    return 0  # already configured
+  fi
+  _runtime_log "ensuring subuid/subgid ranges for ${user} (RootlessKit prerequisite)"
+  _runtime_run sudo usermod \
+    --add-subuids 100000-165535 --add-subgids 100000-165535 "$user" || return 1
+  return 0
+}
+
+# Run the rootless containerd setup as the invoking (non-root) user — the
+# setuptool installs a `systemctl --user` unit and must NOT run under sudo.
+# Then install the BuildKit containerd-worker (the variant leerie needs: its
+# ensure_base_in_buildkit_ns copies the base image into the `buildkit`
+# containerd namespace, which the OCI-worker variant can't read). Finally
+# enable linger so the user services survive logout.
+_runtime_linux_rootless_setup() {
+  _runtime_log "setting up rootless containerd (containerd-rootless-setuptool.sh install)"
+  _runtime_run containerd-rootless-setuptool.sh install || return 1
+  _runtime_log "installing the rootless BuildKit containerd-worker"
+  _runtime_run env CONTAINERD_NAMESPACE=default \
+    containerd-rootless-setuptool.sh install-buildkit-containerd || return 1
+  _runtime_log "enabling linger so rootless services survive logout"
+  _runtime_run sudo loginctl enable-linger "$(id -un)" || return 1
+  return 0
+}
 
 # Returns 0 on success, 1 on failure. Caller is responsible for the TTY
-# guard before invoking (apt-get / dnf / pacman / sudo systemctl all
-# prompt for the sudo password).
+# guard before invoking (apt-get / sudo all prompt for the sudo password).
 runtime_install_linux() {
   if _runtime_have_runnable nerdctl && nerdctl info >/dev/null 2>&1; then
-    return 0  # already set up
+    return 0  # already set up and reachable
   fi
-  local distro arch nerdctl_url
+  local distro arch
   distro="$(_runtime_detect_distro)"
   arch="$(_runtime_nerdctl_arch)"
-  nerdctl_url="https://github.com/containerd/nerdctl/releases/download/v${NERDCTL_VERSION}/nerdctl-${NERDCTL_VERSION}-linux-${arch}.tar.gz"
 
   case "$distro" in
     debian)
-      _runtime_log "installing containerd via apt-get"
-      _runtime_run sudo apt-get update || return 1
-      _runtime_run sudo apt-get install -y containerd || return 1
-      if [ "$arch" = "unknown" ]; then
-        _runtime_err "could not detect host arch for the nerdctl binary download."
-        _runtime_err "Install nerdctl manually from https://github.com/containerd/nerdctl/releases"
-        return 1
-      fi
-      _runtime_log "installing nerdctl ${NERDCTL_VERSION} (linux-${arch}) from upstream"
-      if [ "$DRY_RUN" = "false" ]; then
-        curl -L "$nerdctl_url" | sudo tar -C /usr/local/bin -xz nerdctl || return 1
-      else
-        printf '  $ curl -L %s | sudo tar -C /usr/local/bin -xz nerdctl\n' "$nerdctl_url"
-      fi
+      _runtime_linux_apt_prereqs || return 1
+      _runtime_linux_install_nerdctl "$arch" || return 1
+      _runtime_linux_install_cni "$arch" || return 1
+      _runtime_linux_install_buildkit "$arch" || return 1
+      _runtime_linux_ensure_subid || return 1
+      _runtime_linux_rootless_setup || return 1
       ;;
-    fedora)
-      _runtime_log "installing containerd via dnf"
-      _runtime_run sudo dnf install -y containerd || return 1
-      if [ "$arch" = "unknown" ]; then
-        _runtime_err "could not detect host arch for the nerdctl binary download."
-        _runtime_err "Install nerdctl manually from https://github.com/containerd/nerdctl/releases"
-        return 1
-      fi
-      _runtime_log "installing nerdctl ${NERDCTL_VERSION} (linux-${arch}) from upstream"
-      if [ "$DRY_RUN" = "false" ]; then
-        curl -L "$nerdctl_url" | sudo tar -C /usr/local/bin -xz nerdctl || return 1
-      else
-        printf '  $ curl -L %s | sudo tar -C /usr/local/bin -xz nerdctl\n' "$nerdctl_url"
-      fi
-      ;;
-    arch)
-      _runtime_log "installing containerd + nerdctl via pacman"
-      _runtime_run sudo pacman -S --noconfirm containerd nerdctl || return 1
+    fedora|arch)
+      # Not auto-installed yet — the apt-equivalent package names for the
+      # rootless prerequisites are unverified on these distros, and a
+      # half-working auto-install that reports success is worse than an honest
+      # hint. See docs/INSTALL.md "Rootless mode" for the manual steps.
+      _runtime_err "auto-install of the rootless runtime is currently"
+      _runtime_err "Debian/Ubuntu-only (detected: ${distro})."
+      _runtime_err "Set up rootless containerd manually — see docs/INSTALL.md"
+      _runtime_err "'Rootless mode' — or pass --no-runtime-install to skip."
+      return 1
       ;;
     *)
       _runtime_err "unsupported Linux distro (detected: ${distro}). Auto-install"
-      _runtime_err "only supports debian/ubuntu, fedora/rhel, and arch."
-      _runtime_err "Install nerdctl + containerd manually (see docs/INSTALL.md) or"
+      _runtime_err "of the rootless runtime currently supports debian/ubuntu only."
+      _runtime_err "Set up rootless containerd manually (see docs/INSTALL.md) or"
       _runtime_err "pass --no-runtime-install to skip the auto-install step."
       return 1
       ;;
   esac
 
-  if [ "$DRY_RUN" = "false" ] \
-     && _runtime_have_runnable nerdctl && ! nerdctl info >/dev/null 2>&1; then
-    _runtime_log "enabling + starting containerd via systemd"
-    _runtime_run sudo systemctl enable --now containerd || return 1
+  # Verify end-to-end. The whole point of this rework: never report success on
+  # an unreachable runtime. Under --dry-run we can't actually probe, so skip.
+  if [ "$DRY_RUN" = "false" ]; then
+    _runtime_log "verifying the runtime is reachable (nerdctl info)"
+    if ! nerdctl info >/dev/null 2>&1; then
+      _runtime_err "rootless containerd was set up but 'nerdctl info' still fails."
+      _runtime_err "Ensure ~/.local/bin and /usr/local/bin are on your PATH, then"
+      _runtime_err "check: systemctl --user status containerd"
+      _runtime_err "See docs/INSTALL.md 'Rootless mode' for the manual steps."
+      return 1
+    fi
   fi
   return 0
 }

--- a/tests/test_runtime_install.py
+++ b/tests/test_runtime_install.py
@@ -1,0 +1,229 @@
+"""Tests for the Linux rootless runtime install path in
+``scripts/runtime-install.sh`` and the claude auto-install in
+``scripts/install.sh``.
+
+Background (the incident these encode against): a fresh Ubuntu install
+following the docs dead-ended through three walls, because the old
+``runtime_install_linux`` installed only ``containerd`` (apt) + the bare
+``nerdctl`` binary and reported success without verifying reachability — no
+CNI plugins (so ``nerdctl run`` failed on the missing bridge plugin), no
+BuildKit (so leerie's image build failed on a missing ``buildctl``), no
+rootless setup, and no ``nerdctl info`` check. The rework installs the full
+rootless stack (the exact separate-install sequence proven by hand on the
+server) and verifies reachability, and ``install.sh`` auto-installs the
+``claude`` CLI instead of only hinting.
+
+Strategy: source the real scripts under ``DRY_RUN=true`` with detection
+helpers stubbed (mirroring the extract-and-run-the-real-arm approach in
+``test_config_verb.py``). Under dry-run every command is *printed* not run,
+so we assert on the emitted command sequence — no network, no apt, no
+container. The Fedora/Arch tests pin the deliberate Debian/Ubuntu-only
+narrowing so a future contributor can't assume those arms are wired.
+"""
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+RUNTIME_INSTALL = REPO_ROOT / "scripts" / "runtime-install.sh"
+INSTALL_SH = REPO_ROOT / "scripts" / "install.sh"
+
+
+# ---------------------------------------------------------------------------
+# runtime-install.sh — Linux rootless path
+# ---------------------------------------------------------------------------
+# Harness: source the real script, then stub the three detection seams
+# (_runtime_detect_distro / _runtime_nerdctl_arch / _runtime_have_runnable)
+# so runtime_install_linux runs a chosen distro/arch under DRY_RUN=true and
+# prints (never executes) its command plan.
+def _run_linux_install(distro: str, arch: str = "amd64") -> subprocess.CompletedProcess:
+    # No `set -e`: runtime_install_linux legitimately returns 1 on the
+    # hint paths, and we must still reach the `echo "__rc=$?"` line to observe
+    # it. `set -u` alone is fine.
+    script = f"""
+      set -u
+      . "{RUNTIME_INSTALL}"
+      _runtime_detect_distro() {{ echo {distro}; }}
+      _runtime_nerdctl_arch()  {{ echo {arch}; }}
+      # Force "not already installed / not reachable" so the install body runs.
+      _runtime_have_runnable() {{ return 1; }}
+      nerdctl() {{ return 1; }}
+      runtime_install_linux
+      echo "__rc=$?"
+    """
+    return subprocess.run(
+        ["bash", "-c", script],
+        capture_output=True,
+        text=True,
+        env={"DRY_RUN": "true", "PATH": "/usr/bin:/bin", "HOME": "/home/tester"},
+    )
+
+
+def test_debian_emits_full_rootless_sequence_in_order() -> None:
+    r = _run_linux_install("debian")
+    out = r.stdout
+    # The load-bearing assertion: every step of the proven sequence appears,
+    # in order. We locate each marker's index in the output and assert the
+    # indices are strictly increasing.
+    markers = [
+        # 1. apt prereqs — containerd + the rootless prerequisite set.
+        "apt-get install -y containerd rootlesskit slirp4netns uidmap dbus-user-session",
+        # 2. nerdctl binary from the pinned upstream tarball.
+        "nerdctl-2.3.1-linux-amd64.tar.gz",
+        # 3. CNI plugins into /opt/cni/bin (the CNI_PATH nerdctl names).
+        "/opt/cni/bin",
+        # 4. BuildKit into ~/.local (puts buildctl/buildkitd on PATH).
+        "buildkit-v0.31.2.linux-amd64.tar.gz",
+        # 5. subuid/subgid guard.
+        "usermod --add-subuids 100000-165535 --add-subgids 100000-165535",
+        # 6. rootless setuptool install, then the buildkit-containerd worker.
+        "containerd-rootless-setuptool.sh install",
+        "install-buildkit-containerd",
+        # 7. enable-linger.
+        "loginctl enable-linger",
+    ]
+    last = -1
+    for m in markers:
+        idx = out.find(m)
+        assert idx != -1, f"missing step {m!r} in:\n{out}"
+        assert idx > last, f"step {m!r} out of order in:\n{out}"
+        last = idx
+
+
+def test_debian_cni_before_buildkit_before_rootless() -> None:
+    # Ordering that matters for correctness: CNI (for nerdctl run) and the
+    # BuildKit binary (buildkitd on PATH) must both precede the rootless
+    # setuptool — install-buildkit-containerd exits 1 without buildkitd.
+    out = _run_linux_install("debian").stdout
+    assert out.index("/opt/cni/bin") < out.index("buildkit-v0.31.2")
+    assert out.index("buildkit-v0.31.2") < out.index(
+        "install-buildkit-containerd"
+    )
+
+
+def test_debian_buildkit_uses_containerd_worker_variant() -> None:
+    # Must be install-buildkit-containerd (containerd worker; leerie's
+    # ensure_base_in_buildkit_ns needs the buildkit namespace), NOT the plain
+    # OCI-worker install-buildkit.
+    out = _run_linux_install("debian").stdout
+    assert "install-buildkit-containerd" in out
+    assert "CONTAINERD_NAMESPACE=default" in out
+    # The bare OCI variant name must not appear as a standalone command.
+    assert not re.search(r"install-buildkit\b(?!-containerd)", out)
+
+
+def test_debian_rootless_setup_runs_without_sudo() -> None:
+    # The setuptool installs a `systemctl --user` unit and must NOT be run
+    # under sudo. Assert the setuptool line carries no leading sudo.
+    out = _run_linux_install("debian").stdout
+    for line in out.splitlines():
+        if "containerd-rootless-setuptool.sh install" in line:
+            assert "sudo" not in line, f"setuptool must not run under sudo: {line!r}"
+
+
+def test_fedora_falls_back_to_docs_hint_not_autoinstall() -> None:
+    r = _run_linux_install("fedora")
+    assert "__rc=1" in r.stdout, "fedora must return non-zero (hint path)"
+    # It must NOT emit any package-manager / rootless install commands.
+    for forbidden in (
+        "apt-get install",
+        "dnf install",
+        "pacman -S",
+        "containerd-rootless-setuptool.sh",
+        "/opt/cni/bin",
+    ):
+        assert forbidden not in r.stdout, (
+            f"fedora must not auto-install ({forbidden!r} leaked):\n{r.stdout}"
+        )
+    assert "docs/INSTALL.md" in r.stderr
+
+
+def test_arch_falls_back_to_docs_hint_not_autoinstall() -> None:
+    r = _run_linux_install("arch")
+    assert "__rc=1" in r.stdout
+    for forbidden in (
+        "apt-get install",
+        "pacman -S",
+        "containerd-rootless-setuptool.sh",
+        "/opt/cni/bin",
+    ):
+        assert forbidden not in r.stdout, (
+            f"arch must not auto-install ({forbidden!r} leaked):\n{r.stdout}"
+        )
+    assert "docs/INSTALL.md" in r.stderr
+
+
+def test_unknown_distro_returns_hint() -> None:
+    r = _run_linux_install("unknown")
+    assert "__rc=1" in r.stdout
+    assert "docs/INSTALL.md" in r.stderr
+    assert "containerd-rootless-setuptool.sh" not in r.stdout
+
+
+def test_version_constants_pinned() -> None:
+    # Pin the pinned versions (like test_resolve_confidence_rounds.py pins
+    # DEFAULT_CAPS) so a bump is a deliberate, reviewed change kept in lockstep
+    # with docs/INSTALL.md.
+    text = RUNTIME_INSTALL.read_text()
+    assert 'NERDCTL_VERSION="${NERDCTL_VERSION:-2.3.1}"' in text
+    assert 'CNI_VERSION="${CNI_VERSION:-v1.9.1}"' in text
+    assert 'BUILDKIT_VERSION="${BUILDKIT_VERSION:-v0.31.2}"' in text
+
+
+# ---------------------------------------------------------------------------
+# install.sh — claude auto-install with opt-out
+# ---------------------------------------------------------------------------
+# Harness: extract the preflight section is impractical (it depends on many
+# helpers), so instead drive the real install.sh under --dry-run with git and
+# curl stubbed as present and claude stubbed as ABSENT, and observe whether
+# the claude installer is invoked. We stub `install_claude`'s side-effect by
+# putting a fake `claude.ai` unreachable behind --dry-run: under --dry-run the
+# `run` helper only prints the command, so we assert on that printed line.
+def _run_install_preflight(no_claude_install_env: str | None) -> subprocess.CompletedProcess:
+    # Build a PATH with stub git+curl present and claude absent. The stubs
+    # live in a temp dir created inside the bash script itself.
+    env = {"PATH": "/usr/bin:/bin", "HOME": "/home/tester"}
+    if no_claude_install_env is not None:
+        env["LEERIE_NO_CLAUDE_INSTALL"] = no_claude_install_env
+    script = f"""
+      set -eu
+      stub=$(mktemp -d)
+      # git + curl present (real ones are fine); claude absent from PATH.
+      ln -s "$(command -v git)"  "$stub/git"
+      ln -s "$(command -v curl)" "$stub/curl"
+      export PATH="$stub:/usr/bin:/bin"
+      # Run install.sh in --dry-run so nothing is actually installed; it
+      # exits after preflight only if we make later steps no-op. We only care
+      # about preflight output, so capture up to the runtime phase.
+      bash "{INSTALL_SH}" --dry-run 2>&1 | sed -n '1,60p' || true
+    """
+    return subprocess.run(
+        ["bash", "-c", script], capture_output=True, text=True, env=env
+    )
+
+
+def test_claude_autoinstall_invoked_when_missing_and_optout_off() -> None:
+    r = _run_install_preflight(no_claude_install_env=None)
+    # Under --dry-run the `run` helper prints the command; the claude
+    # installer line must appear (auto-install fired), not the manual hint.
+    assert "https://claude.ai/install.sh" in r.stdout, (
+        f"claude auto-install should fire when missing:\n{r.stdout}"
+    )
+
+
+def test_claude_autoinstall_skipped_with_optout() -> None:
+    r = _run_install_preflight(no_claude_install_env="1")
+    # With opt-out, the installer must NOT run; the manual hint must show and
+    # preflight must fail (exit 1 path — surfaced as the missing hint).
+    assert "https://claude.ai/install.sh" not in r.stdout, (
+        f"opt-out must skip the claude installer:\n{r.stdout}"
+    )
+    assert "claude CLI is missing" in r.stdout
+
+
+def test_install_sh_documents_no_claude_install_flag() -> None:
+    text = INSTALL_SH.read_text()
+    assert "--no-claude-install" in text
+    assert "LEERIE_NO_CLAUDE_INSTALL" in text


### PR DESCRIPTION
## Problem

A fresh Ubuntu 26.04 install **following the docs** dead-ended through a chain of walls, each a real installer defect:

1. `install.sh` set up **rootful** containerd (`apt-get install containerd` + `systemctl enable --now containerd`) that an unprivileged `nerdctl` can't reach → `nerdctl cannot reach containerd` right after `install: done`.
2. It reported success **without ever verifying `nerdctl info`**.
3. The minimal nerdctl tarball extraction used `tar … -xz nerdctl` (nerdctl only), so `containerd-rootless-setuptool.sh` was **never on PATH** → the "setuptool not found" wall.
4. **No CNI plugins** → `nerdctl run` failed on `needs CNI plugin "bridge" … in CNI_PATH ("/opt/cni/bin")`.
5. **No BuildKit** → the image build failed on `` `buildctl` needs to be installed and `buildkitd` needs to be running ``.
6. `claude` was only *checked* and `exit 1`'d — never installed.

Every step was reproduced by hand on a live server, and this PR encodes the exact sequence that fixed it.

## What changed

**`scripts/runtime-install.sh`** — Debian/Ubuntu `runtime_install_linux` now stands up the full **rootless** stack and verifies reachability:

- apt: `containerd rootlesskit slirp4netns uidmap dbus-user-session`
- pinned nerdctl → `/usr/local/bin` (whole tarball, so the setuptool lands on PATH)
- CNI plugins (`v1.9.1`) → `/opt/cni/bin`
- BuildKit (`v0.31.2`) → `~/.local` (puts `buildctl`/`buildkitd` on PATH before the setuptool precheck)
- ensure `/etc/subuid`+`/etc/subgid` (idempotent; RootlessKit prerequisite)
- `containerd-rootless-setuptool.sh install` + `CONTAINERD_NAMESPACE=default … install-buildkit-containerd` (the containerd-worker variant leerie needs)
- `loginctl enable-linger`
- **verify `nerdctl info` and fail loudly** — never report success on an unreachable runtime

Fedora/Arch fall back to a `docs/INSTALL.md` hint rather than an unverified auto-install (deliberate narrowing; keeps every shipped path proven).

**`scripts/install.sh`** — auto-installs `claude` via the official native installer (`curl -fsSL https://claude.ai/install.sh | bash`) with `--no-claude-install` / `LEERIE_NO_CLAUDE_INSTALL` opt-out; its own Linux runtime section no longer tries to enable the rootful daemon when nerdctl can't reach containerd.

**Docs (three-layer rule)** — `docs/INSTALL.md` "Rootless mode" rewritten as an ordered copy-pasteable sequence; `docs/IMPLEMENTATION.md` §0 (table, Path B, runtime-requirements, file-tree) updated; launcher `print_install_hint` + log line fixed. DESIGN.md unchanged (architecture — rootless containerd, §6 — is unchanged; only the install mechanism changed).

**Tests** — new `tests/test_runtime_install.py` (11): dry-run bash-harness assertions that the Debian path emits the full sequence **in order**, Fedora/Arch take the hint-and-`return 1` path, the version constants are pinned, and the claude auto-install fires (and honors the opt-out).

## Verification

- All tarball extraction paths verified against the **real** downloaded tar indices (nerdctl flat root, CNI flat, BuildKit `bin/` prefix).
- subuid guard idempotency + claude re-verify PATH override exercised in real (non-dry-run) mode.
- `bash -n` + `shellcheck` clean on all scripts; `leerie --version` fast path intact.
- `pytest tests/`: **4316 passed**, 87 skipped. The 9 failures (`test_terminal_auth_*`, `test_transient_transport_retry`) are pre-existing and unrelated — they fail identically on clean `main` with `ModuleNotFoundError: No module named 'tenacity'` (a dev-shell dep gap; the container/CI env has it).
- End-to-end: the encoded sequence was proven live on a fresh Ubuntu 26.04 server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)