### PR TITLE
fix(P1): give sub-file region children a region-scoped intent so the overlap judge can tell them apart

### DIFF
--- a/docs/IMPLEMENTATION.md
+++ b/docs/IMPLEMENTATION.md
@@ -4676,12 +4676,25 @@ accept the subtask as leaf); then splits via either:
     contiguous line-windows (`partition_lines()`), which also serves as the
     whole-file fallback when no ranges are available. Children are built by
     `_subfile_child()` (analog of `_migration_child()`), each listing the same
-    single file plus an `owned_region` field and a `_cofile_cluster` marker.
-    `_check_intra_file_surface()` is the zero-tolerance coverage/overlap backstop
-    (union == `[1, EOF]`, pairwise-disjoint). Same-file co-ownership is legitimate
-    downstream (schedule ignores `files_likely_touched`; overlap judge excludes
-    same-file/different-region; `git merge` reconciles); `check_planner_output`'s
-    `INTRA_DOMAIN_OVERLAP` advisory is suppressed for `_cofile_cluster` children.
+    single file plus an `owned_region` field, a `_cofile_cluster` marker, and
+    (unlike `_migration_child()`, whose verbatim `intent` inheritance is safe
+    because chunks own disjoint files) a **region-scoped `intent`** — mechanically
+    derived from the parent's intent plus the region's line range and symbols,
+    not a byte-identical copy. `_check_intra_file_surface()` is the
+    zero-tolerance coverage/overlap backstop (union == `[1, EOF]`,
+    pairwise-disjoint). Same-file co-ownership is legitimate downstream
+    (schedule ignores `files_likely_touched`; `git merge` reconciles);
+    `check_planner_output`'s `INTRA_DOMAIN_OVERLAP` advisory is suppressed for
+    `_cofile_cluster` children. The overlap judge excludes same-file/
+    different-region collisions via two mechanisms: the region-scoped
+    `intent` gives it a textual signal (its prompt's "What is NOT a
+    collision" list names same-`_cofile_cluster` pairs explicitly), and
+    `check_overlap_judge_output`'s `SPURIOUS_COFILE_COLLISION` check is a
+    code-enforced backstop (§12) that flags any `unresolvable` verdict
+    between same-`_cofile_cluster` subtasks regardless of the judge's own
+    reasoning — closing a real incident where 40 region children with an
+    unscoped, identical `intent` gave the judge no signal to distinguish
+    them and it wrongly died on 5 "unresolvable" collisions.
   - **Oversized-file peel** (`1 < len(files) ≤ chunk_size`, exactly one file over
     `subfile_split_max_span` lines): checked in the split step **before**
     `_subfile_split()`'s single-file tiling, since that tiling's `len(files) == 1`

--- a/orchestrator/leerie.py
+++ b/orchestrator/leerie.py
@@ -5713,8 +5713,11 @@ def _subfile_child(subtask: dict, file: str, region: tuple[int, int],
     aliased lists leak dependencies via `_apply_overlap_drop`). Differences:
 
     - ``files_likely_touched`` is the *single* parent file — every region child
-      co-owns it, which is legitimate downstream (schedule ignores files; the
-      overlap judge excludes same-file/different-region; `git merge` reconciles).
+      co-owns it, which is legitimate downstream (schedule ignores files;
+      `git merge` reconciles; the overlap judge is told to exclude same-file/
+      different-region collisions via the region-scoped ``intent`` below plus
+      the ``_cofile_cluster`` marker it's shown — DESIGN §5 *Cross-domain
+      surface overlap*).
     - ``owned_region`` records the code-computed line range + the symbols it
       contains, so the implementer's prompt scopes it to that span.
     - ``_cofile_cluster`` marks the child as part of an *intentional* same-file
@@ -5735,6 +5738,20 @@ def _subfile_child(subtask: dict, file: str, region: tuple[int, int],
         f"(symbols: {sym_txt}). Do not edit outside this range; a sibling "
         f"subtask owns the rest of the file."
     ).strip()
+    # Region-scoped, not a verbatim parent copy (unlike _migration_child,
+    # where verbatim inheritance is safe because chunks own disjoint files).
+    # Region children co-own the SAME file, so an unscoped intent gives
+    # plan_overlap_judge no textual signal to distinguish N children each
+    # claiming to implement the parent's complete feature — the direct
+    # cause of a real false-positive "unresolvable surface collision"
+    # incident (DESIGN §5 *Cross-domain surface overlap*). Mechanically
+    # derived, no LLM call, matching this function's "Pure + deterministic"
+    # guarantee.
+    intent = (
+        f"{subtask.get('intent', '')} This subtask's slice: only lines "
+        f"{lo}-{hi} of {file} (symbols: {sym_txt}). A sibling subtask "
+        f"owns the rest of the file."
+    ).strip()
     return {
         "id": cid,
         "title": title,
@@ -5743,7 +5760,7 @@ def _subfile_child(subtask: dict, file: str, region: tuple[int, int],
         "owned_region": {"file": file, "start": lo, "end": hi,
                          "symbols": list(symbols)},
         "_cofile_cluster": cluster,
-        "intent": subtask.get("intent", ""),
+        "intent": intent,
         "scope_note": subtask.get("scope_note", ""),
         "depends_on": list(subtask.get("depends_on", []) or []),
         "requires": copy.deepcopy(subtask.get("requires", []) or []),
@@ -6623,6 +6640,33 @@ def check_overlap_judge_output(
                     f"DROP_BREAKS_GRAPH: dropping {dropped_sid!r} "
                     f"would remove provides tags {orphaned} that "
                     "other subtasks require")
+
+    # Code-enforced backstop for a real incident (DESIGN §5½ *Sub-file*):
+    # two subtasks sharing the same non-null `_cofile_cluster` are, by
+    # construction, disjoint-region siblings of one deliberate P1 sub-file
+    # split — their line ranges are pre-verified non-overlapping and their
+    # union covers the whole file (`_check_intra_file_surface`). The judge
+    # is told this in its prompt ("What is NOT a collision"), but a prompt
+    # rule is advisory (§12) — an `unresolvable` verdict between cluster
+    # siblings is always wrong regardless of what the judge's free-text
+    # reasoning says, so it's flagged here as a mechanical issue and fed
+    # back through the existing retry loop (`phase_overlap_judge` passes
+    # `make_feedback_prompt`, unlike the single-pass gates) rather than
+    # trusted to self-correct only from prompt wording.
+    for c in collisions:
+        if c.get("resolution") != "unresolvable":
+            continue
+        a = by_id.get(c.get("a_sid", ""), {})
+        b = by_id.get(c.get("b_sid", ""), {})
+        a_cluster = a.get("_cofile_cluster")
+        b_cluster = b.get("_cofile_cluster")
+        if a_cluster and a_cluster == b_cluster:
+            issues.append(
+                f"SPURIOUS_COFILE_COLLISION: {c.get('a_sid', '?')} <-> "
+                f"{c.get('b_sid', '?')} share _cofile_cluster "
+                f"{a_cluster!r} — same-file/different-region siblings of "
+                "a deliberate sub-file split can never collide; retract "
+                "this finding")
 
     # The overlap judge's `judgment` self-score is NO LONGER a gating axis
     # (DESIGN §8 *Independent adversarial verification*): this worker IS an
@@ -18453,9 +18497,13 @@ async def phase_overlap_judge(plans: list[dict], task: str, st: State,
 
     # Build the judge's input. The worker sees every subtask's
     # id/title/intent/scope_note/files_likely_touched/provides/requires/
-    # depends_on. `requires` is left as the planner-emitted object form
-    # since the judge may want to read `reason` text in addition to
-    # tag/extent.
+    # depends_on/_cofile_cluster. `requires` is left as the planner-emitted
+    # object form since the judge may want to read `reason` text in
+    # addition to tag/extent. `_cofile_cluster` is the same structural
+    # marker `check_planner_output` uses to suppress its INTRA_DOMAIN_OVERLAP
+    # advisory for a deliberate P1 sub-file split (DESIGN §5½ *Sub-file*) —
+    # included here so the judge has a code-derived signal, not just prose
+    # similarity, for recognizing disjoint-region siblings of one file.
     subtask_views: list[dict] = []
     for plan in plans:
         for s in plan.get("subtasks", []) or []:
@@ -18469,6 +18517,7 @@ async def phase_overlap_judge(plans: list[dict], task: str, st: State,
                 "provides": list(s.get("provides", []) or []),
                 "requires": list(s.get("requires", []) or []),
                 "depends_on": list(s.get("depends_on", []) or []),
+                "_cofile_cluster": s.get("_cofile_cluster"),
             })
     payload = {"task": task, "subtasks": subtask_views}
 

--- a/prompts/plan_overlap_judge.md
+++ b/prompts/plan_overlap_judge.md
@@ -63,6 +63,13 @@ flag it.
   *files* but produce *different* artifacts.
 - **Doc-syncs touching the same documentation file** with different
   sections.
+- **Same `_cofile_cluster` value.** Two or more subtasks sharing the same
+  non-null `_cofile_cluster` value are, by construction, disjoint-region
+  siblings of one deliberate sub-file split — the orchestrator
+  code-computed this partition (their line ranges are pre-verified
+  non-overlapping and their union covers the whole file); it is never
+  LLM-decided. Do NOT flag any pair sharing a `_cofile_cluster` value as
+  a collision, regardless of how similar their `intent` text reads.
 
 ## Input
 

--- a/prompts/plan_overlap_judge.md
+++ b/prompts/plan_overlap_judge.md
@@ -84,7 +84,8 @@ The orchestrator gives you, in your prompt, a JSON payload:
      "files_likely_touched": [...],
      "provides": [...],
      "requires": [...],
-     "depends_on": [...]},
+     "depends_on": [...],
+     "_cofile_cluster": "feat-001" or null},
     ...
   ]
 }

