### PR TITLE
leerie: add AWS_BEARER_TOKEN_BEDROCK static bearer-token Bedrock auth

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -315,6 +315,21 @@ export LEERIE_EC2_SUBNET_ID=subnet-0123456789abcdef0
   --ec2-key-name my-ec2-keypair --ec2-security-group sg-0123456789abcdef0 \
   --ec2-subnet-id subnet-0123456789abcdef0
 
+# Route model calls through Amazon Bedrock via a static bearer token — the
+# Bedrock analogue of CLAUDE_CODE_OAUTH_TOKEN. Needs no `aws` CLI, no SSO
+# session, and no ~/.aws/ staging (unlike the settings.json-driven
+# CLAUDE_CODE_USE_BEDROCK + `aws sso login` mode, whose SSO token the
+# container cannot refresh). AWS_REGION is optional (the CLI defaults to
+# us-east-1); CLAUDE_CODE_USE_BEDROCK defaults to 1 once the bearer token is
+# set, but can still be overridden explicitly. If both this bearer token and
+# a settings.json CLAUDE_CODE_USE_BEDROCK are present, the bearer token wins.
+# Note: if also using --runtime ec2, its AWS_REGION-consuming preflight
+# (require_aws) can pick up this same var — set LEERIE_AWS_REGION explicitly
+# if you want a different EC2-provisioning region than the Bedrock region.
+export AWS_BEARER_TOKEN_BEDROCK=<token>
+export AWS_REGION=us-east-1              # optional, forwarded when set
+./leerie "task"
+
 # Choose the model. Without overrides, every worker — judgment (classifier,
 # planner, reconciler, plan_overlap_judge, provision, integrator) and acting
 # (implementer, conformer) alike — defaults to sonnet. Per-worker overrides
@@ -2264,6 +2279,71 @@ hard gate on missing/bogus data; and two constant pins confirm the
 threshold is exactly 90 minutes and that the launcher never hard-codes
 an 8-hour TTL assumption anywhere (the community-reported 2–15h range
 is why `expiresAt` must be read, never assumed).
