### PR TITLE
docs(tests): fix stale opus-default mention in test_artifact_registry.py

### DIFF
--- a/tests/test_artifact_registry.py
+++ b/tests/test_artifact_registry.py
@@ -5,7 +5,7 @@ Covers:
   - SCHEMAS["artifact_registry"] structural contract (required fields, item
     shape, minLength guards, valid/invalid acceptance)
   - worker registration (WORKER_TYPES; absent from MODEL_DEFAULT_PER_WORKER so
-    it resolves opus; EFFORT_DEFAULT_PER_WORKER entry "medium"; prompt exists)
+    it resolves sonnet; EFFORT_DEFAULT_PER_WORKER entry "medium"; prompt exists)
   - model/effort resolution precedence
   - phase_artifact_registry behavior: returns the artifacts list, drops
     malformed items, degrades to [] on worker crash, is best-effort (no die)
@@ -95,7 +95,7 @@ def test_in_worker_types(leerie):
 
 
 def test_absent_from_model_default_per_worker(leerie):
-    # → resolves to opus via the global MODEL_DEFAULT fallback.
+    # → resolves to sonnet via the global MODEL_DEFAULT fallback.
     assert "artifact_registry" not in leerie.MODEL_DEFAULT_PER_WORKER
 
 


### PR DESCRIPTION
## Summary
- Follow-up to #121 (default every worker to sonnet). A fourth independent audit pass found two docstring/comment lines in `tests/test_artifact_registry.py` still claiming `artifact_registry` "resolves opus" via the global `MODEL_DEFAULT` fallback — the fallback now resolves to `sonnet`.
- The actual test assertion (`test_absent_from_model_default_per_worker`) was already correct; only the surrounding prose was stale. No behavior change.

## Test plan
- [x] `python3 -c "import ast; ast.parse(open('orchestrator/leerie.py').read())"` — n/a to this file but re-confirmed clean
- [x] `grep -n "opus" tests/test_artifact_registry.py` — no remaining hits
- [x] Repo-wide `grep -rn "opus" --include="*.md" --include="*.py" --include="*.sh" .` re-run after this fix — every remaining hit is a legitimate enum/override example, historical note, or explicit test-fixture value; none assert a stale current default

🤖 Generated with [Claude Code](https://claude.com/claude-code)