--- a/tests/test_check_functions.py
+++ b/tests/test_check_functions.py
@@ -572,6 +572,62 @@ class TestCheckOverlapJudgeOutput:
             output, plans, tmp_path)
         assert any("DROP_BREAKS_GRAPH" in i for i in issues)
 
+    def test_spurious_cofile_collision_flagged(self, leerie, tmp_path):
+        """A P1 sub-file split's region siblings share a _cofile_cluster —
+        an `unresolvable` verdict between them is always wrong (DESIGN
+        §5½ *Sub-file*) and must be flagged regardless of the judge's
+        free-text reasoning."""
+        plans = [{"subtasks": [
+            {"id": "feat-002-r1", "files_likely_touched": ["src/big.ts"],
+             "_cofile_cluster": "feat-002"},
+            {"id": "feat-002-r2", "files_likely_touched": ["src/big.ts"],
+             "_cofile_cluster": "feat-002"},
+        ]}]
+        output = {"collisions": [{
+            "a_sid": "feat-002-r1", "b_sid": "feat-002-r2",
+            "artifact": "src/big.ts", "resolution": "unresolvable",
+            "reason": "identical intents"}]}
+        issues = leerie.check_overlap_judge_output(
+            output, plans, tmp_path)
+        assert any("SPURIOUS_COFILE_COLLISION" in i for i in issues)
+
+    def test_spurious_cofile_collision_not_flagged_for_different_clusters(
+            self, leerie, tmp_path):
+        """A genuine collision between subtasks in DIFFERENT (or absent)
+        _cofile_cluster groups must still be reported — the check must
+        not over-suppress an accidental same-file overlap."""
+        plans = [{"subtasks": [
+            {"id": "feat-002-r1", "files_likely_touched": ["src/big.ts"],
+             "_cofile_cluster": "feat-002"},
+            {"id": "refactor-009", "files_likely_touched": ["src/big.ts"]},
+        ]}]
+        output = {"collisions": [{
+            "a_sid": "feat-002-r1", "b_sid": "refactor-009",
+            "artifact": "src/big.ts", "resolution": "unresolvable",
+            "reason": "genuine conflict"}]}
+        issues = leerie.check_overlap_judge_output(
+            output, plans, tmp_path)
+        assert not any("SPURIOUS_COFILE_COLLISION" in i for i in issues)
+
+    def test_spurious_cofile_collision_ignores_non_unresolvable(
+            self, leerie, tmp_path):
+        """The check only fires on `unresolvable` — a `merge`/`drop_a`/
+        `drop_b` resolution between cluster siblings is not the failure
+        mode this guards against (an unresolvable die() is)."""
+        plans = [{"subtasks": [
+            {"id": "feat-002-r1", "files_likely_touched": ["src/big.ts"],
+             "_cofile_cluster": "feat-002"},
+            {"id": "feat-002-r2", "files_likely_touched": ["src/big.ts"],
+             "_cofile_cluster": "feat-002"},
+        ]}]
+        output = {"collisions": [{
+            "a_sid": "feat-002-r1", "b_sid": "feat-002-r2",
+            "artifact": "src/big.ts", "resolution": "merge",
+            "reason": "unrelated"}]}
+        issues = leerie.check_overlap_judge_output(
+            output, plans, tmp_path)
+        assert not any("SPURIOUS_COFILE_COLLISION" in i for i in issues)
+
 
 # --- check_implementer_output ------------------------------------------ #
 