+The Bedrock bearer-token auth path (`AWS_BEARER_TOKEN_BEDROCK` — the
+static-credential analogue of `CLAUDE_CODE_OAUTH_TOKEN` for Bedrock,
+DESIGN §6 *Credential strategy*: preferred over the pre-existing
+settings.json-driven SSO/profile Bedrock path since a container cannot
+refresh a short-lived SSO token any more than it can refresh a subscription
+OAuth session) is tested in `tests/test_bedrock_bearer_token.py`: the
+bearer token is forwarded verbatim alongside a `CLAUDE_CODE_USE_BEDROCK`
+default of `1` (confirmed live against the real CLI that the token alone is
+a no-op without this flag — the CLI falls through to firstParty/OAuth
+dispatch otherwise) and an optional `AWS_REGION`; an explicit
+`CLAUDE_CODE_USE_BEDROCK=0` override still wins over the default; the
+bearer-token path never invokes `bedrock_preflight()`/`aws sts
+get-caller-identity` and mounts no `~/.aws`, even when `aws` is present and
+would fail; the bearer-token path wins when both it and a settings.json
+`CLAUDE_CODE_USE_BEDROCK=1` are present (matching the real CLI's own
+credential-resolution order — its Bedrock client construction
+short-circuits SSO/profile resolution once `AWS_BEARER_TOKEN_BEDROCK` is
+set); and the pre-existing SSO/profile path is unaffected when the bearer
+token is absent (regression control). The Fly detached-launch heredoc gets
+its own dedicated coverage for three defects found and fixed during
+implementation, since the heredoc is unquoted (`<<PY`) and therefore
+substitutes shell expansions inside what looks like inert Python comment
+text: (1) a raw `"${AWS_BEARER_TOKEN_BEDROCK}"` string substitution let a
+token containing `"`/`\` break out of the Python string literal and run as
+arbitrary code on the remote Fly machine — fixed by JSON-encoding every
+heredoc-substituted value host-side (mirroring the pre-existing
+`_launch_argv_json` technique), pinned by
+`test_fly_heredoc_values_are_json_encoded_not_raw` and three live
+end-to-end tests (`test_malicious_token_with_quote_does_not_break_out_of_python_literal`,
+`test_malicious_token_with_backslash_does_not_break_out`,
+`test_normal_token_unaffected_by_json_encoding`) that extract the real
+JSON-encoding lines and `child_env[...]` block verbatim from the launcher,
+splice them into a harness, and actually pipe the result through
+`python3 -`; (2) a first-draft fix comment containing the literal text
+`${VAR}` crashed the entire launcher with `unbound variable` under
+`set -u` on every Bedrock bearer-token Fly launch (worse than the injection
+defect, since it fired unconditionally rather than only on a hostile
+token) — pinned by
+`test_child_env_heredoc_body_has_no_stray_unbound_var_substitution`, which
+scans the real extracted heredoc body for any `${...}`-shaped token outside
+an explicit allowlist of the known, intentional substitution names; (3) a
+balanced backtick pair in a comment (`` `if <json>:` ``) was parsed by bash
+as a command-substitution delimiter — a different expansion mechanism than
+`${...}`, so unguarded by the previous fix — printing a spurious `syntax
+error: unexpected end of file` to the user's terminal on every launch and
+silently dropping that comment's text from the script sent to the remote
+machine (caught by diffing `shellcheck -x leerie` against `git stash`,
+since `bash -n` does not catch it) — pinned by
+`test_child_env_heredoc_body_has_no_backtick_characters`. All three
+regression tests were falsified live (reintroducing each exact defect and
+confirming the corresponding test fails, then re-confirming it passes on
+the fix) rather than trusted on inspection alone.
+Since the existing Bedrock SSO/profile path (`detect_bedrock_mode()` /
+`bedrock_preflight()`) shipped with zero test coverage before this work,
+`tests/test_bedrock_mode.py` closes that gap: `detect_bedrock_mode()`'s
+3-file merge and truthy-value matching (`1`/`true`/`yes`/`on`,
+case-insensitive, OR semantics since the flag has no "disable" value, and
+tolerance of a malformed settings file); and `bedrock_preflight()`'s three
+outcomes (missing `aws` binary, a failing `aws sts get-caller-identity`
+simulating an expired/missing SSO token — with and without an `AWS_PROFILE`
+naming the profile in the recovery hint — and a valid SSO session). Both
+files extract `detect_bedrock_mode()`/`bedrock_preflight()` verbatim from
+the launcher via source-slicing (same discipline as
+`test_launcher_env_forwarding.py`'s `_extract_forwarding_loop`) rather than
+reproducing them by hand.
 The terminal auth-failure classifier and its full routing path — the
 `b57027d3…` incident this run's credential-strategy work responds to,
 where a container's expired OAuth session surfaced as "worker failed

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -1938,6 +1938,35 @@ sets `CLAUDE_CODE_OAUTH_TOKEN` — the same long-lived-token launch this
 section already recommends structurally avoids the failure in the first
 place.
 
+**The same refresh-vs-static distinction applies to Bedrock auth.** The
+launcher's Bedrock support (§"Finalization" above) predates this section
+and defaults to AWS SSO/profile auth: `detect_bedrock_mode()` reads
+`CLAUDE_CODE_USE_BEDROCK` out of the merged Claude `settings.json` files,
+then `bedrock_preflight()` requires the host `aws` CLI and a live `aws sts
+get-caller-identity` before staging `~/.aws/` (config + SSO token cache)
+read-only into the container. SSO access tokens are short-lived (~12h) and
+refreshed only by the host's interactive `aws sso login` browser flow — a
+non-interactive container cannot do that either, the identical
+container-cannot-refresh problem this section already solved for
+subscription auth via `CLAUDE_CODE_OAUTH_TOKEN`.
+
+`AWS_BEARER_TOKEN_BEDROCK` is the Bedrock analogue: a static bearer
+credential the Claude CLI sends as `Authorization: Bearer <token>` directly
+to the Bedrock runtime endpoint, with no refresh-token/expiry machinery
+anywhere near it (verified against the CLI's own bundled source and live
+end-to-end testing — the token alone is a no-op unless
+`CLAUDE_CODE_USE_BEDROCK` is also set, since the CLI otherwise falls
+through to its firstParty/OAuth dispatch path). Because it needs no `aws`
+CLI, no SSO session, and no `~/.aws/` staging, leerie triggers this path
+from a plain host env var (`AWS_BEARER_TOKEN_BEDROCK`), independent of the
+settings.json-driven `detect_bedrock_mode()` gate, and skips
+`bedrock_preflight()`/the `~/.aws` mount entirely when it is set — mirroring
+this section's existing precedent of preferring the credential immune to
+the expiry failure class over the one that requires host-side refresh.
+When both are present, the bearer token wins, matching the Claude CLI's own
+credential-resolution order (its Bedrock client construction short-circuits
+SSO/profile resolution once `AWS_BEARER_TOKEN_BEDROCK` is set).
+
 **Decomposition needs the same discipline against the loss of
 in-progress spend.** §5½ (P1)'s `fit_judge` and coupled-minority
 `splitter` calls have no crash barrier today: a single `WorkerError`

--- a/docs/IMPLEMENTATION.md
+++ b/docs/IMPLEMENTATION.md
@@ -742,7 +742,8 @@ The launcher passes the following mounts to `nerdctl run`:
 | `$STAGE/.config/git` (per-run host scratch) | `/home/leerie/.config/git` | rw | XDG-style git config (`~/.config/git/config`, `~/.config/git/ignore`) copied per-container. |
 | `$STAGE/.ssh` (per-run host scratch) | `/home/leerie/.ssh` | rw | Per-container copy of `~/.ssh/` with `agent/`, `S.*`, and `*.sock` excluded — host UNIX sockets aren't reachable from inside the container and `cp -a` on them is pointless. Keys and `known_hosts` ride along so workers can SSH-push if needed. Permissions set to `0700`. |
 | `$STAGE/.gnupg` (per-run host scratch) | `/home/leerie/.gnupg` | rw | Per-container copy of `~/.gnupg/` with agent socket files (`S.gpg-agent*`, `S.scdaemon`, `S.keyboxd`) excluded and `use-keyboxd` stripped from `common.conf` (the container cannot reach the host keyboxd daemon; stripping the directive makes gpg fall back to file-based `pubring.kbx` lookup — on keyboxd-only hosts signing keys become unfindable, which is acceptable since commit signing is best-effort). Keyrings + `trustdb.gpg` ride along so workers can `git commit -S` if signing is configured. Permissions set to `0700`. |
-| `$STAGE/.aws` (per-run host scratch, **Bedrock mode only**) | `/home/leerie/.aws` | **ro** | Staged when `detect_bedrock_mode()` finds `CLAUDE_CODE_USE_BEDROCK` set to a truthy value (`1`, `true`, `yes`, or `on`, case-insensitive — matching Claude CLI's `isEnvTruthy`) in the `env` block of any of the three settings files the Claude CLI merges (`~/.claude/settings.json` (userSettings), `<USER_REPO>/.claude/settings.json` (projectSettings), `<USER_REPO>/.claude/settings.local.json` (localSettings)). The Claude CLI's AWS SDK resolves credentials via pure file I/O — reads `~/.aws/config` (profile + SSO session config) and `~/.aws/sso/cache/*.json` (SSO access tokens, ~12 h TTL) directly; no `aws` binary is needed inside the container. `~/.aws/cli/cache` is excluded (CLI result cache; large, irrelevant to auth). Mounted **read-only** because workers never write credentials. The `aws` binary (`awsAuthRefresh`) is a host-only concern: `aws sso login` requires an interactive TTY/browser and cannot run inside a non-interactive container; `bedrock_preflight()` catches an expired SSO token on the host before the container starts and prints the recovery hint (`aws sso login --profile <profile>`). On the Fly.io path, `$STAGE/.aws/` is included in the tar pipe to `seed_auth` automatically (`.aws` is not in the seed-auth exclude list) and lands at `/home/leerie/.aws/` on the remote machine. Belt-and-suspenders: when Bedrock mode is active, the launcher also injects `CLAUDE_CODE_USE_BEDROCK=1`, `AWS_PROFILE`, and `AWS_REGION` as explicit env vars — via `AUTH_MOUNTS` `-e` flags on the local nerdctl path and via `child_env` in the Fly detached-launch heredoc — so workers activate Bedrock through `process.env` independently of how the in-container claude binary handles `settings.json` env blocks. |
+| `$STAGE/.aws` (per-run host scratch, **Bedrock SSO/profile mode only**) | `/home/leerie/.aws` | **ro** | Staged when `detect_bedrock_mode()` finds `CLAUDE_CODE_USE_BEDROCK` set to a truthy value (`1`, `true`, `yes`, or `on`, case-insensitive — matching Claude CLI's `isEnvTruthy`) in the `env` block of any of the three settings files the Claude CLI merges (`~/.claude/settings.json` (userSettings), `<USER_REPO>/.claude/settings.json` (projectSettings), `<USER_REPO>/.claude/settings.local.json` (localSettings)) — and only when `AWS_BEARER_TOKEN_BEDROCK` (see below) is **not** set on the host; the bearer-token path needs none of this. The Claude CLI's AWS SDK resolves credentials via pure file I/O — reads `~/.aws/config` (profile + SSO session config) and `~/.aws/sso/cache/*.json` (SSO access tokens, ~12 h TTL) directly; no `aws` binary is needed inside the container. `~/.aws/cli/cache` is excluded (CLI result cache; large, irrelevant to auth). Mounted **read-only** because workers never write credentials. The `aws` binary (`awsAuthRefresh`) is a host-only concern: `aws sso login` requires an interactive TTY/browser and cannot run inside a non-interactive container; `bedrock_preflight()` catches an expired SSO token on the host before the container starts and prints the recovery hint (`aws sso login --profile <profile>`). On the Fly.io path, `$STAGE/.aws/` is included in the tar pipe to `seed_auth` automatically (`.aws` is not in the seed-auth exclude list) and lands at `/home/leerie/.aws/` on the remote machine. Belt-and-suspenders: when Bedrock SSO/profile mode is active, the launcher also injects `CLAUDE_CODE_USE_BEDROCK=1`, `AWS_PROFILE`, and `AWS_REGION` as explicit env vars — via `AUTH_MOUNTS` `-e` flags on the local nerdctl path and via `child_env` in the Fly detached-launch heredoc — so workers activate Bedrock through `process.env` independently of how the in-container claude binary handles `settings.json` env blocks. |
+| `AWS_BEARER_TOKEN_BEDROCK` (host env var, **Bedrock bearer-token mode**) | forwarded as `-e`/`child_env` only — **no bind mount** | n/a | The static-bearer-token analogue of `CLAUDE_CODE_OAUTH_TOKEN`, triggered by a plain host env var independently of `detect_bedrock_mode()`'s settings.json scan, and taking precedence over the SSO/profile path above when both are present (matching the Claude CLI's own credential-resolution order — verified live against the CLI, v2.1.220: its Bedrock client construction short-circuits SSO/profile resolution once `AWS_BEARER_TOKEN_BEDROCK` is set). No `aws` CLI, no SSO session, no `~/.aws` staging — `bedrock_preflight()` is skipped entirely on this path. The launcher forwards `AWS_BEARER_TOKEN_BEDROCK` verbatim, `CLAUDE_CODE_USE_BEDROCK` (defaulting to `1` if the host didn't set it — confirmed live that the bearer token alone is a no-op without this flag, since the CLI otherwise falls through to firstParty/OAuth dispatch), and `AWS_REGION` when set (optional — the CLI defaults to `us-east-1`) as explicit `-e` flags on the local nerdctl path and `child_env` entries in the Fly detached-launch heredoc, mirroring the `CLAUDE_CODE_OAUTH_TOKEN` forwarding pattern above rather than the SSO path's settings.json extraction. On the Fly path specifically, every value substituted into the detached-launch heredoc (the bearer token, region, and use-bedrock flag, plus the pre-existing `_BEDROCK_PROFILE`/`_BEDROCK_REGION`/host-TZ values) is JSON-encoded host-side first (`python3 -c 'import json,sys; print(json.dumps(sys.argv[1]))'`, the same technique `_launch_argv_json` already uses for orchestrator argv) rather than substituted as a raw `"${VAR}"` string — an opaque bearer token is exactly the kind of value likely to contain a `"` or `\` that would otherwise break out of the Python string literal and execute as arbitrary code on the remote machine. |
 
 The four host-auth mounts (`~/.config/gh`, `~/.git-credentials`, `~/.ssh`,
 `$SSH_AUTH_SOCK`) that earlier versions of leerie bind-mounted **no longer
@@ -5934,16 +5935,35 @@ child_env["USER_REPO"] = "$(basename "$USER_REPO")"
 # `readlink /etc/localtime | sed 's|.*/zoneinfo/||'` (works on
 # macOS and Linux). Dockerfile installs `tzdata` so the IANA name
 # resolves; empty value → Python astimezone() falls back to UTC.
