### PR TITLE
chore(release): 0.9.83

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "leerie",
       "source": ".",
-      "version": "0.9.82",
+      "version": "0.9.83",
       "description": "Deterministic, headless task orchestrator for Claude Code. Classifies a task, decomposes it into dependency-ordered waves, and executes each subtask in an isolated git worktree under an evidence-gated implement/validate loop. Runs entirely on the Claude Code CLI/subscription via `claude -p` workers."
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "leerie",
   "displayName": "Leerie",
-  "version": "0.9.82",
+  "version": "0.9.83",
   "description": "Deterministic, headless task orchestrator for Claude Code. Classifies a task, decomposes it into granular subtasks, schedules them into dependency-ordered waves, and executes each in an isolated git worktree under an evidence-gated implement/validate loop. Runs entirely on the Claude Code CLI/subscription via `claude -p` workers.",
   "author": { "name": "Andres Restrepo", "email": "andres@enricai.com", "url": "https://enricai.com" },
   "license": "MIT",


### PR DESCRIPTION
Bumps both plugin manifests `0.9.82 → 0.9.83`.

Ships since v0.9.82:

- Make the planning phase resumable via per-phase checkpoints (#116)
- Replace self-graded confidence with independent adversarial verification gates (#117)
- Run `phase_wiring_gate` on the post-drop plan, not pre-filter (#118)
- Lower judgment-worker default effort high → medium for Opus 5 (#114)
- Fix stale `'high'` in `test_judgment_workers_pinned_set` docstring (#115)

On squash-merge the subject becomes `chore(release): 0.9.83 (#N)`, which the
release workflow matches to tag `v0.9.83` and publish the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)