--- a/tests/test_phase_overlap_judge.py
+++ b/tests/test_phase_overlap_judge.py
@@ -2349,3 +2349,50 @@ def test_phase_log_parts_partition_every_action_shape(
     # shapes this fixture does not enumerate.
     assert parts == {"merge": 3, "drop": 2, "multi_drop": 3,
                      "skipped_redundant": 1, "skipped_would_cycle": 3}, parts
+
+
+def test_subtask_views_include_cofile_cluster():
+    """`phase_overlap_judge`'s `subtask_views` payload build must include
+    `_cofile_cluster` — the same structural marker `check_planner_output`
+    uses to suppress its INTRA_DOMAIN_OVERLAP advisory for a deliberate
+    P1 sub-file split. Without it in the judge's payload, the judge has
+    no code-derived signal (only free-text `intent`/`scope_note`
+    similarity) to recognize disjoint-region siblings of one file — the
+    root cause of a real false-positive "unresolvable surface collision"
+    incident (DESIGN §5 *Cross-domain surface overlap*, §5½ *Sub-file*).
+
+    Source-coupled rather than driven end-to-end: the existing
+    `_run_phase_overlap_judge` test helper stubs `_run_checked_loop`
+    directly, bypassing the `subtask_views` build entirely, so it cannot
+    observe this payload (mirrors test_inspect_tools.py's
+    test_overlap_judge_call_site_uses_inspect_tools pattern for the same
+    reason)."""
+    from pathlib import Path
+    leerie_py = (Path(__file__).resolve().parent.parent
+                 / "orchestrator" / "leerie.py")
+    src = leerie_py.read_text()
+    start = src.index("async def phase_overlap_judge(")
+    end = src.index("\nasync def ", start + 1)
+    body = src[start:end]
+    assert '"_cofile_cluster": s.get("_cofile_cluster")' in body, (
+        "phase_overlap_judge's subtask_views build must include "
+        "_cofile_cluster so the judge has a structural signal for "
+        "disjoint-region same-file siblings"
+    )
+
+
+def test_prompt_documents_cofile_cluster_exclusion():
+    """`prompts/plan_overlap_judge.md`'s "What is NOT a collision" list
+    must name `_cofile_cluster` explicitly — the prompt-side half of the
+    fix (advisory; `check_overlap_judge_output`'s SPURIOUS_COFILE_COLLISION
+    is the code-enforced backstop, per CLAUDE.md §12 "prompts are
+    advisory, code enforces")."""
+    from pathlib import Path
+    prompt_path = (Path(__file__).resolve().parent.parent
+                   / "prompts" / "plan_overlap_judge.md")
+    text = prompt_path.read_text()
+    assert "_cofile_cluster" in text, (
+        "plan_overlap_judge.md must document the _cofile_cluster "
+        "exclusion rule so the judge is told about the signal it's "
+        "given in its payload"
+    )

--- a/tests/test_phase_overlap_judge.py
+++ b/tests/test_phase_overlap_judge.py
@@ -2396,3 +2396,30 @@ def test_prompt_documents_cofile_cluster_exclusion():
         "exclusion rule so the judge is told about the signal it's "
         "given in its payload"
     )
