### PR TITLE
docs(test): fix stale 'high' in effort docstring (follow-up to #114)

### DIFF
--- a/tests/test_resolve_efforts.py
+++ b/tests/test_resolve_efforts.py
@@ -251,7 +251,7 @@ def test_post_run_workers_resolved(leerie, repo_root, monkeypatch):
 
 
 def test_judgment_workers_pinned_set(leerie):
-    """Pins which workers default to 'high'. Adding a worker to the
+    """Pins which workers default to 'medium'. Adding a worker to the
     judgment set should be a deliberate decision, not a silent drift.
     Acting workers (implementer, conformer) must stay absent — their
     reasoning depth is bounded by the DESIGN §8 evidence gate."""


### PR DESCRIPTION
Follow-up to #114. A post-merge audit found one stale doc reference the earlier sweeps missed.

## What

`tests/test_resolve_efforts.py` — the `test_judgment_workers_pinned_set` docstring said workers *"default to 'high'"*, but #114 lowered the default to `medium`. This corrects the prose (`'high'` → `'medium'`).

## Why it was missed

Prior sweeps grepped for assertion-shaped references (`== "high"`, value literals). This is prose inside a docstring on a **value-agnostic set-membership test** — the assertion only checks *which* workers are in `EFFORT_DEFAULT_PER_WORKER`, not their values, so the test was (and stays) green. Only the descriptive text was stale.

## Verification

- `git grep "default to 'high'" -- tests/` → empty (zero stale prose)
- `pytest tests/test_resolve_efforts.py` → 18 passed
- Diff: 1 file, +1/−1 (docstring line only; assertion unchanged)

No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)