-child_env["TZ"] = "${_host_tz}"
-# Belt-and-suspenders Bedrock activation (when _BEDROCK_ACTIVE=true on
-# the host): variables substituted host-side before the script is piped
-# to the machine (same pattern as USER_REPO and TZ above).
-if "${_BEDROCK_ACTIVE}" == "true":
+child_env["TZ"] = ${_host_tz_json}
+# Bedrock bearer-token activation (when _BEDROCK_BEARER_ACTIVE=true on the
+# host): takes precedence over the SSO/profile block below, mirroring the
+# nerdctl path's AUTH_MOUNTS ordering. Every value below is JSON-encoded
+# host-side (via a `python3 -c 'import json,sys; print(json.dumps(...))'`
+# call per variable, same technique _launch_argv_json above already uses
+# for argv) rather than substituted as a raw quoted-var string — a raw
+# substitution is not injection-safe: an opaque secret like a bearer token
+# is exactly the kind of value likely to contain a double-quote or
+# backslash that would otherwise break out of the Python string literal
+# and run as arbitrary code on this remote machine. A JSON-encoded empty
+# string is falsy in Python, so the truthiness checks below behave the
+# same as unset. NOTE: this heredoc is unquoted (<<PY) -- never put a
+# backtick pair in a comment here, since bash treats it as a
+# command-substitution delimiter even inside heredoc body text.
+if "${_BEDROCK_BEARER_ACTIVE}" == "true":
+    child_env["AWS_BEARER_TOKEN_BEDROCK"] = ${_bedrock_bearer_token_json}
+    child_env["CLAUDE_CODE_USE_BEDROCK"] = ${_bedrock_use_bedrock_json}
+    if ${_bedrock_bearer_region_json}:
+        child_env["AWS_REGION"] = ${_bedrock_bearer_region_json}
+# Belt-and-suspenders Bedrock SSO/profile activation (when
+# _BEDROCK_ACTIVE=true on the host), skipped when the bearer-token block
+# above already activated:
+elif "${_BEDROCK_ACTIVE}" == "true":
     child_env["CLAUDE_CODE_USE_BEDROCK"] = "1"
-    if "${_BEDROCK_PROFILE}":
-        child_env["AWS_PROFILE"] = "${_BEDROCK_PROFILE}"
-    if "${_BEDROCK_REGION}":
-        child_env["AWS_REGION"] = "${_BEDROCK_REGION}"
+    if ${_bedrock_profile_json}:
+        child_env["AWS_PROFILE"] = ${_bedrock_profile_json}
+    if ${_bedrock_region_json}:
+        child_env["AWS_REGION"] = ${_bedrock_region_json}
 extra_path = "/usr/local/share/mise/installs/node/lts-current/bin"
 if extra_path not in child_env.get("PATH", ""):
     child_env["PATH"] = extra_path + ":" + child_env.get("PATH", "")

--- a/leerie
+++ b/leerie
@@ -5543,7 +5543,30 @@ if [ -d "$HOME/.gnupg" ]; then
   fi
 fi
 
-# -- ~/.aws/ (Bedrock mode only) --
+# -- Bedrock bearer-token mode (AWS_BEARER_TOKEN_BEDROCK) --
+# The static-bearer-token analogue of CLAUDE_CODE_OAUTH_TOKEN: a plain,
+# non-expiring-by-refresh credential the Claude CLI sends as
+# `Authorization: Bearer <token>` directly to the Bedrock runtime endpoint.
+# Unlike SSO/profile Bedrock auth below, it needs no `aws` CLI, no SSO
+# session, and no ~/.aws/ staging — verified live against the Claude CLI
+# (v2.1.220): the bearer token alone does nothing (the CLI falls through to
+# firstParty/OAuth) unless CLAUDE_CODE_USE_BEDROCK is also set, so this
+# block always forwards both. Triggered by a plain host env var, independent
+# of the settings.json-driven detect_bedrock_mode() below — and takes
+# precedence over it, mirroring the CLI's own credential resolution (its
+# Bedrock client construction short-circuits SSO/profile resolution when
+# AWS_BEARER_TOKEN_BEDROCK is set) and DESIGN §6's "prefer the credential
+# immune to the container-can't-refresh failure class" precedent for
+# CLAUDE_CODE_OAUTH_TOKEN vs Keychain.
+_BEDROCK_BEARER_ACTIVE=false
+if [ -n "${AWS_BEARER_TOKEN_BEDROCK:-}" ]; then
+  _BEDROCK_BEARER_ACTIVE=true
+  AUTH_MOUNTS+=(-e "AWS_BEARER_TOKEN_BEDROCK=$AWS_BEARER_TOKEN_BEDROCK")
+  AUTH_MOUNTS+=(-e "CLAUDE_CODE_USE_BEDROCK=${CLAUDE_CODE_USE_BEDROCK:-1}")
+  [ -n "${AWS_REGION:-}" ] && AUTH_MOUNTS+=(-e "AWS_REGION=$AWS_REGION")
+fi
+
+# -- ~/.aws/ (Bedrock SSO/profile mode only) --
 # The Claude CLI's AWS SDK resolves credentials via pure file I/O:
 #   ~/.aws/config          — profile definition + SSO session config
 #   ~/.aws/sso/cache/*.json — cached SSO access tokens (~12 h TTL)
@@ -5551,10 +5574,13 @@ fi
 # No aws binary is needed inside the container for normal operation.
 # cli/cache is excluded (CLI result cache; large, irrelevant to auth).
 # Mount read-only: workers never write AWS credentials.
+# Skipped entirely when the bearer-token block above is active: no aws
+# CLI/SSO dependency for that path, and the CLI prefers the bearer token
+# over SSO/profile credentials anyway when both are present.
 _BEDROCK_ACTIVE=false
 _BEDROCK_PROFILE=""
 _BEDROCK_REGION=""
-if detect_bedrock_mode; then
+if [ "$_BEDROCK_BEARER_ACTIVE" = "false" ] && detect_bedrock_mode; then
   _BEDROCK_ACTIVE=true
   if [ ! -d "$HOME/.aws" ]; then
     remote_log "error: Bedrock mode is enabled but ~/.aws/ not found on host."
@@ -6251,6 +6277,20 @@ print(json.dumps(sys.argv[1:]))
         # name. Empty if /etc/localtime isn't a symlink — Python's
         # astimezone() then falls back to UTC.
         _host_tz="$(readlink /etc/localtime 2>/dev/null | sed 's|.*/zoneinfo/||')"
+        # JSON-encode every value substituted into the heredoc below as a
+        # Python string literal (same technique _launch_argv_json already
+        # uses for argv) — a raw "${VAR}" substitution is not injection-safe:
+        # a value containing `"` or `\` breaks out of the literal and runs
+        # as arbitrary Python on the remote machine. Load-bearing for
+        # AWS_BEARER_TOKEN_BEDROCK specifically (an opaque secret token is
+        # exactly the kind of value likely to contain such bytes), applied
+        # to every substituted value here for consistency.
+        _host_tz_json="$(python3 -c 'import json, sys; print(json.dumps(sys.argv[1]))' "$_host_tz")"
+        _bedrock_bearer_token_json="$(python3 -c 'import json, sys; print(json.dumps(sys.argv[1]))' "${AWS_BEARER_TOKEN_BEDROCK:-}")"
+        _bedrock_use_bedrock_json="$(python3 -c 'import json, sys; print(json.dumps(sys.argv[1]))' "${CLAUDE_CODE_USE_BEDROCK:-1}")"
+        _bedrock_bearer_region_json="$(python3 -c 'import json, sys; print(json.dumps(sys.argv[1]))' "${AWS_REGION:-}")"
+        _bedrock_profile_json="$(python3 -c 'import json, sys; print(json.dumps(sys.argv[1]))' "$_BEDROCK_PROFILE")"
+        _bedrock_region_json="$(python3 -c 'import json, sys; print(json.dumps(sys.argv[1]))' "$_BEDROCK_REGION")"
         _launch_script="$(cat <<PY
 import fcntl, os, pwd, subprocess, sys, time
 argv = ${_launch_argv_json}
@@ -6312,17 +6352,34 @@ child_env["USER_REPO"] = "$(basename "$USER_REPO")"
 # tzdata so /usr/share/zoneinfo/<IANA> resolves. If readlink fails
 # (e.g. /etc/localtime not a symlink), the substitution yields ""
 # and Python's astimezone() falls back to UTC — same as today.