+
+
+def test_prompt_input_example_lists_cofile_cluster():
+    """The literal worked JSON example in `prompts/plan_overlap_judge.md`'s
+    "## Input" section must itself include `_cofile_cluster` as a field
+    on the example subtask object — not just mentioned elsewhere in the
+    file (test_prompt_documents_cofile_cluster_exclusion covers that).
+
+    Regression pin: the "What is NOT a collision" exclusion rule was
+    added referencing `_cofile_cluster`, and the real Python payload
+    build was updated to include it, but the prompt's own worked example
+    of the input shape was initially missed — an LLM reading its own
+    system prompt could reasonably treat that example as the
+    authoritative field list and disregard a field not shown there,
+    silently undermining the fix."""
+    from pathlib import Path
+    prompt_path = (Path(__file__).resolve().parent.parent
+                   / "prompts" / "plan_overlap_judge.md")
+    text = prompt_path.read_text()
+    start = text.index("## Input")
+    end = text.index("## Output", start)
+    input_section = text[start:end]
+    assert "_cofile_cluster" in input_section, (
+        "the ## Input section's worked JSON example must list "
+        "_cofile_cluster as an example subtask field, not just "
+        "reference it elsewhere in the prompt"
+    )

--- a/tests/test_recursive_decompose.py
+++ b/tests/test_recursive_decompose.py
@@ -742,6 +742,59 @@ def test_subfile_oversized_single_file_region_splits(leerie, tmp_path):
     assert covered == set(range(1, 2001))
 
 
