### PR TITLE
fix: constrain size field to enum and fix drifted integrator schema

### DIFF
--- a/docs/IMPLEMENTATION.md
+++ b/docs/IMPLEMENTATION.md
@@ -7303,8 +7303,12 @@ type. Required fields, current shape:
   out-of-graph prerequisite (other repo, ops runbook, manual step) that
   bypasses the reconciler and surfaces in `plan.json` as a `preconditions`
   entry — see DESIGN §5 `requires.extent`.** `provides` remains an array of
-  bare strings. `size` is `small` or `medium` — `large` is
-  rejected by `validate_plan`. `runs_commands` (array of strings, optional)
+  bare strings. `size` is a schema enum of `small`, `medium`, or `large` —
+  `large` is a legal value the planner/reconciler prompts are told to avoid,
+  not one the schema rejects: it triggers the size-resolution retry loop
+  (see "Size-resolution retry loop" and the size gate under "Phase 2½
+  checks") and, if it survives that retry, `validate_plan` dies with an
+  OVERSIZED/size-related error as the final backstop. `runs_commands` (array of strings, optional)
   declares every command the subtask actually invokes, as structured data —
   populated when the task text prescribes a specific command/script/tool
   invocation the planner gave its own run-the-command subtask (see

--- a/orchestrator/leerie.py
+++ b/orchestrator/leerie.py
@@ -1194,7 +1194,7 @@ SCHEMAS: dict[str, dict] = {
                         "requires": {"type": "array", "items": _REQUIRES_ITEM},
                         "provides": {"type": "array", "items": {"type": "string"}},
                         "success_criteria_seed": {"type": "string"},
-                        "size": {"type": "string"},
+                        "size": {"type": "string", "enum": ["small", "medium", "large"]},
                         "investigation_notes": {"type": "string"},
                         # The commands this subtask actually invokes, as
                         # structured data — so a prescribed-procedure
@@ -1294,7 +1294,7 @@ SCHEMAS: dict[str, dict] = {
                         "requires": {"type": "array", "items": _REQUIRES_ITEM},
                         "provides": {"type": "array", "items": {"type": "string"}},
                         "success_criteria_seed": {"type": "string"},
-                        "size": {"type": "string"},
+                        "size": {"type": "string", "enum": ["small", "medium", "large"]},
                         "investigation_notes": {"type": "string"},
                     },
                 },
@@ -1957,7 +1957,7 @@ SCHEMAS: dict[str, dict] = {
                         "provides": {
                             "type": "array", "items": {"type": "string"}},
                         "success_criteria_seed": {"type": "string"},
-                        "size": {"type": "string"},
+                        "size": {"type": "string", "enum": ["small", "medium", "large"]},
                         "investigation_notes": {"type": "string"},
                     },
                 },
@@ -6472,7 +6472,7 @@ def check_planner_output(
                 "success_criteria_seed")
 
     for s in subtasks:
-        if (s.get("size") or "").lower() == "large":
+        if s.get("size") == "large":
             issues.append(
                 f"OVERSIZED: {s.get('id', '?')} has size='large' "
                 "— split it")
@@ -7590,7 +7590,7 @@ def validate_plan(subtasks: dict) -> None:
             errors.append(f"{sid}: id must start with one of "
                           f"{sorted(_ID_PREFIXES)} — cross-domain collisions "
                           "and audit-trail ambiguity otherwise")
-        if s.get("size", "").lower() == "large":
+        if s.get("size") == "large":
             # Name the actual author. Reconciler-added subtasks carry
             # `_added_by_reconciler: true` (stamped in
             # `_apply_reconciler_output`). The phase 2½ size gate catches
@@ -15011,7 +15011,7 @@ def _find_oversized_added_subtasks(plans: list[dict]) -> list[dict]:
         for s in plan.get("subtasks", []):
             if not s.get("_added_by_reconciler"):
                 continue
-            if (s.get("size") or "").lower() == "large":
+            if s.get("size") == "large":
                 oversized.append(s)
     return oversized
 

--- a/scripts/remote/collect-subtrees.sh
+++ b/scripts/remote/collect-subtrees.sh
@@ -193,7 +193,9 @@ done
 staging="${LEERIE_STATE_DIR}/runs/${run_id}/worktrees/staging"
 leerie_dir="${LEERIE_STATE_DIR}/runs/${run_id}"
 integrator_prompt="${SCRIPTS}/../prompts/integrator.md"
-integrator_schema='{"type":"object","required":["incoming_subtask","status"],"properties":{"incoming_subtask":{"type":"string"},"status":{"type":"string","enum":["resolved","design-conflict","failed"]},"resolution_summary":{"type":"string"},"diagnosis":{"type":["string","null"]}}}'
+# Must be kept in sync with SCHEMAS["integrator"] in orchestrator/leerie.py —
+# this script can't import Python, so there's no other guard against drift.
+integrator_schema='{"type":"object","required":["incoming_subtask","status","confidence"],"properties":{"incoming_subtask":{"type":"string"},"status":{"type":"string","enum":["resolved","design-conflict","failed"]},"resolution_summary":{"type":"string"},"diagnosis":{"type":["string","null"]},"confidence":{"type":"object","required":["resolution","basis","falsifiers_tested","contradictions_reconciled","gap_to_close"],"properties":{"resolution":{"type":"number"},"basis":{"type":"string","maxLength":2000},"falsifiers_tested":{"type":"array","items":{"type":"string","maxLength":500}},"contradictions_reconciled":{"type":"array","items":{"type":"string","maxLength":500}},"gap_to_close":{"type":"object","properties":{"resolution":{"type":"string"}}}}}}}'
 
 integrated_count=0
 resolved_count=0

--- a/tests/test_reconciler_size_gate.py
+++ b/tests/test_reconciler_size_gate.py
@@ -98,14 +98,16 @@ def test_find_oversized_ignores_reconciler_added_small_medium(leerie):
     assert leerie._find_oversized_added_subtasks(plans) == []
 
 
-def test_find_oversized_case_insensitive(leerie):
-    """Defensive: the validate_plan check is case-insensitive (`.lower()`),
-    and the size gate mirrors that — a `Large` or `LARGE` from a
-    misbehaving model is still caught."""
+def test_find_oversized_is_exact_match_only(leerie):
+    """`size` is now a schema enum (`small`/`medium`/`large`), so a
+    non-canonical value like `LARGE` can never reach this function on a
+    schema-valid response — case-insensitivity is enforced at the schema
+    layer (`claude_p()`'s `--json-schema` validation), not here. This
+    function does an exact-match comparison and does not re-fold case."""
     s = _subtask("feat-001", size="LARGE")
     s["_added_by_reconciler"] = True
     plans = [_plan("_reconciler", s)]
-    assert len(leerie._find_oversized_added_subtasks(plans)) == 1
+    assert leerie._find_oversized_added_subtasks(plans) == []
 
 
 def test_find_oversized_returns_all_offenders(leerie):


### PR DESCRIPTION
## Summary

Closes two real gaps found by an audit of CLAUDE.md's structured-output rule ("all natural-language interpretation is done by an LLM worker returning schema-validated structured JSON — never by regex or hand-parsing in Python"):

- **`scripts/remote/collect-subtrees.sh`** shells out to `claude -p` directly for force-finalize conflict resolution, bypassing `claude_p()`. Its inline `integrator_schema` had drifted from `SCHEMAS["integrator"]` in `orchestrator/leerie.py` — missing the `confidence` field/requirement entirely. Fixed to match field-for-field, with a comment documenting the sync obligation (this script can't import Python, so there's no automated guard against future drift).
- **The `size` field** on planner/reconciler/splitter subtask schemas was unconstrained `{"type": "string"}` despite only `small`/`medium`/`large` being valid per the worker prompts, so three call sites did informal Python string matching (`.lower() == "large"`) instead of the schema enforcing it. Constrained the field to `enum: ["small", "medium", "large"]` and simplified the three downstream comparisons to a plain `== "large"` now that a schema-valid response can never be `None`, wrong-case, or a synonym.

Also updated one stale line in `docs/IMPLEMENTATION.md` that said `large` is "rejected by `validate_plan`" — it's actually a legal schema value that triggers a size-resolution retry loop and, if that retry exhausts, `validate_plan`'s backstop check.

## Test plan

- [x] `pytest tests/` — full suite: 4849 passed, 62 skipped (environment-gated: tree-sitter/Linux-only/proc), 0 failed
- [x] `python3 -c "import ast; ast.parse(...)"` on `orchestrator/leerie.py` — OK
- [x] `bash -n scripts/remote/collect-subtrees.sh` — OK
- [x] Structurally diffed the fixed `integrator_schema` JSON against `SCHEMAS["integrator"]` (via `_confidence_schema(["resolution"])`'s real expansion) — exact match, including `maxLength` caps
- [x] Renamed `test_find_oversized_case_insensitive` → `test_find_oversized_is_exact_match_only` since case-insensitivity is now enforced at the schema layer, not in `_find_oversized_added_subtasks` — confirmed no other test in the suite relies on non-canonical `size` casing
- [x] Three independent adversarial audits (parallel Explore agents) of every changed file found zero defects

🤖 Generated with [Claude Code](https://claude.com/claude-code)