-child_env["TZ"] = "${_host_tz}"
-# Belt-and-suspenders Bedrock activation: inject env vars explicitly so
-# claude -p workers use Bedrock via process.env regardless of whether the
-# settings.json env block is applied by the in-container claude binary.
-# Variables are substituted host-side (heredoc is unquoted <<PY).
-if "${_BEDROCK_ACTIVE}" == "true":
+child_env["TZ"] = ${_host_tz_json}
+# Bedrock bearer-token activation (AWS_BEARER_TOKEN_BEDROCK) -- takes
+# precedence over the SSO/profile block below, mirroring the nerdctl path's
+# AUTH_MOUNTS ordering above. Every value is JSON-encoded host-side before
+# substitution instead of a raw quoted-var string -- an opaque bearer
+# token is exactly the kind of value likely to contain a double-quote or
+# backslash that would otherwise break out of a raw Python string literal
+# and run as arbitrary code on this remote machine (see _launch_argv_json
+# above, which already uses this technique for argv). A JSON-encoded empty
+# string is falsy in Python, so the truthiness checks below behave the
+# same as the unset case. NOTE: this heredoc is unquoted (<<PY) -- never
+# put a backtick pair in a comment here, since bash treats it as a
+# command-substitution delimiter even inside heredoc body text.
+if "${_BEDROCK_BEARER_ACTIVE}" == "true":
+    child_env["AWS_BEARER_TOKEN_BEDROCK"] = ${_bedrock_bearer_token_json}
+    child_env["CLAUDE_CODE_USE_BEDROCK"] = ${_bedrock_use_bedrock_json}
+    if ${_bedrock_bearer_region_json}:
+        child_env["AWS_REGION"] = ${_bedrock_bearer_region_json}
+# Belt-and-suspenders Bedrock SSO/profile activation: inject env vars
+# explicitly so claude -p workers use Bedrock via process.env regardless of
+# whether the settings.json env block is applied by the in-container claude
+# binary. Skipped when the bearer-token block above already activated.
+elif "${_BEDROCK_ACTIVE}" == "true":
     child_env["CLAUDE_CODE_USE_BEDROCK"] = "1"
-    if "${_BEDROCK_PROFILE}":
-        child_env["AWS_PROFILE"] = "${_BEDROCK_PROFILE}"
-    if "${_BEDROCK_REGION}":
-        child_env["AWS_REGION"] = "${_BEDROCK_REGION}"
+    if ${_bedrock_profile_json}:
+        child_env["AWS_PROFILE"] = ${_bedrock_profile_json}
+    if ${_bedrock_region_json}:
+        child_env["AWS_REGION"] = ${_bedrock_region_json}
 # Ensure the launcher's PATH includes the mise-managed claude binary.
 # (The Dockerfile installs claude into the mise-managed node prefix;
 # fly's hallpass ssh session inherits a minimal PATH that may not

