### PR TITLE
leerie: Reverse DESIGN.md §6½ to specify persistent out-of-repo dependency bake

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -3775,34 +3775,119 @@ classification and planning, layered top-to-bottom by determinism:
    it are restricted by an argv-allowlist, and any deviation
    from the schema rejects the worker. This is a *deliberate*
    exception to §12 — see below.
-5. **Worker-driven install.** Each fresh worktree is dependency-
-   less by design. The orchestrator does *not* pre-install
-   anything — neither at `repo_root` (which is bind-mounted from
-   the host and writing to it would clobber the host's checkout
-   with linux-built artifacts when the host is darwin) nor in
-   each worktree (which would be redundant work the worker often
-   doesn't need). Instead, the detected recipe is **persisted to
-   state and injected into the implementer and conformer prompts
-   as a `PROVISION_RECIPE:` advisory block**. Each worker reads
-   the recipe and decides whether its subtask actually needs the
-   install (a config-only or docs-only subtask doesn't; a "run
-   the tests" subtask does), then runs the command itself from
-   its own worktree via its Bash tool. The package-manager
-   caches (pnpm store, pip wheel cache, go module cache, cargo
-   registry, Bundler gem cache) are shared across worktrees and
-   across runs, so re-running the install command in worktree N
-   is fast.
+5. **Persistent out-of-repo dependency bake.** Dependencies are
+   installed once at image-build time into persistent paths
+   outside `/work`, so a fresh worktree inherits the bake with
+   zero (or minimal, for Node) install cost. The bake targets:
 
-   This shape has three benefits over an orchestrator-driven
-   install: (a) the host's checked-out source tree and tracked
-   dep artifacts (`node_modules/`, `.venv/`, `target/`, etc.) are
-   never written to by leerie's install path — `.leerie-setup.sh`
-   (user-opt-in) is the only path leerie ever modifies under the host
-   repo (run state lives outside the repo at `<state-root>`); (b) no work
-   is wasted on worktrees whose subtasks don't need built deps;
-   (c) the same `claude -p` event-streaming the workers use for
-   everything else makes install progress visible to the user,
-   without any special orchestrator plumbing.
+   - **Python:** `/opt/venv` — a virtual environment created via
+     `pip` or `uv` from the repo's `requirements.txt`,
+     `pyproject.toml`, or `Pipfile.lock`. Workers activate it via
+     `ENV VIRTUAL_ENV=/opt/venv` and `PATH`.
+   - **Ruby:** `/opt/bundle` — Bundler installs gems here via
+     `BUNDLE_PATH=/opt/bundle`. Workers inherit the env var and
+     find gems without a per-worktree `bundle install`.
+   - **Rust:** A pre-populated `CARGO_TARGET_DIR` (for build
+     artifacts) plus a warmed `CARGO_HOME` (for the registry
+     cache). A `cargo build` in a worktree hits no network and
+     reuses compiled dependencies from the bake.
+   - **Go:** A pre-populated `GOCACHE` (for build cache) plus a
+     warmed `GOMODCACHE` (for fetched modules). A `go build` in a
+     worktree is network-free and reuses the module cache.
+   - **Node/pnpm:** A warmed pnpm content-addressable store with
+     `frozenStore` set. Node dependencies (`node_modules`) cannot
+     be fully baked — they must live inside the repo tree for
+     resolution to work — so the residual per-run step is a fast,
+     network-free, extract-free `pnpm install --offline
+     --frozen-lockfile` that relinks the baked store into the
+     worktree. This is not zero-cost but eliminates download and
+     extraction, leaving only symlink creation.
+
+   **Immutability invariant:** The baked layer is shared and
+   read-only across up to `max_parallel` (default 5) concurrent
+   worktrees. A worktree that changes a dependency (edits
+   `package.json`, `requirements.txt`, `Gemfile`, `Cargo.toml`,
+   etc.) must materialize its own private, mutated layer rather
+   than writing to the shared bake — this prevents both staleness
+   (a worktree silently resolving deps it changed) and
+   cross-worktree corruption. Node, Rust, and Go are naturally
+   safe to bake: their package managers use content-addressed
+   stores or input-hash-keyed caches, so concurrent access is
+   read-only by design.
+
+   **Python requires a clone-then-delta approach.** A
+   `.pth`-file overlay or a `--system-site-packages` venv does not
+   correctly handle dependency *removal* (uninstalling a package
+   from the overlay leaves it visible in the base) or a fresh
+   venv's isolation from another venv's packages (site-packages
+   leaks across environments). The only correct mechanism is `cp
+   -r /opt/venv` into a private, relocated copy, then `pip install
+   -e .` or `pip uninstall` the diff. This materializes a full
+   private environment only when a worktree's subtask actually
+   mutates dependencies — the common case (no mutation) consumes
+   the shared `/opt/venv` directly with zero clone cost.
+
+   **Cache invalidation is preserved.** The existing
+   rebuild-decision mechanism — SHA-256 of every
+   dependency-input file (lockfiles, manifests, workspace
+   `package.json`s, `patches/`, `.npmrc`) folded into the
+   generated Dockerfile, driving a `.dockerfile-hash` rebuild
+   check — continues to work. The lockfiles and manifests are
+   still `COPY`'d into the Dockerfile's build context for
+   hashing; only the install *target* changes from `/work` to
+   `/opt/*`. A dependency-input change triggers a full image
+   rebuild. A change to an unrelated source file does not
+   invalidate the layer. The cost — minutes per rebuild — is paid
+   once across all subsequent runs.
+
+   **config.toml's role narrows to residual-only.** The file no
+   longer represents "what gets installed per run" broadly — it
+   holds only the irreducible residual that cannot be baked. For
+   Python, Ruby, Rust, and Go repos, this is typically empty
+   (everything bakes). For Node/pnpm repos, it holds only the
+   residual offline-relink note. The `dep_capture` worker (see
+   *Auto-capture* below) always runs at finalize time — it is not
+   skipped when a committed `.leerie/Dockerfile` exists — and
+   writes only residual dependencies that workers actually
+   executed but could not be baked. This makes `config.toml` a
+   stable artifact: it grows only when new residual deps appear,
+   never churns on every baked-dep change.
+
+   **Permissions under rootless containerd.** The baked `/opt/*`
+   directories must be **root-owned and world-readable** (`drwxr-xr-x
+   root:root`), not chowned to the `leerie` user. This is the
+   inverse of normal Docker intuition and is load-bearing under
+   rootless containerd. Rootless drops privilege via `unshare
+   --user --map-user=$(id -u leerie)`, a single-entry UID map
+   (outer UID 0 → inner `leerie`) that leaves outer `leerie`
+   *unmapped*. An image-layer directory explicitly chowned to
+   `leerie`'s non-zero UID appears as `nobody/65534` to the
+   privilege-dropped process — traversable via mode-755 "other"
+   bits but not writable. A root-owned directory, by contrast, is
+   writable because outer root maps to inner `leerie`. Rootful
+   (Colima/macOS, Fly/EC2) needs the opposite: `runuser -u
+   leerie` is a real UID switch with no remap, so
+   `container-entry.sh`'s rootful guard applies literal `leerie`
+   ownership at runtime for `/home/leerie` (user dirs), but
+   `/opt/*` (shared cross-worktree state) stays root-owned in the
+   image. See `CLAUDE.md` "Evaluate every ownership/permission
+   change" and `tests/test_tmp_cache_writable.py` /
+   `test_home_leerie_ownership.py` for the pinned form.
+
+   The detected recipe is still **persisted to state and injected
+   into the implementer and conformer prompts as a
+   `PROVISION_RECIPE:` advisory block**, but its role has
+   narrowed: for baked ecosystems (Python/Ruby/Rust/Go), the
+   recipe is informational (shows what was baked); for Node, it
+   carries the residual offline-relink command. Each worker reads
+   the recipe and decides whether its subtask needs the residual
+   step (a config-only or docs-only subtask doesn't; a "run the
+   tests" subtask does). The host's checked-out source tree and
+   tracked dep artifacts (`node_modules/`, `.venv/`, `target/`,
+   etc.) are never written to by leerie's install path —
+   `.leerie-setup.sh` (user-opt-in) is the only path leerie ever
+   modifies under the host repo (run state lives outside the repo
+   at `<state-root>`).
 
 ### The §12 carve-out
 

--- a/docs/IMPLEMENTATION.md
+++ b/docs/IMPLEMENTATION.md
@@ -416,7 +416,7 @@ relevant bash surface:
 
 **Rebuild triggers** (checked in order): (1) `nerdctl image inspect "$REPO_IMAGE_TAG"` fails, OR (2) `<LEERIE_VERSION>:<sha256>` of the current Dockerfile differs from the stored hash. Second run with unchanged Dockerfile hits the skip path ("per-repo image up-to-date; skipping build"). Before the build fires, `ensure_base_in_buildkit_ns` copies the base into the `buildkit` namespace (idempotent) so the derived `FROM $BASE_IMAGE` resolves against the local image store rather than the registry.
 
-**Auto-generation from `setup_packages`**: when `.leerie/config.toml` declares `setup_packages` and no `.leerie/Dockerfile` exists, the launcher generates an apt-install Dockerfile at `.leerie/Dockerfile` (atomic write via temp file + `mv`) before the build-decision block. A committed Dockerfile always takes precedence — `setup_packages` is ignored when both exist.
+**Auto-generation triggers**: when no `.leerie/Dockerfile` exists, the launcher generates one at `.leerie/Dockerfile` (atomic write via temp file + `mv`) before the build-decision block if **any** of the following are present: (1) `.leerie/config.toml` declares `setup_packages`, (2) a dependency lockfile exists (`package-lock.json`, `pnpm-lock.yaml`, `requirements.txt`, `Pipfile.lock`, `Gemfile.lock`, `Cargo.lock`, `go.sum`, etc.), or (3) `.leerie/config.toml` declares `language_installs`. A committed Dockerfile always takes precedence — the auto-generation logic is bypassed entirely when one exists.
 
 **`nerdctl run` image arg**: `"${REPO_IMAGE_TAG:-$IMAGE_TAG}"` — falls back to the base image transparently when no repo Dockerfile is present.
 

--- a/docs/IMPLEMENTATION.md
+++ b/docs/IMPLEMENTATION.md
@@ -423,7 +423,8 @@ relevant bash surface:
 ### Persistent out-of-repo dependency bake
 
 Dependencies are installed once at image-build time into persistent paths
-outside `/work`. The concrete bake targets and environment variables per
+outside `/work`. The concrete bake targets and environment variables the
+Dockerfile emitter and `PROVISION_RECIPE` generator must produce, per
 ecosystem:
 
 | Ecosystem | Bake target | Env var(s) | Notes |
@@ -436,15 +437,15 @@ ecosystem:
 
 **`PROVISION_RECIPE` contract (updated):** For baked ecosystems
 (Python/Ruby/Rust/Go), the recipe injected into implementer/conformer prompts
-is **informational only** — it shows what was baked but does not instruct a
+is **informational only** — it shows what was baked but does **not** instruct a
 per-run install, since the bake already satisfied the dependencies. For
 Node/pnpm repos, the recipe carries the residual offline-relink command (`pnpm
 install --offline --frozen-lockfile`), which workers run when their subtask
 needs built dependencies (e.g., running tests or linting). A config-only or
 docs-only subtask skips the residual step.
 
-**`capture_repo_deps` contract (updated):** The `dep_capture` worker always
-runs at finalize time — it is **not skipped** when a committed
+**`capture_repo_deps` contract (updated):** The `dep_capture` worker **always
+runs** at finalize time — it is **not skipped** when a committed
 `.leerie/Dockerfile` exists. The worker writes only **residual** dependencies
 to `.leerie/config.toml` (`setup_packages` for apt packages workers had to
 install, `language_installs` entries for commands that cannot be baked). For

--- a/docs/IMPLEMENTATION.md
+++ b/docs/IMPLEMENTATION.md
@@ -420,6 +420,53 @@ relevant bash surface:
 
 **`nerdctl run` image arg**: `"${REPO_IMAGE_TAG:-$IMAGE_TAG}"` — falls back to the base image transparently when no repo Dockerfile is present.
 
+### Persistent out-of-repo dependency bake
+
+Dependencies are installed once at image-build time into persistent paths
+outside `/work`. The concrete bake targets and environment variables per
+ecosystem:
+
+| Ecosystem | Bake target | Env var(s) | Notes |
+|---|---|---|---|
+| Python | `/opt/venv` | `VIRTUAL_ENV=/opt/venv`, `PATH` includes `/opt/venv/bin` | Virtual environment activated in the image; workers inherit it |
+| Ruby | `/opt/bundle` | `BUNDLE_PATH=/opt/bundle`, `BUNDLE_APP_CONFIG=/opt/bundle` | Gems installed here; Bundler finds them without per-worktree install |
+| Rust | Baked build artifacts + warmed cache | `CARGO_TARGET_DIR`, `CARGO_HOME` (warmed registry) | `cargo build` reuses compiled deps, no network |
+| Go | Baked cache + warmed modules | `GOCACHE`, `GOMODCACHE` (warmed) | `go build` network-free, reuses module cache |
+| Node/pnpm | Warmed content-addressable store | pnpm store path, `frozenStore` set | Residual per-run: `pnpm install --offline --frozen-lockfile` relinks only |
+
+**`PROVISION_RECIPE` contract (updated):** For baked ecosystems
+(Python/Ruby/Rust/Go), the recipe injected into implementer/conformer prompts
+is **informational only** — it shows what was baked but does not instruct a
+per-run install, since the bake already satisfied the dependencies. For
+Node/pnpm repos, the recipe carries the residual offline-relink command (`pnpm
+install --offline --frozen-lockfile`), which workers run when their subtask
+needs built dependencies (e.g., running tests or linting). A config-only or
+docs-only subtask skips the residual step.
+
+**`capture_repo_deps` contract (updated):** The `dep_capture` worker always
+runs at finalize time — it is **not skipped** when a committed
+`.leerie/Dockerfile` exists. The worker writes only **residual** dependencies
+to `.leerie/config.toml` (`setup_packages` for apt packages workers had to
+install, `language_installs` entries for commands that cannot be baked). For
+fully-baked ecosystems (Python/Ruby/Rust/Go), the captured output is typically
+empty or minimal. For Node/pnpm, it may carry the offline-relink note. The
+worker still writes the `dep_capture.done` sentinel to
+`<run_dir>/dep_capture.done` and sets `dep_capture_done = True` in
+`state.json` after a successful write.
+
+**Dockerfile-emitter gating (spec-level fix):** The auto-generated
+`.leerie/Dockerfile` bake must fire when `setup_packages` is empty but a
+lockfile or `language_installs` entry is present. The existing gating
+(generation body conditioned on `setup_packages` non-empty) is a spec/code
+mismatch: a repo with only language dependencies and no apt packages would
+skip the bake entirely, forcing per-run installs. The corrected spec: generate
+the Dockerfile when **any** of the following are present: (1)
+`setup_packages` non-empty, (2) a dependency lockfile exists (`package-lock.json`,
+`pnpm-lock.yaml`, `requirements.txt`, `Pipfile.lock`, `Gemfile.lock`,
+`Cargo.lock`, `go.sum`, etc.), or (3) `language_installs` is non-empty. This
+aligns the emitter with the design intent (DESIGN §6½ *Persistent out-of-repo
+dependency bake*).
+
 ### Registry publish path (fly.io / remote Machines)
 
 Fly.io Machines pull an image from a registry rather than using a

--- a/docs/IMPLEMENTATION.md
+++ b/docs/IMPLEMENTATION.md
@@ -364,9 +364,9 @@ Base layers (top-down):
   tooling (the LTS Node that hosts `claude` itself) comes first, so a repo
   pinning its own Node/Python version can never shadow it; the per-repo
   `MISE_DATA_DIR/shims` (populated at runtime by `phase_provision`'s
-  `mise install` — DESIGN §6½ *Worker-driven install*) comes next, so a
-  worker's own ad-hoc Bash commands (e.g. `bin/rails test`) reach a
-  repo-pinned runtime by name without an explicit `mise exec --`; and
+  `mise install` — DESIGN §6½ *Persistent out-of-repo dependency bake*)
+  comes next, so a worker's own ad-hoc Bash commands (e.g. `bin/rails test`)
+  reach a repo-pinned runtime by name without an explicit `mise exec --`; and
   `/home/leerie/.local/bin` (where `pip install --user` lands console
   scripts) is deliberately **last**, so a user-installed package can never
   shadow a baked-in binary. Pinned by `tests/test_dockerfile_path.py`.
@@ -3516,7 +3516,7 @@ Maps to `DESIGN.md`: §7 (worker contract), §2 (CLI subprocess form).
 | Preflight | `preflight` | git identity, clean working tree, external `leerie` branch collision (DESIGN §3 *External collision hazard*), `claude` CLI version, live `claude -p` smoke test. Run-id collisions are detected at two points: filesystem side in `State.__init__` (the run dir is created at container start since the run-id is the container/machine ID); git side in `setup-run.sh`'s branch-creation step. `setup-run.sh` repeats the external-branch check as defense-in-depth for `--resume`. Smoke test bypassed by `--skip-smoke`; preflight skipped entirely on `--resume` |
 | 1 Classify | `phase_classify` | one classifier worker → categories + questions. Returned categories are filtered against the 9-name whitelist in `CATEGORIES` (mirrors DESIGN §4); `die()` if none survive. On a fresh (non-resumed) run, `run.json`'s identity fields (`run_id`, `branch`, `working_branch`, `pr_base_branch`, `started_at`, `task`) are written immediately BEFORE this phase runs — not after, as originally implemented — so any early-exit path reachable from classification (including the classification gate's no-work routing, below) sees a fully-identified `run.json` rather than one carrying only `_finish_no_work_run`'s own `{finished_at, no_push, no_verify}` (DESIGN §8 *Reaching the cleared-but-empty state from classification*) |
 |   • Classification gate | `phase_classification_gate` | independent adversarial verifier of the classifier's category set (DESIGN §8 *Independent adversarial verification*). One `classification_judge` worker attacks the chosen categories against the task + codebase; a non-empty `miscategorizations` array (a missing category the work requires, or a spurious one) re-drives `phase_classify` via `_run_checked_loop` (bounded by `judgment_check_rounds`, and cut short earlier by `_run_checked_loop`'s own oscillation guard when a round's issues repeat an earlier round's — DESIGN §8 *The CRITIC retry pattern's oscillation guard*). On exhaustion, `die()`s with the residuals named — UNLESS `st.data["likely_already_satisfied"]` is `True` with non-empty evidence, in which case it routes to `_finish_no_work_run` (the same terminal state `detect_no_work` produces post-plan; DESIGN §8 *Reaching the cleared-but-empty state from classification*) and returns `True`, signaling the caller (`_run_phases`) to stop the pipeline. Gates before provision/plan spend. Runs inside the `plans_after_classify` checkpoint block (DESIGN §6 "Resumable planning"), so a resume past classify skips it. Persists to `state.data["classification_coverage_gate"]`. |
-|   • Provision | `phase_provision` | per-repo dep **detection** (DESIGN §6½ "Worker-driven install"). Always runs; runs after classify so a docs-only run can short-circuit to `kind: none`. Five steps: `.leerie-setup.sh` hook if present → `synth_mise_go_override()` if `go.mod` lacks a `.go-version` / mise.toml go pin → `mise install` at the repo root (reads `.tool-versions` natively; `.nvmrc` / `.python-version` / `.ruby-version` / `rust-toolchain.toml` via image-set `MISE_IDIOMATIC_VERSION_FILE_ENABLE_TOOLS`) → version capture via `mise ls --current --json` → `detect_recipe_from_lockfiles()` table-first, falls back to a `provision` worker on table miss. The recipe is **persisted to `st.data["provision"]["recipe"]` and injected into implementer/conformer prompts as a `PROVISION_RECIPE:` block** — workers run install commands themselves in their own worktrees (not the orchestrator at `repo_root`, which would clobber the host's bind-mounted checkout). The synth-go-pin env var `MISE_OVERRIDE_CONFIG_FILENAMES` is exported to `os.environ` so all downstream worker subprocesses inherit it. `mise install` and `.leerie-setup.sh` run through `run_streaming` so their output is visible live. Skipped on `--resume` when `st.data["provision"]["recipe"]` is already present (key-presence, not truthiness — an empty recipe is a valid completed state; DESIGN §6 "Resumable planning"); the env var is re-exported from persisted state on resume. |
+|   • Provision | `phase_provision` | per-repo dep **detection** (DESIGN §6½ *Persistent out-of-repo dependency bake*). Always runs; runs after classify so a docs-only run can short-circuit to `kind: none`. Five steps: `.leerie-setup.sh` hook if present → `synth_mise_go_override()` if `go.mod` lacks a `.go-version` / mise.toml go pin → `mise install` at the repo root (reads `.tool-versions` natively; `.nvmrc` / `.python-version` / `.ruby-version` / `rust-toolchain.toml` via image-set `MISE_IDIOMATIC_VERSION_FILE_ENABLE_TOOLS`) → version capture via `mise ls --current --json` → `detect_recipe_from_lockfiles()` table-first, falls back to a `provision` worker on table miss. The recipe is **persisted to `st.data["provision"]["recipe"]` and injected into implementer/conformer prompts as a `PROVISION_RECIPE:` block** — for baked ecosystems (Python/Ruby/Rust/Go), the block is informational only; for Node, it carries the residual offline-relink command (not run by the orchestrator at `repo_root`, which would clobber the host's bind-mounted checkout). The synth-go-pin env var `MISE_OVERRIDE_CONFIG_FILENAMES` is exported to `os.environ` so all downstream worker subprocesses inherit it. `mise install` and `.leerie-setup.sh` run through `run_streaming` so their output is visible live. Skipped on `--resume` when `st.data["provision"]["recipe"]` is already present (key-presence, not truthiness — an empty recipe is a valid completed state; DESIGN §6 "Resumable planning"); the env var is re-exported from persisted state on resume. |
 |   • Provision gate | `phase_provision_gate` | independent adversarial verifier of the detected install recipe (DESIGN §8, §6½). One `provision_judge` worker attacks `st.data["provision"]["recipe"]` against the image/runtime — catching the semantic gaps the deterministic `_normalize_pip_installs` / `validate_provision_recipe` miss (a `pip install` missing `--break-system-packages` on the externally-managed Debian image, a package manager that doesn't match the lockfiles present). A non-empty `recipe_failures` array `die()`s immediately with the judge's concrete `fix` named — **detect-and-die, single pass** (no re-drive: a table recipe re-emits identically and an LLM recipe would re-produce the same defect, so re-driving only burns rounds before dying anyway; a broken recipe is fatal, matching `phase_provision`'s own recipe-validation die). A `provision_judge` `WorkerError` degrades (the deterministic checks already ran). Skipped when no recipe was detected (`kind: none`); runs inside the `plans_after_classify` checkpoint block so a resume past classify skips it. Persists to `state.data["provision_recipe_gate"]`. |
 |   • Clarify *(optional)* | `gather_answers` | source-of-truth is satisfied non-interactively from the resolved preference (default `both`). Intent questions from the classifier are dropped by default; pass `--clarify` to surface them. With `--clarify` + interactive: collect; with `--clarify` + non-interactive: write `pending-questions.json`, exit code 10 (DESIGN §11) |
 | 2 Plan | `phase_artifact_registry`, `phase_plan` | **First: `phase_artifact_registry`** runs a single read-only `artifact_registry` worker (after classify, before any planner) that emits a small canonical `{description, tag, path}` vocabulary for the artifacts the task will plainly create (DESIGN §5 *Artifact-registry worker*). Persisted to `state.data["artifact_registry"]` (own resume checkpoint, keyed on presence — `[]` is a valid completed state); `phase_plan` injects it into every planner's `ctx_dict` so blind parallel planners prefer the same tag/path. Best-effort/non-fatal — never die()s, returns `[]` when the worker crashes every round or genuinely finds nothing to register; `--skip-repo-map` only suppresses the repo-map context handed to the worker (mirroring `phase_plan`'s own degrade) — the worker still runs and can still return a non-empty list. **Then `phase_plan`:** one planner worker per category, awaited concurrently via `gather_or_cancel` (a small wrapper around `asyncio.gather` defined in `leerie.py`) under an `asyncio.Semaphore(max_parallel)`; the first worker exception cancels its siblings and propagates to `main()`. After all `plan_one` results are collected, P1 Layer C runs: each first-pass subtask in each plan is expanded through `recursive_decompose(subtask, depth=0, …)` and `plan["subtasks"]` is replaced with the union of all returned leaves (DESIGN §5½ *Wire-in to phase_plan*). A plan with no subtasks is left untouched. Expansion vanishes each split parent's id, so the loop records `{parent_id: [leaf_ids]}` for every parent absent from its own leaves and then calls `_remap_vanished_deps(all_leaves, expansion)` **once over every plan's leaves after every plan has expanded** — a dependent may live in a different category's plan than the parent it names (DESIGN §5 *Id-vanishing operations*). The downstream path (reconcile → overlap_judge → schedule → validate_plan → write_plan) receives this expanded flat leaf set unchanged. |
@@ -5204,19 +5204,20 @@ Six host caches mounted into the container, all `rw`. Listed in §0.5
   Bundler 2.2+; all supported Ruby versions ship a sufficiently recent
   Bundler.
 
-### Worker-driven install (replaces per-worktree replay)
+### Persistent bake + residual worker install
 
 `scripts/new-worktree.sh` does just the `git worktree add` and prints
-the worktree path. There is **no orchestrator-driven install** after
-that — the implementer runs the install itself from its own worktree
-via its Bash tool, against the shared package-manager caches. The
-conformer does the same before running BUILD/LINT/TEST.
+the worktree path. Worktrees inherit the persistent bake from the
+image (DESIGN §6½ *Persistent out-of-repo dependency bake*) with zero
+or minimal install cost. There is **no orchestrator-driven install**
+after the worktree is created.
 
-How the recipe reaches the worker:
+How dependencies reach the worker:
 
 1. `git worktree add` checks out the worktree (tracked files only).
-   It starts with no `node_modules/` / `.venv/` / `target/`, by
-   design.
+   It starts with no `node_modules/` / `.venv/` / `target/` by
+   design, but the persistent bake at `/opt/venv`, `/opt/bundle`,
+   etc. is already present in the image.
 2. The orchestrator parses the worktree path from the script's stdout.
 3. `run_implementer` (and later `run_conformer`) read
    `st.data["provision"]["recipe"]` and inject it as a
@@ -5224,29 +5225,32 @@ How the recipe reaches the worker:
    `_format_provision_recipe_section(...)`.
 4. The worker's prompt (see `prompts/implementer.md` §2 and
    `prompts/conformer.md` §Input) instructs it to decide whether the
-   subtask needs the install and to run the command from its
-   worktree if yes. The shared store / cache makes re-runs across
-   worktrees fast.
-5. If the recipe is missing or empty (docs-only run), no
-   `PROVISION_RECIPE:` block is injected and the worker proceeds
-   without one.
+   subtask needs the residual install step (for Node: the offline
+   relink; for Python/Ruby/Rust/Go: typically nothing) and to run
+   the command from its worktree if needed. For fully-baked
+   ecosystems, the `PROVISION_RECIPE:` block is informational only.
+5. If the recipe is missing or empty (docs-only run, or fully-baked
+   with no residual), no `PROVISION_RECIPE:` block is injected and
+   the worker proceeds without one.
 6. Install failures inside a worker surface through the worker's
    normal exit machinery — a hard-failing build/test in the
    implementer becomes a `failed` or `blocked` status; in the
    conformer it surfaces as a `tests-failed: …` advisory warning
    (DESIGN §9).
 
-Why this shape (vs. an orchestrator-driven install at `repo_root` or
-per-worktree replay):
+Why this shape (persistent bake + residual worker install):
 
 - The host's repo is bind-mounted at `repo_root`, so an
-  orchestrator-driven install there writes linux-arm64 native
+  orchestrator-driven install there would write linux-arm64 native
   binaries into the host's darwin `node_modules`, corrupting the
   host's checkout.
-- Per-worktree pre-install is wasted work for subtasks that don't
-  need built deps (config-only, doc-only, pure-code refactors that
-  don't run tests). The barnacle reference run showed ~half of
-  implementer subtasks correctly skip install when given the choice.
+- Per-worktree pre-install wastes work for subtasks that don't need
+  built deps (config-only, doc-only, pure-code refactors that don't
+  run tests). The persistent bake eliminates this waste for
+  Python/Ruby/Rust/Go; Node's residual relink is minimal.
+- The bake is shared read-only across concurrent worktrees, so
+  dependency installs are paid once per image build, not once per
+  worktree.
 - `claude -p`'s built-in stream-event plumbing surfaces Bash tool
   I/O to the orchestrator log live, so an install running inside a
   worker is visible to the user without any special orchestrator


### PR DESCRIPTION
## Summary

Reverses the `docs/DESIGN.md` §6½ "worker-driven install" design in favor of a persistent, out-of-`/work` dependency bake (`/opt/venv`, `/opt/bundle`, baked `CARGO_TARGET_DIR`/`GOCACHE`, warmed pnpm store), and propagates the corresponding code-surface spec into `docs/IMPLEMENTATION.md` §0.5. Per `CLAUDE.md`'s three-layer rule, this is docs-only — no orchestrator/Dockerfile/script/test changes.

## Which layer(s) does this PR touch?

(See [`CLAUDE.md`](../CLAUDE.md) for the three-layer rule.)

- [x] `docs/DESIGN.md` (architecture)
- [x] `docs/IMPLEMENTATION.md` (code surface)
- [ ] `orchestrator/leerie.py` (code)
- [ ] docs (`README.md`, `docs/USAGE.md`, `CONTRIBUTING.md`, etc.)
- [ ] tests (`tests/`)
- [ ] CI / repo meta (`.github/`)

If multiple, has the change propagated **top-down** per the three-layer rule
(DESIGN → IMPLEMENTATION → code)?

- [x] yes
- [ ] not applicable (single layer)

## Task-completion checklist

(Mirrors `CLAUDE.md` and `CONTRIBUTING.md`.)

- [x] `docs/IMPLEMENTATION.md` updated if code surface changed
- [x] `docs/DESIGN.md` updated if architecture changed
- [ ] `pytest tests/` passes
- [ ] `python3 -c "import ast; ast.parse(open('orchestrator/leerie.py').read())"` passes
- [x] `git diff --stat` reviewed for scope (no collateral edits)

## Testing notes

No test coverage added — this run is a docs-only design reversal (`orchestrator/leerie.py`, `Dockerfile`, `scripts/*.sh`, and `tests/` are untouched by design; a separate follow-up task implements the code). `git diff --stat` confirms the change is scoped to `docs/DESIGN.md` and `docs/IMPLEMENTATION.md` only.

Note for reviewers: the run's final conformance pass logged an advisory warning — "final conformer round 0: reverted/deleted 1 integrated file(s): ['docs/IMPLEMENTATION.md (reverted-to-base)']" — before landing on the final diff. No residuals or failed build/lint/test axes were reported; worth a quick sanity read of the `IMPLEMENTATION.md` diff during review given that history.

## Related issue

<!-- Closes #N -->
