### PR TITLE
fix(install): prepend ~/.local/bin so buildkitd resolves during rootless setup

### DIFF
--- a/scripts/runtime-install.sh
+++ b/scripts/runtime-install.sh
@@ -408,6 +408,14 @@ _runtime_linux_ensure_subid() {
 # containerd namespace, which the OCI-worker variant can't read). Finally
 # enable linger so the user services survive logout.
 _runtime_linux_rootless_setup() {
+  # Ensure the just-installed binaries resolve regardless of the caller's PATH.
+  # BuildKit went to ~/.local/bin, which is NOT on a fresh `curl | bash`
+  # (non-login) shell's PATH on Ubuntu — so `install-buildkit-containerd`'s
+  # own `command -v buildkitd` precheck would fail and exit 1 without this.
+  # /usr/local/bin (nerdctl + the setuptool itself) is usually present, but we
+  # prepend both to be safe. Same inline-PATH technique the install.sh claude
+  # re-verify uses. Scoped to this function via `local` so it doesn't leak.
+  local PATH="$HOME/.local/bin:/usr/local/bin:$PATH"
   _runtime_log "setting up rootless containerd (containerd-rootless-setuptool.sh install)"
   _runtime_run containerd-rootless-setuptool.sh install || return 1
   _runtime_log "installing the rootless BuildKit containerd-worker"
@@ -459,7 +467,11 @@ runtime_install_linux() {
 
   # Verify end-to-end. The whole point of this rework: never report success on
   # an unreachable runtime. Under --dry-run we can't actually probe, so skip.
+  # Probe with the same PATH the setup used (the just-installed nerdctl is in
+  # /usr/local/bin, buildkit in ~/.local/bin) so the check reflects what a
+  # subsequent leerie run — which prepends ~/.local/bin itself — will see.
   if [ "$DRY_RUN" = "false" ]; then
+    local PATH="$HOME/.local/bin:/usr/local/bin:$PATH"
     _runtime_log "verifying the runtime is reachable (nerdctl info)"
     if ! nerdctl info >/dev/null 2>&1; then
       _runtime_err "rootless containerd was set up but 'nerdctl info' still fails."

--- a/tests/test_runtime_install.py
+++ b/tests/test_runtime_install.py
@@ -123,6 +123,64 @@ def test_debian_rootless_setup_runs_without_sudo() -> None:
             assert "sudo" not in line, f"setuptool must not run under sudo: {line!r}"
 
 
+def test_rootless_setup_puts_buildkitd_on_path(tmp_path) -> None:
+    # Regression (2026-07-26): BuildKit installs to ~/.local/bin, but on a fresh
+    # `curl | bash` (non-login) shell ~/.local/bin is NOT on PATH — so
+    # `containerd-rootless-setuptool.sh install-buildkit-containerd`'s own
+    # `command -v buildkitd` precheck would fail and exit 1, resurfacing the
+    # exact wall this change fixes. _runtime_linux_rootless_setup must prepend
+    # ~/.local/bin so buildkitd resolves regardless of the caller's PATH.
+    #
+    # This runs the REAL (non-dry-run) helper with a buildkitd stub in a fake
+    # ~/.local/bin that is deliberately absent from the base PATH, and stubs the
+    # setuptool to record whether buildkitd resolved at call time.
+    home = tmp_path
+    (home / ".local" / "bin").mkdir(parents=True)
+    (home / ".local" / "bin" / "buildkitd").write_text("#!/bin/sh\necho buildkitd\n")
+    (home / ".local" / "bin" / "buildkitd").chmod(0o755)
+    marker = tmp_path / "resolved.txt"
+    # Stub the setuptool as a REAL executable on a dedicated stub dir (not a
+    # bash function) so the `env CONTAINERD_NAMESPACE=default …
+    # containerd-rootless-setuptool.sh` call — which does a PATH lookup and
+    # can't see shell functions — resolves it, exactly as production's
+    # /usr/local/bin copy would. It records whether buildkitd is on PATH at
+    # call time. sudo (loginctl) is stubbed the same way.
+    stub = tmp_path / "stub"
+    stub.mkdir()
+    (stub / "containerd-rootless-setuptool.sh").write_text(
+        f'#!/bin/sh\nif command -v buildkitd >/dev/null 2>&1; then\n'
+        f'  echo resolved >> "{marker}"\nelse\n  echo missing >> "{marker}"\nfi\n'
+    )
+    (stub / "containerd-rootless-setuptool.sh").chmod(0o755)
+    (stub / "sudo").write_text('#!/bin/sh\nexec "$@"\n')  # loginctl → no-op-ish
+    (stub / "sudo").chmod(0o755)
+    (stub / "loginctl").write_text("#!/bin/sh\nexit 0\n")
+    (stub / "loginctl").chmod(0o755)
+    script = f"""
+      set -u
+      . "{RUNTIME_INSTALL}"
+      DRY_RUN=false
+      _runtime_linux_rootless_setup
+      echo "__rc=$?"
+    """
+    r = subprocess.run(
+        ["bash", "-c", script],
+        capture_output=True,
+        text=True,
+        # Base PATH has the stub dir + system dirs, but deliberately EXCLUDES
+        # ~/.local/bin — the production trap the fix must overcome.
+        env={"PATH": f"{stub}:/usr/bin:/bin", "HOME": str(home)},
+    )
+    assert "__rc=0" in r.stdout, f"rootless_setup should succeed:\n{r.stdout}\n{r.stderr}"
+    recorded = marker.read_text() if marker.exists() else ""
+    # The setuptool ran (at least once) and saw buildkitd resolvable — never
+    # "missing", which is the exit-1 production failure.
+    assert "resolved" in recorded, f"buildkitd did not resolve on PATH: {recorded!r}"
+    assert "missing" not in recorded, (
+        f"buildkitd was missing from PATH at setuptool call — the exit-1 bug: {recorded!r}"
+    )
+
+
 def test_fedora_falls_back_to_docs_hint_not_autoinstall() -> None:
     r = _run_linux_install("fedora")
     assert "__rc=1" in r.stdout, "fedora must return non-zero (hint path)"


### PR DESCRIPTION
## Follow-up to #111 — a real bug found on post-merge audit

#111 landed the rootless installer, but a skeptical re-read found a **shippable-breaking PATH bug** that the dry-run tests couldn't catch (it's a real PATH-resolution issue).

### The bug

`_runtime_linux_install_buildkit` installs BuildKit to `~/.local/bin` (`~/.local/bin/buildkitd`). Then `_runtime_linux_rootless_setup` runs `containerd-rootless-setuptool.sh install-buildkit-containerd`, whose **first action is `command -v buildkitd`** — and it `exit 1`s if buildkitd isn't on PATH.

But on a fresh `curl | bash` (non-login) shell, **`~/.local/bin` is not on PATH** by default on Ubuntu. So the precheck fails, the buildkit worker never installs, and the run dies — resurfacing the exact `` `buildctl` needs to be installed `` wall #111 set out to fix.

It only worked during hand-testing because the operator had manually run `export PATH="$HOME/.local/bin:$PATH"` earlier in the session.

**Proven:** with `PATH=/usr/bin:/bin`, `command -v buildkitd` → not found → setuptool would exit 1. The BuildKit tarball ships `bin/buildkitd`, confirming the target.

### The fix

Prepend `~/.local/bin` (and `/usr/local/bin`) to PATH — scoped `local` to the function, still exported to child processes since PATH is already an env var — at the top of `_runtime_linux_rootless_setup` and in the final `nerdctl info` verify block. This mirrors the inline-PATH technique `install.sh` already uses for its claude re-verify.

### Test

New **non-dry-run** regression test: runs `_runtime_linux_rootless_setup` with a `buildkitd` stub in a `~/.local/bin` deliberately absent from the base PATH, and a setuptool stub that records whether buildkitd resolved at call time. Verified non-vacuous — it **fails** (buildkitd "missing") with the fix reverted, **passes** with it.

## Verification

- `bash -n` + `shellcheck -S warning` clean.
- `pytest tests/test_runtime_install.py`: 12 passed.
- Full `pytest tests/`: 4317 passed, same 9 pre-existing `tenacity`-missing failures (unrelated; fail identically on `main`).
- Diff is +12 lines in `runtime-install.sh` (2 prepends + comments) and +58 in the test — nothing else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)