--- a/tests/test_bedrock_bearer_token.py
+++ b/tests/test_bedrock_bearer_token.py
@@ -1,0 +1,553 @@
+"""Tests for the Bedrock bearer-token auth path (AWS_BEARER_TOKEN_BEDROCK).
+
+The static-bearer-token analogue of CLAUDE_CODE_OAUTH_TOKEN: a plain,
+non-expiring-by-refresh credential the Claude CLI sends as
+`Authorization: Bearer <token>` directly to the Bedrock runtime endpoint.
+Unlike the existing settings.json-driven SSO/profile Bedrock path
+(`detect_bedrock_mode()` / `bedrock_preflight()`), it needs no `aws` CLI, no
+SSO session, and no ~/.aws/ staging — verified live against the real Claude
+CLI (v2.1.220, see docs/DESIGN.md §6 *Credential strategy*): the bearer
+token alone is a no-op (the CLI falls through to firstParty/OAuth dispatch)
+unless CLAUDE_CODE_USE_BEDROCK is also set.
+
+The harness extracts the real launcher block verbatim (from the
+`_BEDROCK_BEARER_ACTIVE` assignment through the SSO/profile block's closing
+`fi`) so the tests exercise real code, not a copy — same discipline as
+tests/test_launcher_env_forwarding.py's `_extract_forwarding_loop`. Also
+mirrors tests/test_credential_precedence.py's forwarding-block extraction
+approach for the `-e` injection surface.
+"""
+from __future__ import annotations
+
+import json
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+LAUNCHER = REPO_ROOT / "leerie"
+LOG_SH = REPO_ROOT / "scripts" / "remote" / "_log.sh"
+
+# The launcher's own shebang is `#!/usr/bin/env bash` — it runs under
+# whichever bash the invoking PATH resolves first, not necessarily macOS's
+# ancient /usr/bin/bash 3.2 (which has real gaps here: an empty array under
+# `set -u` throws "unbound variable" on bash 3.2 but not modern bash — see
+# CLAUDE.md's bash-3.2 portability discipline for the EC2 scripts). Resolve
+# a real bash from the *test-runner's* PATH once, up front, so the harness
+# subprocess (deliberately given a minimal PATH to isolate the `aws` stub)
+# still runs under the same bash the launcher itself expects.
+_BASH = shutil.which("bash") or "/bin/bash"
+
+
+def _extract_bedrock_block() -> str:
+    """Pull the full Bedrock activation region (bearer-token block +
+    SSO/profile block) verbatim from the launcher, from the
+    `_BEDROCK_BEARER_ACTIVE` assignment through the SSO block's closing
+    `fi`, just before the "Mount each staged file/dir" comment."""
+    src = LAUNCHER.read_text()
+    start = src.index("_BEDROCK_BEARER_ACTIVE=false")
+    end = src.index("# -- Mount each staged file/dir at its default in-container path. --")
+    block = src[start:end]
+    assert "AWS_BEARER_TOKEN_BEDROCK=$AWS_BEARER_TOKEN_BEDROCK" in block
+    assert "detect_bedrock_mode" in block
+    return block
+
+
+def _extract_bedrock_functions() -> str:
+    """Pull detect_bedrock_mode() and bedrock_preflight() verbatim from the
+    launcher so the harness has real implementations, not stubs, for the
+    SSO/profile control-flow paths this module also covers."""
+    src = LAUNCHER.read_text()
+    start = src.index("detect_bedrock_mode() {")
+    end = src.index("\n}\n", src.index("bedrock_preflight() {")) + len("\n}\n")
+    block = src[start:end]
+    assert "detect_bedrock_mode() {" in block
+    assert "bedrock_preflight() {" in block
+    return block
+
+
+_HARNESS = r"""
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ---- shared host-side logging helper (real file, sourced) ---------------
+. "__LOG_SH__"
+
+# ---- detect_bedrock_mode / bedrock_preflight, extracted verbatim --------
+__BEDROCK_FUNCTIONS__
+
+# ---- stub AUTH_MOUNTS-consuming state the block reads/writes ------------
+AUTH_MOUNTS=()
+HOME="__HOME__"
+USER_REPO="__USER_REPO__"
+STAGE="__STAGE__"
+mkdir -p "$STAGE"
+
+# ---- Bedrock activation block, extracted verbatim from the launcher -----
+__BEDROCK_BLOCK__
+
+# ---- emit AUTH_MOUNTS so the test can inspect it -------------------------
+for a in "${AUTH_MOUNTS[@]+"${AUTH_MOUNTS[@]}"}"; do printf '%s\n' "$a"; done
+echo "---"
+echo "BEARER_ACTIVE=$_BEDROCK_BEARER_ACTIVE"
+echo "SSO_ACTIVE=$_BEDROCK_ACTIVE"
+"""
+
+
+def _run(env: dict, *, aws_on_path: bool = False, aws_succeeds: bool = True,
+          settings_json: dict | None = None, home_has_aws: bool = True,
+          tmp_path: Path) -> tuple[int, list[str], bool, bool]:
+    """Run the harness; return (rc, auth_mounts_tokens, bearer_active, sso_active).
+
+    settings_json seeds ~/.claude/settings.json (the SSO path's detection
+    source). home_has_aws controls whether $HOME/.aws exists (the SSO
+    path's precondition check).
+    """
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    (fake_home / ".claude").mkdir()
+    if settings_json is not None:
+        (fake_home / ".claude" / "settings.json").write_text(json.dumps(settings_json))
+    if home_has_aws:
+        (fake_home / ".aws").mkdir()
+
+    user_repo = tmp_path / "repo"
+    user_repo.mkdir()
+
+    stage = tmp_path / "stage"
+
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    if aws_on_path:
+        aws_stub = bin_dir / "aws"
+        aws_stub.write_text(
+            "#!/usr/bin/env bash\n"
+            f"exit {0 if aws_succeeds else 1}\n"
+        )
+        aws_stub.chmod(0o755)
+
+    harness = (
+        _HARNESS
+        .replace("__LOG_SH__", str(LOG_SH))
+        .replace("__BEDROCK_FUNCTIONS__", _extract_bedrock_functions())
+        .replace("__BEDROCK_BLOCK__", _extract_bedrock_block())
+        .replace("__HOME__", str(fake_home))
+        .replace("__USER_REPO__", str(user_repo))
+        .replace("__STAGE__", str(stage))
+    )
+    result = subprocess.run(
+        [_BASH, "-c", harness],
+        env={"PATH": f"{bin_dir}:/usr/bin:/bin", **env},
+        capture_output=True,
+        text=True,
+    )
+    lines = result.stdout.splitlines()
+    bearer_active = False
+    sso_active = False
+    tokens = []
+    for line in lines:
+        if line == "---":
+            continue
+        if line.startswith("BEARER_ACTIVE="):
+            bearer_active = line.split("=", 1)[1] == "true"
+        elif line.startswith("SSO_ACTIVE="):
+            sso_active = line.split("=", 1)[1] == "true"
+        else:
+            tokens.append(line)
+    return result.returncode, tokens, bearer_active, sso_active
+
+
+def _env_pairs(tokens: list[str]) -> dict[str, str]:
+    pairs = {}
+    for i, tok in enumerate(tokens):
+        if tok == "-e" and i + 1 < len(tokens) and "=" in tokens[i + 1]:
+            name, _, value = tokens[i + 1].partition("=")
+            pairs[name] = value
+    return pairs
+
+
+def _has_aws_mount(tokens: list[str]) -> bool:
+    return any(t.endswith(":/home/leerie/.aws:ro") for t in tokens)
+
+
+# ---------------------------------------------------------------------------
+# Bearer token set -> forwards AWS_BEARER_TOKEN_BEDROCK, defaults
+# CLAUDE_CODE_USE_BEDROCK=1, forwards AWS_REGION when set.
+# ---------------------------------------------------------------------------
+
+def test_bearer_token_forwarded(tmp_path: Path) -> None:
+    rc, tokens, bearer_active, sso_active = _run(
+        {"AWS_BEARER_TOKEN_BEDROCK": "bedrock-tok-123"}, tmp_path=tmp_path,
+    )
+    assert rc == 0, tokens
+    pairs = _env_pairs(tokens)
+    assert pairs["AWS_BEARER_TOKEN_BEDROCK"] == "bedrock-tok-123"
+    assert bearer_active is True
+    assert sso_active is False
+
+
+def test_claude_code_use_bedrock_defaults_to_one(tmp_path: Path) -> None:
+    """CLAUDE_CODE_USE_BEDROCK is required alongside the bearer token —
+    verified live against the real CLI that the token alone is a no-op
+    (falls through to firstParty/OAuth). The launcher must default it."""
+    rc, tokens, _, _ = _run(
+        {"AWS_BEARER_TOKEN_BEDROCK": "bedrock-tok-123"}, tmp_path=tmp_path,
+    )
+    assert rc == 0, tokens
+    pairs = _env_pairs(tokens)
+    assert pairs["CLAUDE_CODE_USE_BEDROCK"] == "1"
+
+
+def test_claude_code_use_bedrock_explicit_override_wins(tmp_path: Path) -> None:
+    """An explicit CLAUDE_CODE_USE_BEDROCK=0 alongside the bearer token is
+    forwarded verbatim — a user override beats the launcher's default."""
+    rc, tokens, _, _ = _run(
+        {"AWS_BEARER_TOKEN_BEDROCK": "bedrock-tok-123", "CLAUDE_CODE_USE_BEDROCK": "0"},
+        tmp_path=tmp_path,
+    )
+    assert rc == 0, tokens
+    pairs = _env_pairs(tokens)
+    assert pairs["CLAUDE_CODE_USE_BEDROCK"] == "0"
+
+
+def test_aws_region_forwarded_when_set(tmp_path: Path) -> None:
+    rc, tokens, _, _ = _run(
+        {"AWS_BEARER_TOKEN_BEDROCK": "bedrock-tok-123", "AWS_REGION": "us-west-2"},
+        tmp_path=tmp_path,
+    )
+    assert rc == 0, tokens
+    pairs = _env_pairs(tokens)
+    assert pairs["AWS_REGION"] == "us-west-2"
+
+
+def test_aws_region_not_forwarded_when_unset(tmp_path: Path) -> None:
+    """AWS_REGION is optional — the CLI defaults to us-east-1 internally
+    (verified live), so no -e flag should be emitted when unset."""
+    rc, tokens, _, _ = _run(
+        {"AWS_BEARER_TOKEN_BEDROCK": "bedrock-tok-123"}, tmp_path=tmp_path,
+    )
+    assert rc == 0, tokens
+    pairs = _env_pairs(tokens)
+    assert "AWS_REGION" not in pairs
+
+
+# ---------------------------------------------------------------------------
+# Bearer token set -> no aws CLI / SSO preflight, no ~/.aws mount.
+# ---------------------------------------------------------------------------
+
+def test_bearer_token_skips_aws_preflight_and_mount(tmp_path: Path) -> None:
+    """No `aws` binary on PATH at all — the bearer-token path must not
+    invoke bedrock_preflight() (which would exit 1 without `aws`)."""
+    rc, tokens, bearer_active, sso_active = _run(
+        {"AWS_BEARER_TOKEN_BEDROCK": "bedrock-tok-123"},
+        aws_on_path=False,
+        tmp_path=tmp_path,
+    )
+    assert rc == 0, tokens
+    assert not _has_aws_mount(tokens)
+    assert bearer_active is True
+    assert sso_active is False
+
+
+def test_bearer_token_skips_preflight_even_with_aws_present_but_failing(tmp_path: Path) -> None:
+    """Even when `aws` IS on PATH and would fail sts get-caller-identity,
+    the bearer-token path must not call it — it has no SSO dependency."""
+    rc, tokens, _, _ = _run(
+        {"AWS_BEARER_TOKEN_BEDROCK": "bedrock-tok-123"},
+        aws_on_path=True,
+        aws_succeeds=False,
+        tmp_path=tmp_path,
+    )
+    assert rc == 0, tokens
+    assert not _has_aws_mount(tokens)
+
+
+# ---------------------------------------------------------------------------
+# Both bearer token AND settings.json CLAUDE_CODE_USE_BEDROCK present ->
+# bearer-token path wins (no ~/.aws mount, no preflight call).
+# ---------------------------------------------------------------------------
+
+def test_bearer_token_wins_over_settings_json_sso(tmp_path: Path) -> None:
+    rc, tokens, bearer_active, sso_active = _run(
+        {"AWS_BEARER_TOKEN_BEDROCK": "bedrock-tok-123"},
+        aws_on_path=True,
+        aws_succeeds=True,
+        settings_json={"env": {"CLAUDE_CODE_USE_BEDROCK": "1"}},
+        tmp_path=tmp_path,
+    )
+    assert rc == 0, tokens
+    assert bearer_active is True
+    assert sso_active is False
+    assert not _has_aws_mount(tokens)
+
+
+# ---------------------------------------------------------------------------
+# Neither set -> unchanged existing behavior (regression control).
+# ---------------------------------------------------------------------------
+
+def test_neither_set_is_a_no_op(tmp_path: Path) -> None:
+    rc, tokens, bearer_active, sso_active = _run({}, tmp_path=tmp_path)
+    assert rc == 0, tokens
+    assert bearer_active is False
+    assert sso_active is False
+    assert tokens == []
+
+
+def test_settings_json_sso_still_works_without_bearer_token(tmp_path: Path) -> None:
+    """Regression control: the pre-existing SSO/profile path is unaffected
+    when the bearer token is absent."""
+    rc, tokens, bearer_active, sso_active = _run(
+        {},
+        aws_on_path=True,
+        aws_succeeds=True,
+        settings_json={"env": {"CLAUDE_CODE_USE_BEDROCK": "1"}},
+        tmp_path=tmp_path,
+    )
+    assert rc == 0, tokens
+    assert bearer_active is False
+    assert sso_active is True
+    assert _has_aws_mount(tokens)
+    pairs = _env_pairs(tokens)
+    assert pairs["CLAUDE_CODE_USE_BEDROCK"] == "1"
+
+
+# ---------------------------------------------------------------------------
+# Fly detached-launch heredoc mirrors the same precedence/defaults.
+# ---------------------------------------------------------------------------
+
+def test_fly_heredoc_forwards_bearer_token_vars() -> None:
+    """Source-coupling: the Fly detached-launch child_env block must carry
+    the same AWS_BEARER_TOKEN_BEDROCK / CLAUDE_CODE_USE_BEDROCK / AWS_REGION
+    injection, gated on _BEDROCK_BEARER_ACTIVE, mirroring the nerdctl path's
+    AUTH_MOUNTS block (test_launcher_env_forwarding.py's
+    test_fly_path_also_delivers_user_repo pins the same "both paths must
+    carry the same injection" discipline for USER_REPO). Values are
+    JSON-encoded host-side (see test_fly_heredoc_values_are_json_encoded_not_raw
+    below) rather than substituted as raw "${VAR}" strings."""
+    src = LAUNCHER.read_text()
+    assert 'if "${_BEDROCK_BEARER_ACTIVE}" == "true":' in src
+    assert 'child_env["AWS_BEARER_TOKEN_BEDROCK"] = ${_bedrock_bearer_token_json}' in src
+    assert 'child_env["CLAUDE_CODE_USE_BEDROCK"] = ${_bedrock_use_bedrock_json}' in src
+
+
+def test_fly_heredoc_values_are_json_encoded_not_raw() -> None:
+    """Regression guard for the injection defect found in post-implementation
+    audit: a raw `"${AWS_BEARER_TOKEN_BEDROCK}"` substitution inside the
+    unquoted heredoc lets a token containing `"` or `\\` break out of the
+    Python string literal and run as arbitrary code on the remote Fly
+    machine. Every value substituted into the heredoc must instead be
+    pre-encoded via `python3 -c 'import json,sys; print(json.dumps(...))'`
+    (the same technique `_launch_argv_json` already uses for argv) and
+    referenced unquoted (already a valid Python literal)."""
+    src = LAUNCHER.read_text()
+    assert 'child_env["AWS_BEARER_TOKEN_BEDROCK"] = "${AWS_BEARER_TOKEN_BEDROCK}"' not in src, (
+        "raw string substitution of a secret token into the Fly heredoc "
+        "reintroduces the Python-injection defect — JSON-encode it host-side "
+        "first (see _bedrock_bearer_token_json)"
+    )
+    assert "_bedrock_bearer_token_json=" in src
+    assert "json.dumps(sys.argv[1])" in src
+    assert "child_env[\"AWS_BEARER_TOKEN_BEDROCK\"] = ${_bedrock_bearer_token_json}" in src
+
+
+def test_child_env_heredoc_body_has_no_stray_unbound_var_substitution() -> None:
+    """Regression guard for a second, more severe defect found alongside the
+    injection one: the heredoc is UNQUOTED (`<<PY`, not `<<'PY'`), so bash
+    substitutes every `${...}`-shaped token in its body — including inside
+    what looks like a Python comment. A draft of the fix above's own
+    explanatory comment read `...a raw "${VAR}" string...`; under the
+    launcher's `set -euo pipefail`, `$VAR` being unset made `${VAR}` an
+    unbound-variable reference that crashed the ENTIRE launcher (not just
+    a broken script) on every Fly run with Bedrock bearer-token mode active
+    — worse than the injection defect, since it fired on every run rather
+    than only a maliciously-crafted token. Verified live: reintroducing
+    that exact comment text into the heredoc body reproduces
+    `bash: line N: VAR: unbound variable` when the surrounding script is
+    executed. Only the KNOWN, intentional substitution names may appear in
+    `${...}` form inside this region."""
+    block = _extract_child_env_bedrock_block()
+    known = {
+        "_host_tz_json", "_bedrock_bearer_token_json", "_bedrock_use_bedrock_json",
+        "_bedrock_bearer_region_json", "_BEDROCK_BEARER_ACTIVE", "_bedrock_profile_json",
+        "_BEDROCK_ACTIVE", "_bedrock_region_json",
+    }
+    found = set(re.findall(r"\$\{([A-Za-z_][A-Za-z0-9_]*)", block))
+    unexpected = found - known
+    assert not unexpected, (
+        f"unexpected ${{...}}-shaped substitution(s) in the unquoted Fly "
+        f"heredoc body: {sorted(unexpected)} — if these are meant to be "
+        f"literal text (e.g. inside a comment), the heredoc's unquoted "
+        f"nature means bash will still try to substitute them, crashing "
+        f"under `set -u` if unset. Rephrase the comment to avoid the "
+        f"${{...}} shape entirely."
+    )
+
+
+def test_child_env_heredoc_body_has_no_backtick_characters() -> None:
+    """Regression guard for a third defect found on re-audit, distinct from
+    the `${...}`-unbound-variable one above: this heredoc is unquoted, so a
+    BALANCED backtick pair in a comment (e.g. `` `if <json>:` ``) is parsed
+    by bash as a command-substitution delimiter — command substitution is a
+    different expansion mechanism than `${...}` parameter expansion, so the
+    `${...}`-allowlist scan above does not catch it. Verified live: bash
+    tries to execute the literal text between the backticks as a shell
+    command, fails with `syntax error: unexpected end of file` (printed to
+    the user's terminal on every Fly + Bedrock-bearer-token launch), and
+    silently drops that comment's text from the script actually sent to the
+    remote machine. `shellcheck -x leerie` also flags this
+    (SC1009/SC1073/SC1050/SC1072) — diffing shellcheck output against
+    `git stash` is how this was originally caught; `bash -n` alone does not
+    catch it. This heredoc's content is pure Python, which never needs a
+    literal backtick, so the invariant is simply: none allowed."""
+    block = _extract_child_env_bedrock_block()
+    assert "`" not in block, (
+        "a backtick character appeared in the unquoted Fly heredoc body — "
+        "bash will treat a balanced pair as command substitution even "
+        "inside a comment, corrupting the script and printing a spurious "
+        "syntax error to the user on every launch. Rephrase to avoid "
+        "backticks entirely (e.g. drop inline code-formatting in prose)."
+    )
+
+
+def test_fly_heredoc_bearer_precedes_sso_elif() -> None:
+    """The Fly heredoc's bearer-token `if` must be an `elif`-paired
+    predecessor of the SSO `_BEDROCK_ACTIVE` check, mirroring the nerdctl
+    path's `_BEDROCK_BEARER_ACTIVE=false && detect_bedrock_mode` guard —
+    both paths must apply the same precedence."""
+    src = LAUNCHER.read_text()
+    bearer_idx = src.index('if "${_BEDROCK_BEARER_ACTIVE}" == "true":')
+    sso_idx = src.index('elif "${_BEDROCK_ACTIVE}" == "true":')
+    assert bearer_idx < sso_idx, (
+        "the Fly heredoc's bearer-token check must precede the SSO elif — "
+        "otherwise the two could both fire or fire in the wrong order"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Coupling guard: nerdctl block's precedence variable name matches the
+# Fly heredoc's substitution reference, so a rename on one side cannot
+# silently diverge from the other.
+# ---------------------------------------------------------------------------
+
+def test_precedence_variable_name_shared_across_both_runtimes() -> None:
+    src = LAUNCHER.read_text()
+    assert src.count("_BEDROCK_BEARER_ACTIVE") >= 3, (
+        "expected _BEDROCK_BEARER_ACTIVE to appear in both the nerdctl "
+        "AUTH_MOUNTS block and the Fly heredoc substitution — a rename on "
+        "one side without the other would silently break precedence"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Live end-to-end regression: a malicious bearer token must not break out of
+# the Fly heredoc's Python string literal. Extracts the real JSON-encoding
+# lines + a minimal heredoc body verbatim from the launcher, actually runs
+# the resulting script through `python3 -` (mirroring how flyctl ssh console
+# pipes it to the remote machine), and asserts no injected code executed.
+# ---------------------------------------------------------------------------
+
+def _extract_json_encoding_lines() -> str:
+    """Pull the `_host_tz_json=...` through `_bedrock_region_json=...`
+    JSON-encoding assignments verbatim from the launcher."""
+    src = LAUNCHER.read_text()
+    start = src.index('_host_tz_json="$(python3')
+    end = src.index('\n', src.index('_bedrock_region_json="$(python3'))
+    block = src[start:end]
+    assert "_bedrock_bearer_token_json=" in block
+    assert "_bedrock_region_json=" in block
+    return block
+
+
+def _extract_child_env_bedrock_block() -> str:
+    """Pull the real `child_env["TZ"] = ...` through the SSO `elif` block's
+    closing line verbatim from the launcher's Fly heredoc — the actual code
+    under test, not a hand-copied reproduction (a hand-copy would not catch
+    a regression reintroduced only in the real launcher; verified this
+    matters live — see the git-history note on this test)."""
+    src = LAUNCHER.read_text()
+    start = src.index('child_env["TZ"] = ${_host_tz_json}')
+    end = src.index('\n', src.index('child_env["AWS_REGION"] = ${_bedrock_region_json}'))
+    block = src[start:end]
+    assert 'child_env["AWS_BEARER_TOKEN_BEDROCK"] = ${_bedrock_bearer_token_json}' in block
+    return block
+
+
+# The token travels via the real env var (like the actual launcher receives
+# it from the user's shell), NOT baked into the script text — embedding an
+# arbitrary token directly into bash source would itself be a second,
+# unrelated injection bug in the *test harness*, distinct from the one this
+# test verifies is fixed in the launcher.
+_INJECTION_HARNESS = r"""
+#!/usr/bin/env bash
+set -euo pipefail
+CLAUDE_CODE_USE_BEDROCK=""
+AWS_REGION=""
+_BEDROCK_PROFILE=""
+_BEDROCK_REGION=""
+_BEDROCK_BEARER_ACTIVE=true
+_BEDROCK_ACTIVE=false
+_host_tz="America/Chicago"
+
+__JSON_ENCODING_LINES__
+
+_script="$(cat <<PY
+child_env = {}
+__CHILD_ENV_BLOCK__
+import sys
+print(child_env["AWS_BEARER_TOKEN_BEDROCK"], file=sys.stderr)
+PY
+)"
+printf '%s' "$_script" | python3 -
+"""
+
+
+def _run_injection_harness(token: str, tmp_path: Path) -> tuple[int, str, str]:
+    harness = (
+        _INJECTION_HARNESS
+        .replace("__JSON_ENCODING_LINES__", _extract_json_encoding_lines())
+        .replace("__CHILD_ENV_BLOCK__", _extract_child_env_bedrock_block())
+    )
+    canary = tmp_path / "pwned"
+    result = subprocess.run(
+        [_BASH, "-c", harness],
+        env={
+            "PATH": "/usr/bin:/bin",
+            "PWNED_CANARY": str(canary),
+            "AWS_BEARER_TOKEN_BEDROCK": token,
+        },
+        capture_output=True,
+        text=True,
+    )
+    return result.returncode, result.stdout, result.stderr
+
+
+def test_malicious_token_with_quote_does_not_break_out_of_python_literal(tmp_path: Path) -> None:
+    """The historical defect payload: a token ending in a quote followed by
+    Python code. Before the fix this executed as real Python on the target
+    interpreter; after the fix it must round-trip as an inert string."""
+    canary = tmp_path / "pwned"
+    token = f'tok"; import os; os.system("touch {canary}"); x="'
+    rc, _, stderr = _run_injection_harness(token, tmp_path)
+    assert rc == 0, stderr
+    assert not canary.exists(), (
+        "the malicious token executed as Python — injection defect is back"
+    )
+    assert token in stderr, "the token must still round-trip through unchanged"
+
+
+def test_malicious_token_with_backslash_does_not_break_out(tmp_path: Path) -> None:
+    canary = tmp_path / "pwned2"
+    token = f'tok\\"; import os; os.system("touch {canary}"); x="'
+    rc, _, stderr = _run_injection_harness(token, tmp_path)
+    assert rc == 0, stderr
+    assert not canary.exists()
+    assert token in stderr
+
+
+def test_normal_token_unaffected_by_json_encoding(tmp_path: Path) -> None:
+    """A realistic token (no special characters) round-trips unchanged."""
+    token = "sk-bedrock-abc123XYZ"
+    rc, _, stderr = _run_injection_harness(token, tmp_path)
+    assert rc == 0, stderr
+    assert token in stderr

--- a/tests/test_bedrock_mode.py
+++ b/tests/test_bedrock_mode.py
@@ -1,0 +1,266 @@
+"""Tests for the settings.json-driven Bedrock SSO/profile mode
+(`detect_bedrock_mode()` / `bedrock_preflight()` in `leerie`).
+
+This mechanism shipped with zero test coverage before this module — see
+docs/DESIGN.md §6 *Credential strategy* for how it relates to the newer
+AWS_BEARER_TOKEN_BEDROCK path (tests/test_bedrock_bearer_token.py), which
+sits directly on top of it (the bearer-token block short-circuits this one).
+Closing this gap here so a future edit to the shared AUTH_MOUNTS/heredoc
+region doesn't silently regress the SSO path.
+
+Extracts detect_bedrock_mode()/bedrock_preflight() verbatim from the
+launcher (same discipline as test_bedrock_bearer_token.py's
+_extract_bedrock_functions) so the tests exercise real code, not a copy.
+"""
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+LAUNCHER = REPO_ROOT / "leerie"
+LOG_SH = REPO_ROOT / "scripts" / "remote" / "_log.sh"
+
+# See test_bedrock_bearer_token.py's _BASH comment: macOS's /usr/bin/bash
+# (3.2) throws "unbound variable" on an empty array under `set -u` in
+# bedrock_preflight()'s `aws_args=()` — a real gap in that pre-existing,
+# previously-untested function, distinct from what this module is testing.
+# Resolve a modern bash so these tests exercise the same logic the launcher
+# itself runs under in practice (its own shebang is `#!/usr/bin/env bash`).
+_BASH = shutil.which("bash") or "/bin/bash"
+
+
+def _extract_bedrock_functions() -> str:
+    src = LAUNCHER.read_text()
+    start = src.index("detect_bedrock_mode() {")
+    end = src.index("\n}\n", src.index("bedrock_preflight() {")) + len("\n}\n")
+    block = src[start:end]
+    assert "detect_bedrock_mode() {" in block
+    assert "bedrock_preflight() {" in block
+    return block
+
+
+_DETECT_HARNESS = r"""
+#!/usr/bin/env bash
+set -euo pipefail
+. "__LOG_SH__"
+__BEDROCK_FUNCTIONS__
+HOME="__HOME__"
+USER_REPO="__USER_REPO__"
+if detect_bedrock_mode; then
+  echo DETECTED
+else
+  echo NOT_DETECTED
+fi
+"""
+
+# bedrock_preflight() calls `exit 1` on failure (not `return 1` — it's
+# meant to abort the whole launcher), so a plain `if bedrock_preflight;
+# then ... else ...` never reaches the else arm: exit terminates this
+# entire subshell. Run it in a subshell whose own exit is captured instead.
+_PREFLIGHT_HARNESS = r"""
+#!/usr/bin/env bash
+set -uo pipefail
+. "__LOG_SH__"
+__BEDROCK_FUNCTIONS__
+HOME="__HOME__"
+USER_REPO="__USER_REPO__"
+if (set -e; bedrock_preflight); then
+  echo PREFLIGHT_OK
+else
+  echo PREFLIGHT_FAILED
+fi
+"""
+
+
+def _write_settings(base: Path, rel: str, content: dict) -> None:
+    path = base / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(content))
+
+
+def _run_detect(tmp_path: Path, *, user_settings: dict | None = None,
+                 project_settings: dict | None = None,
+                 local_settings: dict | None = None) -> str:
+    fake_home = tmp_path / "home"
+    fake_home.mkdir(parents=True)
+    user_repo = tmp_path / "repo"
+    user_repo.mkdir(parents=True)
+    if user_settings is not None:
+        _write_settings(fake_home, ".claude/settings.json", user_settings)
+    if project_settings is not None:
+        _write_settings(user_repo, ".claude/settings.json", project_settings)
+    if local_settings is not None:
+        _write_settings(user_repo, ".claude/settings.local.json", local_settings)
+
+    harness = (
+        _DETECT_HARNESS
+        .replace("__LOG_SH__", str(LOG_SH))
+        .replace("__BEDROCK_FUNCTIONS__", _extract_bedrock_functions())
+        .replace("__HOME__", str(fake_home))
+        .replace("__USER_REPO__", str(user_repo))
+    )
+    result = subprocess.run(
+        [_BASH, "-c", harness],
+        env={"PATH": "/usr/bin:/bin"},
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    return result.stdout.strip()
+
+
+def _run_preflight(tmp_path: Path, *, aws_on_path: bool, aws_succeeds: bool = True,
+                    profile: str | None = None) -> tuple[str, str]:
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    user_repo = tmp_path / "repo"
+    user_repo.mkdir()
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+
+    if profile is not None:
+        _write_settings(fake_home, ".claude/settings.json", {"env": {"AWS_PROFILE": profile}})
+
+    if aws_on_path:
+        aws_stub = bin_dir / "aws"
+        aws_stub.write_text(
+            "#!/usr/bin/env bash\n"
+            f"exit {0 if aws_succeeds else 1}\n"
+        )
+        aws_stub.chmod(0o755)
+
+    harness = (
+        _PREFLIGHT_HARNESS
+        .replace("__LOG_SH__", str(LOG_SH))
+        .replace("__BEDROCK_FUNCTIONS__", _extract_bedrock_functions())
+        .replace("__HOME__", str(fake_home))
+        .replace("__USER_REPO__", str(user_repo))
+    )
+    result = subprocess.run(
+        [_BASH, "-c", harness],
+        env={"PATH": f"{bin_dir}:/usr/bin:/bin"},
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip(), result.stderr
+
+
+# ---------------------------------------------------------------------------
+# detect_bedrock_mode(): 3-file merge / truthy matching
+# ---------------------------------------------------------------------------
+
+def test_detects_from_user_settings(tmp_path: Path) -> None:
+    out = _run_detect(tmp_path, user_settings={"env": {"CLAUDE_CODE_USE_BEDROCK": "1"}})
+    assert out == "DETECTED"
+
+
+def test_detects_from_project_settings(tmp_path: Path) -> None:
+    out = _run_detect(tmp_path, project_settings={"env": {"CLAUDE_CODE_USE_BEDROCK": "true"}})
+    assert out == "DETECTED"
+
+
+def test_detects_from_local_settings(tmp_path: Path) -> None:
+    out = _run_detect(tmp_path, local_settings={"env": {"CLAUDE_CODE_USE_BEDROCK": "yes"}})
+    assert out == "DETECTED"
+
+
+def test_truthy_values_case_insensitive(tmp_path: Path) -> None:
+    for i, val in enumerate(("1", "TRUE", "Yes", "ON", "on")):
+        out = _run_detect(tmp_path / str(i), user_settings={"env": {"CLAUDE_CODE_USE_BEDROCK": val}})
+        assert out == "DETECTED", f"expected {val!r} to be truthy"
+
+
+def test_falsy_values_not_detected(tmp_path: Path) -> None:
+    for i, val in enumerate(("0", "false", "", "no", "off")):
+        out = _run_detect(tmp_path / str(i), user_settings={"env": {"CLAUDE_CODE_USE_BEDROCK": val}})
+        assert out == "NOT_DETECTED", f"expected {val!r} to be falsy"
+
+
+def test_no_settings_files_not_detected(tmp_path: Path) -> None:
+    out = _run_detect(tmp_path)
+    assert out == "NOT_DETECTED"
+
+
+def test_malformed_settings_json_tolerated(tmp_path: Path) -> None:
+    """A malformed settings file must not crash detection — the function
+    swallows JSON errors per-file and continues checking the others."""
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    (fake_home / ".claude").mkdir()
+    (fake_home / ".claude" / "settings.json").write_text("{not valid json")
+    user_repo = tmp_path / "repo"
+    user_repo.mkdir()
+    _write_settings(user_repo, ".claude/settings.json", {"env": {"CLAUDE_CODE_USE_BEDROCK": "1"}})
+
+    harness = (
+        _DETECT_HARNESS
+        .replace("__LOG_SH__", str(LOG_SH))
+        .replace("__BEDROCK_FUNCTIONS__", _extract_bedrock_functions())
+        .replace("__HOME__", str(fake_home))
+        .replace("__USER_REPO__", str(user_repo))
+    )
+    result = subprocess.run(
+        [_BASH, "-c", harness],
+        env={"PATH": "/usr/bin:/bin"},
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "DETECTED"
+
+
+def test_last_match_wins_precedence_is_or_semantics(tmp_path: Path) -> None:
+    """CLAUDE_CODE_USE_BEDROCK has no 'disable' value (isEnvTruthy only
+    matches truthy strings), so ANY of the three files being truthy is
+    sufficient — a falsy localSettings does not override a truthy
+    userSettings, unlike AWS_PROFILE/AWS_REGION's last-match-wins."""
+    out = _run_detect(
+        tmp_path,
+        user_settings={"env": {"CLAUDE_CODE_USE_BEDROCK": "1"}},
+        local_settings={"env": {"CLAUDE_CODE_USE_BEDROCK": "0"}},
+    )
+    assert out == "DETECTED"
+
+
+# ---------------------------------------------------------------------------
+# bedrock_preflight(): missing aws binary, expired/valid SSO
+# ---------------------------------------------------------------------------
+
+def test_preflight_fails_when_aws_not_on_path(tmp_path: Path) -> None:
+    out, err = _run_preflight(tmp_path, aws_on_path=False)
+    assert out == "PREFLIGHT_FAILED"
+    assert "not found on PATH" in err
+
+
+def test_preflight_fails_when_sts_call_fails(tmp_path: Path) -> None:
+    """Simulates an expired/missing SSO token: `aws sts get-caller-identity`
+    exits non-zero."""
+    out, err = _run_preflight(tmp_path, aws_on_path=True, aws_succeeds=False)
+    assert out == "PREFLIGHT_FAILED"
+    assert "expired or missing" in err
+    assert "aws sso login" in err
+
+
+def test_preflight_succeeds_with_valid_sso(tmp_path: Path) -> None:
+    out, err = _run_preflight(tmp_path, aws_on_path=True, aws_succeeds=True)
+    assert out == "PREFLIGHT_OK"
+
+
+def test_preflight_hint_names_profile_when_set(tmp_path: Path) -> None:
+    """When AWS_PROFILE is set in settings.json, a failed preflight names
+    that profile in its `aws sso login --profile <p>` recovery hint."""
+    out, err = _run_preflight(
+        tmp_path, aws_on_path=True, aws_succeeds=False, profile="my-profile",
+    )
+    assert out == "PREFLIGHT_FAILED"
+    assert "aws sso login --profile my-profile" in err
+
+
+def test_preflight_hint_omits_profile_when_unset(tmp_path: Path) -> None:
+    out, err = _run_preflight(tmp_path, aws_on_path=True, aws_succeeds=False)
+    assert out == "PREFLIGHT_FAILED"
+    assert "--profile" not in err
+    assert "aws sso login " in err or "aws sso login\n" in err or "aws sso login  " in err


### PR DESCRIPTION
## Summary

- Adds a second, independent Bedrock activation path alongside the existing settings.json-driven SSO/profile path (`detect_bedrock_mode()` / `bedrock_preflight()`): a plain host env var `AWS_BEARER_TOKEN_BEDROCK` that needs no `aws` CLI, no SSO session, and no `~/.aws/` staging — the Bedrock analogue of `CLAUDE_CODE_OAUTH_TOKEN`, for the same reason (DESIGN §6 *Credential strategy*): a container cannot refresh a short-lived SSO token any more than it can refresh a subscription OAuth session.
- Verified against the real Claude Code CLI (decompiled bundled JS + live end-to-end testing, v2.1.220): the bearer token requires `CLAUDE_CODE_USE_BEDROCK=1` alongside it to activate (the token alone silently falls through to firstParty/OAuth dispatch), `AWS_REGION` is optional (CLI defaults to `us-east-1`), and the CLI's own credential resolution already prefers the bearer token over SSO/profile when both are present — this PR's precedence rule matches that.
- Closes a pre-existing zero-test-coverage gap on the existing SSO/profile Bedrock path (`tests/test_bedrock_mode.py`).

## Defects found and fixed during implementation

Three real defects were found and fixed via adversarial self-audit (live execution + `shellcheck` diffing, not just inspection), all in the Fly detached-launch heredoc (which is unquoted, `<<PY`, so bash evaluates shell expansions inside what looks like inert Python comment text):

1. **Python injection**: a raw `"${AWS_BEARER_TOKEN_BEDROCK}"` string substitution let a token containing `"`/`\` break out of the Python string literal and execute arbitrary code on the remote Fly machine. Fixed by JSON-encoding every heredoc-substituted value host-side, mirroring the pre-existing `_launch_argv_json` technique.
2. **Launcher crash**: a first-draft fix comment containing literal `${VAR}` text crashed the entire launcher with `unbound variable` under `set -u` on every Bedrock bearer-token Fly launch (worse than defect 1 — fired unconditionally, not just on a hostile token).
3. **Backtick command substitution**: a balanced backtick pair in a comment (`` `if <json>:` ``) was parsed by bash as command substitution — a different expansion mechanism than `${...}`, unguarded by the fix for #2 — printing a spurious `syntax error` to the user's terminal on every launch. Caught by diffing `shellcheck -x leerie` against `git stash` (`bash -n` alone does not catch it).

All three are fixed, tested, and falsification-verified (each regression test confirmed to fail against the reintroduced defect and pass on the fix).

## Test plan

- [x] `bash -n leerie` — clean
- [x] `shellcheck -x leerie` diffed against pre-change baseline — zero new findings
- [x] `python3 -c "import ast; ast.parse(open('orchestrator/leerie.py').read())"` — clean (no Python changes)
- [x] `pytest tests/test_bedrock_bearer_token.py tests/test_bedrock_mode.py -v` — 32/32 pass
- [x] `pytest tests/test_bedrock_bearer_token.py tests/test_bedrock_mode.py tests/test_launcher_env_forwarding.py tests/test_credential_precedence.py tests/test_credential_ttl_preflight.py tests/test_ec2_lib_sh.py tests/test_ec2_e2e_provision.py -q` — 88/88 pass (decisive regression check for this change)
- [x] `git diff --stat` — scoped to exactly `leerie`, `docs/DESIGN.md`, `docs/IMPLEMENTATION.md`, `CLAUDE.md`, plus 2 new test files

🤖 Generated with [Claude Code](https://claude.com/claude-code)