+def test_subfile_region_children_have_distinct_intents(leerie, tmp_path):
+    """Regression: region children must NOT copy the parent's identical
+    `intent` verbatim (unlike _migration_child, where verbatim inheritance
+    is safe because chunks own disjoint files). Region children co-own the
+    SAME file, so an unscoped intent gives plan_overlap_judge no textual
+    signal to distinguish siblings — the direct cause of a real false-
+    positive "unresolvable surface collision" incident."""
+    f = tmp_path / "big.ts"
+    _write_lines(f, 2000)
+    parent_intent = ("Add all token-management machinery: probe functions, "
+                      "ranking logic, failover hook.")
+    parent = {
+        "id": "feat-005",
+        "title": "Route everything through the guard",
+        "intent": parent_intent,
+        "success_criteria_seed": "all sites routed",
+        "files_likely_touched": ["big.ts"],
+    }
+    caps = _make_caps(leerie, subfile_split_max_span=700)
+    st = _make_state(leerie, caps)
+    models = {"fit_judge": "opus", "splitter": "opus"}
+    efforts = {"fit_judge": "high", "splitter": "high"}
+    ranges = [("small1", 1, 100), ("giant", 200, 1900), ("small2", 1901, 1950)]
+
+    async def fake_claude_p(*args, schema_key, sid="", **kwargs):
+        if schema_key == "fit_judge":
+            return _fit_response(0.30)
+        pytest.fail(f"no worker expected for a sub-file split, got {schema_key!r}")
+
+    with patch.object(leerie, "_extract_symbol_ranges", return_value=ranges), \
+         patch.object(leerie, "claude_p", new=fake_claude_p):
+        leaves = _run(leerie.recursive_decompose(
+            parent, 0, st, caps, models, efforts, tmp_path))
+
+    assert len(leaves) >= 2
+    intents = [leaf["intent"] for leaf in leaves]
+    assert len(set(intents)) == len(intents), (
+        "region children must have distinct intents, got duplicates: "
+        f"{intents}")
+    for leaf in leaves:
+        assert leaf["intent"] != parent_intent, (
+            "a region child's intent must not be a byte-identical copy "
+            "of the parent's — plan_overlap_judge cannot distinguish "
+            "siblings from unscoped intent text")
+        # Children must extend, not discard, the parent's stated purpose.
+        assert parent_intent in leaf["intent"], (
+            "a region child's intent must still contain the parent's "
+            "original intent text")
+        r = leaf["owned_region"]
+        assert f"lines {r['start']}-{r['end']}" in leaf["intent"], (
+            "a region child's intent must name its own line range")
+
+
 def test_subfile_ids_carry_domain_prefix(leerie, tmp_path):
     """Region-child ids keep the parent's domain prefix so validate_plan's
     id-prefix check and schedule() cross-domain wiring still pass."""


### PR DESCRIPTION
## Summary

- \`_subfile_child\` (P1 recursive decomposition's intra-file split, DESIGN §5½ *Sub-file*) correctly gives each region-owning child a region-scoped \`title\` and \`success_criteria_seed\`, but copied \`intent\` **verbatim** from the parent. Every region child of a large single-file subtask therefore claimed to implement the parent's entire feature with no visible partition, and since \`plan_overlap_judge\`'s prompt explicitly compares subtasks' "APIs/contracts as described in their intents," N region siblings with byte-identical intent read as N subtasks racing to implement the same complete surface — causing a real "unresolvable surface collision" die() on a genuine \`leerie\` self-run.
- **Verified against real production data**, not just the incident log: extracted the actual \`feat-002-r1\`/\`feat-002-r2\` subtask objects from a genuine failed run's persisted \`state.json\` and confirmed byte-identical \`intent\`, exactly as predicted from the code.
- **Live A/B tested** against the real \`claude -p\` judge (real schema, real prompt, real subtask data): the unfixed payload shape reproduced the collision 5/5 times; the fixed payload shape found 0/5. Re-verified 4/4 clean against the actual patched \`_subfile_child\`/\`phase_overlap_judge\`/prompt after implementation.

## Fix (three parts)

1. \`_subfile_child\` now derives a **region-scoped `intent`** (parent intent + line range + symbols), mechanically — no LLM call.
2. \`phase_overlap_judge\`'s \`subtask_views\` payload now includes \`_cofile_cluster\` (the same marker \`check_planner_output\` already uses to suppress its own \`INTRA_DOMAIN_OVERLAP\` advisory for this exact case), and \`prompts/plan_overlap_judge.md\`'s "What is NOT a collision" list now names same-\`_cofile_cluster\` pairs explicitly.
3. \`check_overlap_judge_output\` gets a new **`SPURIOUS_COFILE_COLLISION`** check: any \`unresolvable\` verdict between two subtasks sharing a \`_cofile_cluster\` is flagged and fed back through the judge's existing retry loop, regardless of the judge's own free-text reasoning — a code-enforced backstop per CLAUDE.md §12 ("prompts are advisory, code enforces"), since 6 real runs of the identical task previously produced wildly different collision counts (0/1/3/5) for the same planner input.

\`_migration_child\` is deliberately untouched — its own docstring already states verbatim intent inheritance is intentional there, and it's safe because migration chunks own disjoint files.

## Test plan

- [x] New regression test: \`test_subfile_region_children_have_distinct_intents\` (region children get distinct, non-parent-copy intents that still contain the parent's original text and name their own line range).
- [x] New \`check_overlap_judge_output\` tests: \`SPURIOUS_COFILE_COLLISION\` fires for same-cluster \`unresolvable\` pairs, does NOT fire for different/absent clusters (precision), and only fires on \`unresolvable\` (not \`merge\`/\`drop\`).
- [x] New source-coupling tests confirming \`_cofile_cluster\` reached the judge payload and the prompt exclusion text landed.
- [x] \`pytest tests/test_recursive_decompose.py tests/test_migration_child_aliasing.py tests/test_check_functions.py tests/test_phase_overlap_judge.py tests/test_advisory_vs_gating.py\` — 225/225 passing (3 pre-existing, unrelated skips for a missing \`jsonschema\` dependency).
- [x] \`python3 -c "import ast; ast.parse(...)"\` — clean.
- [x] **Live re-verification against the actual shipped code**: called the real, patched \`_subfile_child\` to build region children, ran them through the real, patched \`phase_overlap_judge\` payload logic and the real, patched \`plan_overlap_judge.md\` prompt via a real \`claude -p\` call — 4/4 clean runs (0 collisions).
- [ ] Full \`pytest tests/\` suite not run in this session (time-boxed); recommend CI run before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)