### PR TITLE
leerie: Implement out-of-repo dependency bake to /opt/* (finish fix-dep-capture-bake.md)

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -3880,6 +3880,41 @@ classification and planning, layered top-to-bottom by determinism:
      worktree. This is not zero-cost but eliminates download and
      extraction, leaving only symlink creation.
 
+   **Rust and Go require a discardable dummy source file at
+   build time.** Neither `cargo fetch`/`cargo build` nor `go
+   build` will populate their respective build-artifact caches
+   (`CARGO_TARGET_DIR` / `GOCACHE`) against a manifest-only build
+   context (just the lockfile and manifest, no real source) —
+   `cargo` refuses to parse a manifest with no build target at
+   all ("no targets specified"), and `go build ./...` against
+   zero `.go` files is a silent no-op that warms neither cache
+   (only `go mod download`'s module cache, `GOMODCACHE`, warms
+   without one). This is a well-documented Cargo/Go Docker-layer-
+   caching workaround (no `cargo build --dependencies-only`
+   exists): emit a throwaway `src/main.rs` (`fn main() {}`) or
+   `main.go` (a minimal valid package) into the build scratch
+   dir, run the fetch/build step against it to force the
+   dependency graph to compile, then discard the dummy file —
+   never `COPY` it into `/work`. Verified: a real worktree's
+   subsequent build against real source then gets a genuine
+   cache hit from the same baked `CARGO_TARGET_DIR`/`GOCACHE`,
+   fully offline, from a different directory.
+
+   **The Rust bake step must NOT use `cargo build --release`.**
+   Cargo keys its build cache by profile — `debug/` and
+   `release/` are separate subtrees under `CARGO_TARGET_DIR` —
+   so a `--release` bake produces **zero cache benefit** for a
+   plain `cargo build`/`cargo test`, both of which default to
+   the debug profile (the profile implementer/conformer workers
+   actually use). Reproduced live as a real defect during this
+   feature's implementation: baking with `--release` left a real
+   worktree's subsequent `cargo build` recompiling every
+   dependency from scratch (`Compiling serde`, not `Fresh
+   serde`); dropping `--release` from the bake fixed it
+   (`Fresh serde_core`/`Fresh serde`, confirmed for both `cargo
+   build` and `cargo test`). Go has no equivalent profile split,
+   so this trap is Rust-specific.
+
    **Immutability invariant:** The baked layer is shared and
    read-only across up to `max_parallel` (default 5) concurrent
    worktrees. A worktree that changes a dependency (edits
@@ -3897,12 +3932,40 @@ classification and planning, layered top-to-bottom by determinism:
    correctly handle dependency *removal* (uninstalling a package
    from the overlay leaves it visible in the base) or a fresh
    venv's isolation from another venv's packages (site-packages
-   leaks across environments). The only correct mechanism is `cp
-   -r /opt/venv` into a private, relocated copy, then `pip install
-   -e .` or `pip uninstall` the diff. This materializes a full
-   private environment only when a worktree's subtask actually
-   mutates dependencies — the common case (no mutation) consumes
-   the shared `/opt/venv` directly with zero clone cost.
+   leaks across environments). The correct mechanism is `cp -r
+   /opt/venv` into a private copy, then apply the dependency
+   delta via `pip install`/`pip uninstall`. **No `pyvenv.cfg`
+   editing or `bin/` shebang relocation is needed** — verified
+   live: `pyvenv.cfg`'s `home =` line points at the system Python
+   install, not the venv itself, and is unaffected by moving the
+   clone to an arbitrary path. The one real trap is invoking the
+   clone's `bin/pip` directly: that script's shebang is hardcoded
+   to the *original* `/opt/venv`'s python binary, so `bin/pip
+   install`/`bin/pip uninstall` silently operate on the shared
+   `/opt/venv` instead of the clone — corrupting the bake for
+   every other concurrent worktree (reproduced live: an install
+   and an uninstall both leaked through a naive `cp -r` clone).
+   The fix is an invocation convention, not a relocation script:
+   always run `<clone>/bin/python3 -m pip install|uninstall`,
+   never `<clone>/bin/pip`. `python3` resolves correctly via its
+   own relative symlink regardless of where the clone lives, and
+   `-m pip` runs pip as a module inside that interpreter's own
+   `sys.prefix` — sidestepping the shebang trap entirely. This
+   materializes a full private environment only when a worktree's
+   subtask actually mutates dependencies — the common case (no
+   mutation) consumes the shared `/opt/venv` directly with zero
+   clone cost. `uv`/`poetry`/`pipenv` (as opposed to plain `pip`)
+   have their own, less reliable active-venv detection — `uv
+   sync` silently ignores `VIRTUAL_ENV` unless `--active` is
+   passed (verified live: without it, `uv` creates its own
+   `.venv` in the current directory instead of using the baked
+   venv), and `pipenv` has long-standing open bugs about not
+   respecting an already-active venv at all. The bake sidesteps
+   this by installing the tool itself into `/opt/venv` via pip at
+   build time, so the tool's own `/opt/venv/bin/<tool>` binary
+   resolves `sys.prefix` correctly by construction, the same
+   interpreter-path mechanism as the `python3 -m pip` convention
+   above — not environment-variable-based active-venv detection.
 
    **Cache invalidation is preserved.** The existing
    rebuild-decision mechanism — SHA-256 of every

--- a/docs/IMPLEMENTATION.md
+++ b/docs/IMPLEMENTATION.md
@@ -429,10 +429,10 @@ ecosystem:
 
 | Ecosystem | Bake target | Env var(s) | Notes |
 |---|---|---|---|
-| Python | `/opt/venv` | `VIRTUAL_ENV=/opt/venv`, `PATH` includes `/opt/venv/bin` | Virtual environment activated in the image; workers inherit it |
+| Python | `/opt/venv` | `VIRTUAL_ENV=/opt/venv`, `PATH` includes `/opt/venv/bin` | Virtual environment activated in the image; workers inherit it. `uv`/`poetry`/`pipenv` are installed INTO `/opt/venv` at build time (via `pip`) rather than relying on their own active-venv env-var detection — verified unreliable for `uv sync` (ignores `VIRTUAL_ENV` without `--active`) and `pipenv` (long-standing bugs). Plain `pip install -r requirements.txt` needs no such workaround. |
 | Ruby | `/opt/bundle` | `BUNDLE_PATH=/opt/bundle`, `BUNDLE_APP_CONFIG=/opt/bundle` | Gems installed here; Bundler finds them without per-worktree install |
-| Rust | Baked build artifacts + warmed cache | `CARGO_TARGET_DIR`, `CARGO_HOME` (warmed registry) | `cargo build` reuses compiled deps, no network |
-| Go | Baked cache + warmed modules | `GOCACHE`, `GOMODCACHE` (warmed) | `go build` network-free, reuses module cache |
+| Rust | Baked build artifacts + warmed cache | `CARGO_TARGET_DIR`, `CARGO_HOME` (warmed registry) | `cargo build` reuses compiled deps, no network. Requires a discardable dummy `src/main.rs` at build time — `cargo` cannot fetch/build against a manifest-only context with zero source files (see DESIGN §6½). The bake step must build the **debug** profile (no `--release`) — Cargo's cache is profile-keyed, so a `--release` bake shares nothing with the debug-profile `cargo build`/`cargo test` workers actually run. |
+| Go | Baked cache + warmed modules | `GOCACHE`, `GOMODCACHE` (warmed) | `go build` network-free, reuses module cache. Requires a discardable dummy `.go` file at build time — `go mod download` alone warms only `GOMODCACHE`, not `GOCACHE` (see DESIGN §6½). |
 | Node/pnpm | Warmed content-addressable store | pnpm store path, `frozenStore` set | Residual per-run: `pnpm install --offline --frozen-lockfile` relinks only |
 
 **`PROVISION_RECIPE` contract (updated):** For baked ecosystems
@@ -463,10 +463,16 @@ mismatch: a repo with only language dependencies and no apt packages would
 skip the bake entirely, forcing per-run installs. The corrected spec: generate
 the Dockerfile when **any** of the following are present: (1)
 `setup_packages` non-empty, (2) a dependency lockfile exists (`package-lock.json`,
-`pnpm-lock.yaml`, `requirements.txt`, `Pipfile.lock`, `Gemfile.lock`,
-`Cargo.lock`, `go.sum`, etc.), or (3) `language_installs` is non-empty. This
-aligns the emitter with the design intent (DESIGN §6½ *Persistent out-of-repo
-dependency bake*).
+`pnpm-lock.yaml`, `yarn.lock`, `uv.lock`, `poetry.lock`, `Pipfile.lock`,
+`Gemfile.lock`, `Cargo.lock`, `go.mod`+`go.sum` together, `composer.lock`,
+`packages.lock.json`), or (3) `language_installs` is non-empty. This aligns
+the emitter with the design intent (DESIGN §6½ *Persistent out-of-repo
+dependency bake*). Bare `requirements.txt` (no lockfile) is deliberately
+EXCLUDED from this list, mirroring `_lockfile_table_entries`'s existing,
+deliberate exclusion of the same file — it's the ambiguous tail that goes to
+the LLM-driven `dep_capture` fallback, not the deterministic table, so it
+must not trigger a bake either (a bake based on a guessed install command is
+worse than no bake).
 
 ### Registry publish path (fly.io / remote Machines)
 

--- a/leerie
+++ b/leerie
@@ -4467,6 +4467,59 @@ _leerie_repo_id() {
   printf '%s' "$sanitized"
 }
 
+# Shared gating check (IMPLEMENTATION.md §0.5 "Auto-generation triggers"):
+# true when a Dockerfile should be auto-generated because ANY of (1)
+# setup_packages is non-empty, (2) a known dependency lockfile is present in
+# the repo, or (3) language_installs is non-empty in .leerie/config.toml.
+# Used by both resolve_repo_image_tag (the early-return gate) and the main
+# generation body, so the two can never drift out of sync on what counts as
+# "this repo needs a bake."
+#
+# Args: $1 = repo dir, $2 = setup_packages value (already extracted by the
+# caller — avoids re-parsing config.toml twice per call site).
+_leerie_should_generate_dockerfile() {
+  local _repo="$1" _sp_val="$2"
+  if [ -n "$_sp_val" ]; then
+    return 0
+  fi
+  # Mirrors orchestrator/leerie.py's _lockfile_table_entries exactly — bare
+  # requirements.txt / bare pyproject.toml (no lockfile) is deliberately
+  # EXCLUDED here too: it's the ambiguous tail that goes to the LLM
+  # fallback, not the deterministic table, so it must not trigger a bake
+  # either (a bake based on a guess is worse than no bake).
+  for _lf in package-lock.json pnpm-lock.yaml yarn.lock \
+             uv.lock poetry.lock Pipfile.lock \
+             Gemfile.lock Cargo.lock composer.lock \
+             packages.lock.json; do
+    if [ -f "$_repo/$_lf" ]; then
+      unset _lf
+      return 0
+    fi
+  done
+  unset _lf
+  # Go needs BOTH go.mod and go.sum (mirrors _lockfile_table_entries).
+  if [ -f "$_repo/go.mod" ] && [ -f "$_repo/go.sum" ]; then
+    return 0
+  fi
+  local _li_cfg="$_repo/.leerie/config.toml"
+  if [ -f "$_li_cfg" ]; then
+    local _li
+    _li="$( { grep -E '^[[:space:]]*language_installs[[:space:]]*=' \
+                  "$_li_cfg" 2>/dev/null \
+              || true; } \
+            | head -1 \
+            | sed -E 's/^[[:space:]]*language_installs[[:space:]]*=[[:space:]]*//;
+                      s/[[:space:]]*$//')"
+    # language_installs is a JSON array string in config.toml; "[]" (or
+    # quoted "[]") means empty/absent, anything else non-blank means present.
+    case "$_li" in
+      ""|'""'|"''"|'[]'|'"[]"'|"'[]'") : ;;
+      *) return 0 ;;
+    esac
+  fi
+  return 1
+}
+
 # Returns the per-repo image tag when a .leerie/Dockerfile is present
 # (real or auto-generated); empty string otherwise.
 resolve_repo_image_tag() {
@@ -4482,12 +4535,16 @@ resolve_repo_image_tag() {
                     s/[[:space:]]*$//;
                     s/^"(.*)"$/\1/;
                     s/^'"'"'(.*)'"'"'$/\1/')"
-    if [ -z "$sp" ]; then
-      # No Dockerfile and no setup_packages — use base image.
+    # Bug fix: this early-return previously checked setup_packages ONLY, so a
+    # repo with a lockfile / language_installs but no setup_packages fell
+    # through to the base image with no bake at all (IMPLEMENTATION.md §0.5
+    # "Dockerfile-emitter gating"). Broaden via the shared helper.
+    if ! _leerie_should_generate_dockerfile "$USER_REPO" "$sp"; then
+      # No Dockerfile and nothing to bake — use base image.
       echo ""
       return
     fi
-    # setup_packages is set; a Dockerfile will be auto-generated (see below).
+    # Something to bake; a Dockerfile will be auto-generated (see below).
   fi
   local repo_id
   repo_id="$(_leerie_repo_id)"
@@ -4636,28 +4693,38 @@ if [ "$_leerie_do_gen" = "true" ]; then
                     s/[[:space:]]*$//;
                     s/^"(.*)"$/\1/;
                     s/^'"'"'(.*)'"'"'$/\1/')"
-  if [ -n "$_sp" ]; then
-    # Convert comma-separated list to space-separated package names.
-    _sp_packages="$(printf '%s' "$_sp" | tr ',' ' ' | tr -s ' ')"
-    remote_log "auto-generating .leerie/Dockerfile from setup_packages: $_sp_packages"
+  # Bug fix: this used to be `if [ -n "$_sp" ]; then` — the whole generation
+  # body (apt layer, language-dep layer, build-verify fallback) skipped
+  # entirely for a repo with a lockfile / language_installs but no
+  # setup_packages (IMPLEMENTATION.md §0.5 "Dockerfile-emitter gating").
+  # Broaden the outer gate via the shared helper; the apt-package loop below
+  # stays conditional on `$_sp` specifically so a repo with zero system
+  # packages gets a Dockerfile with no dangling/empty apt RUN.
+  if _leerie_should_generate_dockerfile "$USER_REPO" "$_sp"; then
+    remote_log "auto-generating .leerie/Dockerfile (setup_packages=${_sp:-<none>})"
     mkdir -p "$USER_REPO/.leerie"
     # Write to a temp file then move atomically so a half-written file is
     # never visible to the hash check below.
     _gen_df_tmp="$USER_REPO/.leerie/.Dockerfile.gen.$$"
     printf '%s\n' "$LEERIE_GENERATED_SENTINEL" > "$_gen_df_tmp"
-    printf 'ARG BASE_IMAGE\nFROM $BASE_IMAGE\nUSER root\nRUN apt-get update && apt-get install -y --no-install-recommends \\\n' \
-      >> "$_gen_df_tmp"
-    for _pkg in $_sp_packages; do
-      printf '    %s \\\n' "$_pkg" >> "$_gen_df_tmp"
-    done
-    # End the apt layer with the image still at USER root. Do NOT append a
-    # trailing `USER leerie`: the base image's ENTRYPOINT (container-entry.sh)
-    # is inherited here and MUST run as PID-1 root to set up cgroup containment
-    # and launch the cgroup broker before dropping to leerie via `runuser` (see
-    # DESIGN §6; the base Dockerfile omits `USER leerie` for the same reason).
-    # A trailing `USER leerie` makes PID 1 run as leerie → cgroup writes, the
-    # broker socket bind, and `runuser` all fail EACCES and the container exits 1.
-    printf '    && rm -rf /var/lib/apt/lists/*\n' >> "$_gen_df_tmp"
+    printf 'ARG BASE_IMAGE\nFROM $BASE_IMAGE\nUSER root\n' >> "$_gen_df_tmp"
+    if [ -n "$_sp" ]; then
+      # Convert comma-separated list to space-separated package names.
+      _sp_packages="$(printf '%s' "$_sp" | tr ',' ' ' | tr -s ' ')"
+      printf 'RUN apt-get update && apt-get install -y --no-install-recommends \\\n' \
+        >> "$_gen_df_tmp"
+      for _pkg in $_sp_packages; do
+        printf '    %s \\\n' "$_pkg" >> "$_gen_df_tmp"
+      done
+      # End the apt layer with the image still at USER root. Do NOT append a
+      # trailing `USER leerie`: the base image's ENTRYPOINT (container-entry.sh)
+      # is inherited here and MUST run as PID-1 root to set up cgroup containment
+      # and launch the cgroup broker before dropping to leerie via `runuser` (see
+      # DESIGN §6; the base Dockerfile omits `USER leerie` for the same reason).
+      # A trailing `USER leerie` makes PID 1 run as leerie → cgroup writes, the
+      # broker socket bind, and `runuser` all fail EACCES and the container exits 1.
+      printf '    && rm -rf /var/lib/apt/lists/*\n' >> "$_gen_df_tmp"
+    fi
 
     # Language-dep layer (gated on bake_language_deps, default true).
     # Every COPY-input sha is embedded as a comment inside the Dockerfile so the
@@ -4704,7 +4771,22 @@ def _hash_copy_files(repo, copy_files):
     return copy_shas
 
 
-def _emit_layer(copy_files, run_cmd, copy_shas):
+def _emit_layer(copy_files, run_cmd, copy_shas, workdir=None, env_lines=None,
+                 pre_run_lines=None):
+    """Emit the COPY-input-shas comment, an optional `WORKDIR` (out-of-`/work`
+    build scratch dir — never write the /work-mounted tree at build time, see
+    DESIGN §6½ and the darwin no-clobber invariant), optional `ENV` lines
+    (baked ecosystem env like VIRTUAL_ENV/BUNDLE_PATH/CARGO_TARGET_DIR/
+    GOCACHE — must be present in the image so the bake target survives into
+    every container run), the COPY lines, any pre-RUN lines (e.g. a discarded
+    dummy source file some ecosystems need to give their build tool a valid
+    target — see the Rust/Go branches below), and finally the RUN line.
+
+    copy_files/copy_shas stay REPO-RELATIVE regardless of workdir — hashing
+    covers the real dependency-input files, not the scratch dir the install
+    writes into, so the existing .dockerfile-hash cache-invalidation
+    mechanism (leerie:~4982) is unaffected by where the RUN line installs to.
+    """
     sha_comment = "# copy-input-shas: " + " ".join(
         f"{k}={v[:12]}" for k, v in sorted(copy_shas.items())
     )
@@ -4720,11 +4802,20 @@ def _emit_layer(copy_files, run_cmd, copy_shas):
     top_level = [c for c in copy_files if not _needs_own_copy(c)]
     own = [c for c in copy_files if _needs_own_copy(c)]
     print(sha_comment)
+    if workdir:
+        # WORKDIR creates the dir if absent — no separate mkdir needed. This
+        # is what keeps the install OUT of the inherited /work WORKDIR: every
+        # COPY/RUN below runs relative to this scratch dir instead.
+        print(f"WORKDIR {workdir}")
+    for line in (env_lines or []):
+        print(f"ENV {line}")
     if top_level:
         print("COPY " + " ".join(top_level) + " ./")
     for c in own:
         # Directories keep their trailing slash on both sides; files map 1:1.
         print(f"COPY {c} ./{c}")
+    for line in (pre_run_lines or []):
+        print(line)
     print(f"RUN {run_cmd}")
 
 
@@ -4764,6 +4855,103 @@ def _node_ancillary(repo, copy_files):
                 copy_files.append(rel)
     if (repo / "patches").is_dir() and "patches/" not in copy_files:
         copy_files.append("patches/")
+
+
+# Out-of-repo bake targets (DESIGN §6½, IMPLEMENTATION.md §0.5). Node/pnpm is
+# deliberately absent: node_modules cannot be fully baked (must live in the
+# repo tree for resolution), so the pnpm/yarn/npm install still targets the
+# inherited /work WORKDIR — only the pnpm *store* is warmed (via the existing
+# npm_config_store_dir cache mount, already wired at runtime), unchanged by
+# this feature. Composer/.NET are also left targeting /work: no verified
+# out-of-repo bake exists for them yet (out of scope — Python/Ruby/Rust/Go
+# are the four ecosystems this feature covers per the plan).
+#
+# Rust and Go both need a discardable dummy source file at build time: neither
+# `cargo build`/`cargo fetch` nor `go build` will populate their respective
+# build-artifact caches (CARGO_TARGET_DIR / GOCACHE) against a manifest-only
+# COPY context with zero real source files — `cargo` refuses to parse a
+# manifest with no build target at all, and `go build ./...` against zero .go
+# files is a silent no-op that warms neither cache. This is a well-documented
+# Cargo/Go Docker-layer-caching workaround (no `cargo build
+# --dependencies-only` exists) — live-verified this session: a genuine cache
+# hit (`Fresh serde`/`packagefile ...` reused, zero network) from a REAL
+# worktree afterward, against the same baked CARGO_TARGET_DIR/GOCACHE, from a
+# different directory, fully offline.
+def _bake_params_for_manager(manager, run_cmd):
+    """Returns (workdir, env_lines, pre_run_lines, run_cmd) for a bakeable
+    manager, or None if this manager doesn't have a verified out-of-repo bake
+    (falls back to the original /work-targeting run_cmd unchanged)."""
+    m = (manager or "").lower()
+    if m in ("pip", "pip3"):
+        # Plain pip installing from requirements.txt: `pip install -r ...`
+        # already targets whatever interpreter runs it, so putting
+        # /opt/venv/bin first on PATH (baked ENV) is sufficient — no
+        # per-tool active-venv detection involved.
+        return (
+            "/opt/python-build",
+            ["VIRTUAL_ENV=/opt/venv", "PATH=/opt/venv/bin:$PATH"],
+            ["RUN python3 -m venv /opt/venv"],
+            run_cmd,
+        )
+    if m in ("uv", "poetry", "pipenv"):
+        # These tools' own active-venv detection is inconsistent and
+        # live-verified to be unreliable via VIRTUAL_ENV/PATH alone: `uv
+        # sync` silently IGNORES VIRTUAL_ENV unless --active is passed
+        # (verified live this session — without it, uv creates its own
+        # .venv in the build scratch dir instead of /opt/venv); pipenv has
+        # long-standing open bugs about not respecting an already-active
+        # venv at all (pypa/pipenv#1021). Sidestep per-tool detection
+        # entirely: install the tool ITSELF into /opt/venv via pip first,
+        # so when /opt/venv/bin/<tool> runs, its own interpreter's
+        # sys.prefix IS /opt/venv — the same interpreter-path-derived
+        # resolution verified for `python3 -m pip` in the clone+delta
+        # mechanism (1b below), not env-var-based active-venv detection.
+        tool = m
+        extra_flag = " --active" if m == "uv" else ""
+        fixed_run_cmd = run_cmd + extra_flag
+        return (
+            "/opt/python-build",
+            ["VIRTUAL_ENV=/opt/venv", "PATH=/opt/venv/bin:$PATH"],
+            [
+                "RUN python3 -m venv /opt/venv",
+                f"RUN /opt/venv/bin/python3 -m pip install {tool}",
+            ],
+            fixed_run_cmd,
+        )
+    if m in ("bundle", "gem"):
+        return (
+            "/opt/ruby-build",
+            ["BUNDLE_PATH=/opt/bundle", "BUNDLE_APP_CONFIG=/opt/bundle"],
+            [],
+            run_cmd,
+        )
+    if m == "cargo":
+        return (
+            "/opt/rust-build",
+            ["CARGO_TARGET_DIR=/opt/cargo-target"],
+            # Dummy target so `cargo fetch`/`cargo build` have something to
+            # resolve the dependency graph against — discarded, never COPY'd
+            # into /work.
+            ["RUN mkdir -p src && printf 'fn main() {}' > src/main.rs"],
+            # NO --release: cargo keys its build cache by profile
+            # (debug/ vs release/ under CARGO_TARGET_DIR) — a --release bake
+            # produces ZERO cache benefit for a normal `cargo build`/`cargo
+            # test` (both default to the debug profile, which is what
+            # implementer/conformer workers actually run). Verified live:
+            # baking with --release left a real worktree's plain `cargo
+            # build` fully recompiling every dependency from scratch
+            # ("Compiling serde", not "Fresh serde"); dropping --release
+            # fixed it (confirmed "Fresh serde_core"/"Fresh serde").
+            "cargo fetch && cargo build --offline && rm -rf src",
+        )
+    if m == "go":
+        return (
+            "/opt/go-build",
+            ["GOCACHE=/opt/go-cache"],
+            ["RUN printf 'package main\\nfunc main() {}\\n' > _leerie_dummy.go"],
+            "go mod download && go build ./... && rm -f _leerie_dummy.go",
+        )
+    return None
 
 
 # Node package managers whose frozen install reads patches/, workspace
@@ -4825,11 +5013,30 @@ if persisted_installs:
         # ENOENT on a patch and silently degrades to apt-only (DESIGN §6½).
         if _is_node_context(repo, entry.get("manager")):
             _node_ancillary(repo, copy_files)
+        # _filter_residual_deps (already shipped, untouched — see
+        # orchestrator/leerie.py) strips bakeable managers out of what gets
+        # persisted to config.toml, so this branch should rarely see one. But
+        # a stale config.toml from before this feature landed could still
+        # carry a bakeable manager's command — route it through the same
+        # /opt/* bake params rather than emit a raw /work-targeting RUN.
+        bake = _bake_params_for_manager(entry.get("manager"), run_cmd)
+        if bake:
+            workdir, env_lines, pre_run_lines, run_cmd = bake
+        else:
+            workdir = env_lines = pre_run_lines = None
         if copy_files:
             copy_shas = _hash_copy_files(repo, copy_files)
-            _emit_layer(copy_files, run_cmd, copy_shas)
+            _emit_layer(copy_files, run_cmd, copy_shas, workdir=workdir,
+                        env_lines=env_lines, pre_run_lines=pre_run_lines)
         else:
-            # No valid copy inputs: emit RUN without COPY.
+            # No valid copy inputs: emit RUN without COPY (still honor
+            # workdir/env_lines/pre_run_lines for a bakeable manager).
+            if workdir:
+                print(f"WORKDIR {workdir}")
+            for line in (env_lines or []):
+                print(f"ENV {line}")
+            for line in (pre_run_lines or []):
+                print(line)
             print(f"RUN {run_cmd}")
         emitted = True
     sys.exit(0 if emitted else 0)
@@ -4849,6 +5056,7 @@ has_dotnet = (repo / "packages.lock.json").is_file()
 
 copy_files = []
 run_cmd = ""
+manager = None
 
 if has_pnpm:
     copy_files.append("pnpm-lock.yaml")
@@ -4856,54 +5064,65 @@ if has_pnpm:
         copy_files.append("package.json")
     _node_ancillary(repo, copy_files)
     run_cmd = "pnpm install --frozen-lockfile"
+    manager = "pnpm"
 elif has_yarn:
     copy_files.append("yarn.lock")
     if (repo / "package.json").is_file():
         copy_files.append("package.json")
     _node_ancillary(repo, copy_files)
     run_cmd = "yarn install --frozen-lockfile"
+    manager = "yarn"
 elif has_npm:
     copy_files.append("package-lock.json")
     if (repo / "package.json").is_file():
         copy_files.append("package.json")
     _node_ancillary(repo, copy_files)
     run_cmd = "npm ci"
+    manager = "npm"
 elif has_uv:
     copy_files.append("uv.lock")
     if (repo / "pyproject.toml").is_file():
         copy_files.append("pyproject.toml")
     run_cmd = "uv sync"
+    manager = "uv"
 elif has_poetry:
     copy_files.append("poetry.lock")
     if (repo / "pyproject.toml").is_file():
         copy_files.append("pyproject.toml")
     run_cmd = "poetry install"
+    manager = "poetry"
 elif has_pipenv:
     copy_files.append("Pipfile.lock")
     if (repo / "Pipfile").is_file():
         copy_files.append("Pipfile")
     run_cmd = "pipenv install"
+    manager = "pipenv"
 elif has_go:
     copy_files += ["go.mod", "go.sum"]
     run_cmd = "go mod download"
+    manager = "go"
 elif has_cargo:
     copy_files.append("Cargo.lock")
     if (repo / "Cargo.toml").is_file():
         copy_files.append("Cargo.toml")
     run_cmd = "cargo fetch"
+    manager = "cargo"
 elif has_bundle:
     copy_files.append("Gemfile.lock")
     if (repo / "Gemfile").is_file():
         copy_files.append("Gemfile")
     run_cmd = "bundle install"
+    manager = "bundle"
 elif has_composer:
     copy_files.append("composer.lock")
     if (repo / "composer.json").is_file():
         copy_files.append("composer.json")
     run_cmd = "composer install --no-interaction"
+    manager = "composer"
 elif has_dotnet:
     copy_files.append("packages.lock.json")
     run_cmd = "dotnet restore"
+    manager = "dotnet"
 
 if not run_cmd:
     sys.exit(0)
@@ -4913,11 +5132,25 @@ if not run_cmd:
 # only a lockfile bump — triggers a rebuild. A patch edit that leaves the
 # lockfile untouched must still invalidate the image (DESIGN §6½: "every
 # lockfile that participates in the COPY list"; patches participate).
+# NOTE: copy_files stays repo-relative here regardless of the bake's WORKDIR
+# below — hashing covers the real dependency-input files, not the scratch
+# dir the install writes into.
 copy_shas = _hash_copy_files(repo, copy_files)
+
+# Out-of-repo bake (DESIGN §6½): Python/Ruby/Rust/Go target /opt/* instead of
+# the inherited /work WORKDIR. Node/composer/dotnet are unchanged (no
+# verified bake target — Node's node_modules must live in the repo tree; see
+# _bake_params_for_manager's docstring).
+bake = _bake_params_for_manager(manager, run_cmd)
+if bake:
+    workdir, env_lines, pre_run_lines, run_cmd = bake
+else:
+    workdir = env_lines = pre_run_lines = None
 
 # Emit COPY + RUN lines.
 # Shas are embedded as a comment so the Dockerfile sha captures dep-input drift.
-_emit_layer(copy_files, run_cmd, copy_shas)
+_emit_layer(copy_files, run_cmd, copy_shas, workdir=workdir,
+            env_lines=env_lines, pre_run_lines=pre_run_lines)
 PY
       # Guard the exit code so `set -e` never aborts before the temp file is
       # cleaned up (mirrors the _launch_stderr/_early_probe_stderr sites), then
@@ -4956,17 +5189,23 @@ PY
            "$USER_REPO" \
            >/dev/null 2>&1; then
         remote_log "warning: language-dep Dockerfile build failed; falling back to apt-only bake (bake_language_deps=false for this run)"
-        # Regenerate apt-only Dockerfile without the language-dep layer.
+        # Regenerate without the language-dep layer. Bug fix: this used to
+        # unconditionally emit an apt RUN (looping possibly-unset
+        # $_sp_packages) even for a repo with no setup_packages — guard it
+        # the same way as the primary apt layer above.
         _gen_df_tmp2="$USER_REPO/.leerie/.Dockerfile.gen2.$$"
         printf '%s\n' "$LEERIE_GENERATED_SENTINEL" > "$_gen_df_tmp2"
-        printf 'ARG BASE_IMAGE\nFROM $BASE_IMAGE\nUSER root\nRUN apt-get update && apt-get install -y --no-install-recommends \\\n' \
-          >> "$_gen_df_tmp2"
-        for _pkg2 in $_sp_packages; do
-          printf '    %s \\\n' "$_pkg2" >> "$_gen_df_tmp2"
-        done
-        # End at USER root — no trailing `USER leerie` (see the primary
-        # generator above: PID-1 must be root for cgroup containment).
-        printf '    && rm -rf /var/lib/apt/lists/*\n' >> "$_gen_df_tmp2"
+        printf 'ARG BASE_IMAGE\nFROM $BASE_IMAGE\nUSER root\n' >> "$_gen_df_tmp2"
+        if [ -n "$_sp" ]; then
+          printf 'RUN apt-get update && apt-get install -y --no-install-recommends \\\n' \
+            >> "$_gen_df_tmp2"
+          for _pkg2 in $_sp_packages; do
+            printf '    %s \\\n' "$_pkg2" >> "$_gen_df_tmp2"
+          done
+          # End at USER root — no trailing `USER leerie` (see the primary
+          # generator above: PID-1 must be root for cgroup containment).
+          printf '    && rm -rf /var/lib/apt/lists/*\n' >> "$_gen_df_tmp2"
+        fi
         mv "$_gen_df_tmp2" "$_leerie_dockerfile"
         unset _gen_df_tmp2 _pkg2
       else
@@ -5826,9 +6065,26 @@ CACHE_MOUNTS=(
   -e "CARGO_HOME=/home/leerie/.cache/leerie/cargo"
   -e "COREPACK_HOME=/home/leerie/.cache/leerie/corepack"
   -v "$HOME/.cache/leerie/bundle:/home/leerie/.cache/leerie/bundle"
-  -e "BUNDLE_PATH=/home/leerie/.cache/leerie/bundle"
   -e "BUNDLE_CACHE_ALL=1"
 )
+# BUNDLE_PATH: when the per-repo image actually baked gems to /opt/bundle
+# (DESIGN §6½), this `-e` must point there too — a later `-e` wins over an
+# earlier Dockerfile `ENV`, so leaving this at the cache-mount path would
+# silently shadow the bake and send `bundle exec` back to a stale/empty
+# cache dir instead of the baked gems. But /opt/bundle only exists in
+# images that were actually built with the Ruby bake (bake_language_deps
+# disabled, or a build that fell back to apt-only, produces no /opt/bundle
+# at all — pointing BUNDLE_PATH there unconditionally would break `bundle
+# install` for those repos: verified live, "File system is read-only" /
+# ENOENT against a nonexistent, unmounted /opt/bundle). Detect the bake by
+# checking the on-disk Dockerfile (real or auto-generated, already
+# resolved by this point) for the baked ENV line, rather than assuming.
+if [ -f "$USER_REPO/.leerie/Dockerfile" ] && \
+   grep -q '^ENV BUNDLE_PATH=/opt/bundle' "$USER_REPO/.leerie/Dockerfile" 2>/dev/null; then
+  CACHE_MOUNTS+=(-e "BUNDLE_PATH=/opt/bundle")
+else
+  CACHE_MOUNTS+=(-e "BUNDLE_PATH=/home/leerie/.cache/leerie/bundle")
+fi
 # MISE_DATA_DIR / MISE_SYSTEM_DATA_DIR are baked into the image as ENV
 # (Dockerfile) so the resolver and mount target are stable across
 # launcher invocations. Not user-tunable here.

--- a/leerie
+++ b/leerie
@@ -4786,6 +4786,15 @@ def _emit_layer(copy_files, run_cmd, copy_shas, workdir=None, env_lines=None,
     covers the real dependency-input files, not the scratch dir the install
     writes into, so the existing .dockerfile-hash cache-invalidation
     mechanism (leerie:~4982) is unaffected by where the RUN line installs to.
+
+    NOTE: this WORKDIR is never reset back to /work afterward, so it leaks
+    into the final image's baked WORKDIR config. Confirmed harmless: the
+    launcher's `nerdctl run` always passes an explicit `-w /work`
+    (leerie:~7503), which overrides any image-baked WORKDIR at container
+    start; every worker subprocess additionally passes its own explicit
+    `cwd=worktree` (orchestrator/leerie.py's claude_p/run_proc calls) rather
+    than inheriting cwd from the container. Nothing in this codebase relies
+    on the image's own WORKDIR value.
     """
     sha_comment = "# copy-input-shas: " + " ".join(
         f"{k}={v[:12]}" for k, v in sorted(copy_shas.items())

--- a/prompts/conformer.md
+++ b/prompts/conformer.md
@@ -64,7 +64,12 @@ The orchestrator gives you, in your prompt:
   install then. The shared package-manager caches make re-running
   fast. If the block is absent, the orchestrator detected no install
   command for this repo (or the run is docs-only) — proceed with
-  BUILD/LINT/TEST as given.
+  BUILD/LINT/TEST as given. For Python repos where the implementer
+  changed dependencies, use whichever venv it left behind (its private
+  `.venv-private` clone, or the shared `/opt/venv` if unchanged) —
+  never install directly into `/opt/venv` yourself; see
+  `prompts/implementer.md`'s "Python dependency changes" section for
+  the mechanism and why (DESIGN §6½).
 - Possibly a `BASELINE:` block recording the build/lint/test health of
   the **base tree** (before any subtask's change), measured by the
   orchestrator directly. This is authoritative — treat it as ground

--- a/prompts/implementer.md
+++ b/prompts/implementer.md
@@ -39,6 +39,36 @@ The orchestrator gives you, in your prompt:
   (pure docs/config changes). The package-manager caches are warm and
   shared across worktrees, so a re-run is fast.
 
+### Python dependency changes (`/opt/venv` is shared and read-only)
+
+For Python repos, dependencies are baked into a shared virtual environment at
+`/opt/venv` at image-build time (DESIGN §6½). If your subtask does **not**
+change `requirements.txt` / `pyproject.toml` / `Pipfile`, you don't need to do
+anything — the baked venv is already on `PATH` and importable with zero
+install cost.
+
+If your subtask **does** add, remove, or change a Python dependency, you must
+NOT install into `/opt/venv` directly — it's shared read-only across every
+worktree running in this wave (up to `max_parallel`, default 5), and writing
+to it would corrupt sibling worktrees' dependencies mid-run. Instead,
+materialize your own private copy and diff against it:
+
+```bash
+cp -r /opt/venv .venv-private
+# Always invoke via `python3 -m pip`, NEVER `.venv-private/bin/pip` directly —
+# that script's shebang is hardcoded to the ORIGINAL /opt/venv's python
+# binary, so `bin/pip install` would silently install into /opt/venv instead
+# of your private copy (this corrupts the shared bake for every other
+# worktree; verified — do not skip this).
+.venv-private/bin/python3 -m pip install <added-or-changed-package>
+.venv-private/bin/python3 -m pip uninstall -y <removed-package>
+# Use .venv-private/bin/python3 for the rest of the subtask (running tests,
+# imports, etc.) instead of the shared /opt/venv.
+```
+
+No `pyvenv.cfg` editing or shebang relocation is needed — `python3 -m pip`
+resolves correctly against the clone's own path regardless of where it lives.
+
 The subtask spec includes the overall task, the `source_of_truth`, the
 clarification answers, and this subtask's `success_criteria_seed`,
 `depends_on`, `investigation_notes`, and `files_likely_touched`.

--- a/tests/test_build_repo_image.py
+++ b/tests/test_build_repo_image.py
@@ -393,3 +393,327 @@ def test_base_image_build_error_sentinel_in_launcher():
         "Base-image build error sentinel changed in launcher — "
         "update test_launcher_base_image_build_error.py and this test to match."
     )
+
+
+# ---------------------------------------------------------------------------
+# Out-of-repo dependency bake (DESIGN §6½, IMPLEMENTATION.md §0.5):
+# Python/Ruby/Rust/Go install to /opt/* instead of the inherited /work
+# WORKDIR, plus the $_sp gating-bug fix. Runs the FULL Dockerfile-generation
+# block (not just build_repo_image) via the same _run_harness pattern —
+# `.leerie/config.toml` and dependency-manifest fixtures under USER_REPO
+# trigger the real auto-generation path, and the resulting
+# `.leerie/Dockerfile` content is asserted directly.
+# ---------------------------------------------------------------------------
+
+def _write_config_toml(leerie_dir: Path, setup_packages: str = "") -> None:
+    lines = []
+    if setup_packages:
+        lines.append(f'setup_packages = "{setup_packages}"')
+    (leerie_dir / "config.toml").write_text("\n".join(lines) + "\n")
+
+
+def _generate_dockerfile(tmp_path, user_repo: Path, state_dir: Path,
+                          extra_env: dict | None = None):
+    env = {
+        "USER_REPO": str(user_repo),
+        "LEERIE_STATE_HOST_DIR": str(state_dir),
+        "NERDCTL_INSPECT_RC": "1",
+        "NERDCTL_BUILD_RC": "0",
+        "FAKE_GIT_REMOTE": "https://github.com/owner/repo.git",
+        "LEERIE_VERSION": "1.2.3",
+        "IMAGE_TAG": "leerie:1.2.3",
+    }
+    if extra_env:
+        env.update(extra_env)
+    result = _run_harness(tmp_path, "echo done", env=env)
+    return result
+
+
+def test_python_bakes_to_opt_venv(tmp_path):
+    """Load-bearing: a Python fixture (uv.lock, no setup_packages) bakes to
+    /opt/venv with the correct WORKDIR/ENV, not a /work-targeting RUN."""
+    user_repo = tmp_path / "repo"
+    leerie_dir = user_repo / ".leerie"
+    leerie_dir.mkdir(parents=True)
+    _write_config_toml(leerie_dir)
+    (user_repo / "uv.lock").write_text("")
+    (user_repo / "pyproject.toml").write_text('[project]\nname = "x"\n')
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+
+    result = _generate_dockerfile(tmp_path, user_repo, state_dir)
+    assert result.returncode == 0, result.stderr
+
+    df = (leerie_dir / "Dockerfile").read_text()
+    assert "WORKDIR /opt/python-build" in df, df
+    assert "ENV VIRTUAL_ENV=/opt/venv" in df, df
+    assert "ENV PATH=/opt/venv/bin:$PATH" in df, df
+    assert "RUN python3 -m venv /opt/venv" in df, df
+    assert "RUN /opt/venv/bin/python3 -m pip install uv" in df, df
+    assert "RUN uv sync --active" in df, df
+    # Must NOT emit a bare install RUN against the inherited /work WORKDIR.
+    assert "RUN uv sync\n" not in df, df
+
+
+def test_rust_bakes_to_opt_cargo_target_with_dummy_source(tmp_path):
+    """Rust bakes to CARGO_TARGET_DIR=/opt/cargo-target via a discardable
+    dummy src/main.rs (cargo cannot fetch/build with zero source files)."""
+    user_repo = tmp_path / "repo"
+    leerie_dir = user_repo / ".leerie"
+    leerie_dir.mkdir(parents=True)
+    _write_config_toml(leerie_dir)
+    (user_repo / "Cargo.lock").write_text("")
+    (user_repo / "Cargo.toml").write_text('[package]\nname = "x"\n')
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+
+    result = _generate_dockerfile(tmp_path, user_repo, state_dir)
+    assert result.returncode == 0, result.stderr
+
+    df = (leerie_dir / "Dockerfile").read_text()
+    assert "WORKDIR /opt/rust-build" in df, df
+    assert "ENV CARGO_TARGET_DIR=/opt/cargo-target" in df, df
+    assert "src/main.rs" in df, df
+    assert "cargo fetch" in df, df
+    assert "cargo build --offline" in df, df
+    # The dummy source must be discarded, never left for /work.
+    assert "rm -rf src" in df, df
+    # Regression guard: the bake must NOT build the release profile. Cargo
+    # keys its build cache by profile (debug/ vs release/ under
+    # CARGO_TARGET_DIR) — a --release bake shares nothing with the
+    # debug-profile `cargo build`/`cargo test` workers actually run.
+    # Reproduced live during implementation: baking with --release left a
+    # real worktree's `cargo build` fully recompiling every dependency
+    # ("Compiling serde", not "Fresh serde"); dropping it fixed the cache
+    # hit. See DESIGN §6½.
+    assert "--release" not in df, df
+
+
+def test_go_bakes_to_opt_go_cache_with_dummy_source(tmp_path):
+    """Go bakes to GOCACHE=/opt/go-cache via a discardable dummy .go file
+    (go build ./... against zero .go files is a silent no-op that warms
+    nothing — go mod download alone only warms GOMODCACHE)."""
+    user_repo = tmp_path / "repo"
+    leerie_dir = user_repo / ".leerie"
+    leerie_dir.mkdir(parents=True)
+    _write_config_toml(leerie_dir)
+    (user_repo / "go.mod").write_text("module x\n\ngo 1.21\n")
+    (user_repo / "go.sum").write_text("")
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+
+    result = _generate_dockerfile(tmp_path, user_repo, state_dir)
+    assert result.returncode == 0, result.stderr
+
+    df = (leerie_dir / "Dockerfile").read_text()
+    assert "WORKDIR /opt/go-build" in df, df
+    assert "ENV GOCACHE=/opt/go-cache" in df, df
+    assert "_leerie_dummy.go" in df, df
+    assert "go mod download" in df, df
+    assert "go build ./..." in df, df
+    # The dummy source must be discarded, never left for /work.
+    assert "rm -f _leerie_dummy.go" in df, df
+
+
+def test_ruby_bakes_to_opt_bundle(tmp_path):
+    """Ruby bakes to /opt/bundle via BUNDLE_PATH/BUNDLE_APP_CONFIG env,
+    emitted BEFORE the bundle install RUN line."""
+    user_repo = tmp_path / "repo"
+    leerie_dir = user_repo / ".leerie"
+    leerie_dir.mkdir(parents=True)
+    _write_config_toml(leerie_dir)
+    (user_repo / "Gemfile.lock").write_text("")
+    (user_repo / "Gemfile").write_text('source "https://rubygems.org"\n')
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+
+    result = _generate_dockerfile(tmp_path, user_repo, state_dir)
+    assert result.returncode == 0, result.stderr
+
+    df = (leerie_dir / "Dockerfile").read_text()
+    assert "WORKDIR /opt/ruby-build" in df, df
+    env_idx = df.index("ENV BUNDLE_PATH=/opt/bundle")
+    config_idx = df.index("ENV BUNDLE_APP_CONFIG=/opt/bundle")
+    run_idx = df.index("RUN bundle install")
+    assert env_idx < run_idx and config_idx < run_idx, df
+
+
+def test_node_pnpm_still_targets_work_unchanged(tmp_path):
+    """Node/pnpm is deliberately unchanged: node_modules must live in the
+    repo tree for resolution, so no /opt/* WORKDIR/ENV is emitted for it."""
+    user_repo = tmp_path / "repo"
+    leerie_dir = user_repo / ".leerie"
+    leerie_dir.mkdir(parents=True)
+    _write_config_toml(leerie_dir)
+    (user_repo / "pnpm-lock.yaml").write_text("")
+    (user_repo / "package.json").write_text("{}")
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+
+    result = _generate_dockerfile(tmp_path, user_repo, state_dir)
+    assert result.returncode == 0, result.stderr
+
+    df = (leerie_dir / "Dockerfile").read_text()
+    assert "pnpm install --frozen-lockfile" in df, df
+    assert "/opt/" not in df, df
+
+
+# ---------------------------------------------------------------------------
+# $_sp gating-bug fix: a lockfile-only repo (no setup_packages) must still
+# generate a Dockerfile with the language-dep layer.
+# ---------------------------------------------------------------------------
+
+def test_gating_fix_lockfile_without_setup_packages_still_generates(tmp_path):
+    """Regression: previously `if [ -n "$_sp" ]` skipped generation entirely
+    for a repo with a lockfile but no setup_packages."""
+    user_repo = tmp_path / "repo"
+    leerie_dir = user_repo / ".leerie"
+    leerie_dir.mkdir(parents=True)
+    _write_config_toml(leerie_dir, setup_packages="")
+    (user_repo / "uv.lock").write_text("")
+    (user_repo / "pyproject.toml").write_text('[project]\nname = "x"\n')
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+
+    result = _generate_dockerfile(tmp_path, user_repo, state_dir)
+    assert result.returncode == 0, result.stderr
+
+    df_path = leerie_dir / "Dockerfile"
+    assert df_path.exists(), "Dockerfile must be generated for a lockfile-only repo"
+    df = df_path.read_text()
+    assert "RUN uv sync" in df, df
+    # No setup_packages → no apt-get layer at all.
+    assert "apt-get install" not in df, df
+
+
+def test_gating_fix_bare_requirements_txt_does_not_trigger(tmp_path):
+    """Negative control: bare requirements.txt (no lockfile) is deliberately
+    excluded from the deterministic table (mirrors _lockfile_table_entries
+    in orchestrator/leerie.py) — must NOT trigger generation on its own."""
+    user_repo = tmp_path / "repo"
+    leerie_dir = user_repo / ".leerie"
+    leerie_dir.mkdir(parents=True)
+    _write_config_toml(leerie_dir, setup_packages="")
+    (user_repo / "requirements.txt").write_text("requests==2.31.0\n")
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+
+    result = _generate_dockerfile(tmp_path, user_repo, state_dir)
+    assert result.returncode == 0, result.stderr
+    assert not (leerie_dir / "Dockerfile").exists(), (
+        "bare requirements.txt must not trigger Dockerfile auto-generation"
+    )
+
+
+def test_gating_fix_setup_packages_alone_still_works(tmp_path):
+    """Regression control: setup_packages alone (no lockfile) must still
+    generate a Dockerfile with the apt layer, as before this fix."""
+    user_repo = tmp_path / "repo"
+    leerie_dir = user_repo / ".leerie"
+    leerie_dir.mkdir(parents=True)
+    _write_config_toml(leerie_dir, setup_packages="curl,git")
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+
+    result = _generate_dockerfile(tmp_path, user_repo, state_dir)
+    assert result.returncode == 0, result.stderr
+
+    df = (leerie_dir / "Dockerfile").read_text()
+    assert "apt-get install" in df, df
+    assert "curl" in df and "git" in df, df
+
+
+def test_gating_fix_neither_setup_packages_nor_lockfile_no_generation(tmp_path):
+    """Negative control: a repo with neither setup_packages nor a lockfile
+    must not generate a Dockerfile at all (no bake needed)."""
+    user_repo = tmp_path / "repo"
+    leerie_dir = user_repo / ".leerie"
+    leerie_dir.mkdir(parents=True)
+    _write_config_toml(leerie_dir, setup_packages="")
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+
+    result = _generate_dockerfile(tmp_path, user_repo, state_dir)
+    assert result.returncode == 0, result.stderr
+    assert not (leerie_dir / "Dockerfile").exists()
+
+
+# ---------------------------------------------------------------------------
+# Cache-invalidation regression: a lockfile bump still changes the emitted
+# Dockerfile's COPY-input SHA comment (and thus .dockerfile-hash) even
+# against the new /opt/* bake target.
+# ---------------------------------------------------------------------------
+
+def test_lockfile_bump_still_changes_hash_against_opt_target(tmp_path):
+    """A dependency-input change must still invalidate .dockerfile-hash even
+    though the install target moved from /work to /opt/venv."""
+    user_repo = tmp_path / "repo"
+    leerie_dir = user_repo / ".leerie"
+    leerie_dir.mkdir(parents=True)
+    _write_config_toml(leerie_dir)
+    (user_repo / "uv.lock").write_text("original-lockfile-content\n")
+    (user_repo / "pyproject.toml").write_text('[project]\nname = "x"\n')
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+
+    result1 = _generate_dockerfile(tmp_path, user_repo, state_dir)
+    assert result1.returncode == 0, result1.stderr
+    hash1 = (state_dir / ".dockerfile-hash").read_text()
+    assert "/opt/venv" in (leerie_dir / "Dockerfile").read_text()
+
+    # Remove the leerie-generated Dockerfile so it regenerates (the launcher
+    # only refreshes an uncommitted generated file in place, which requires
+    # `git ls-files` to report it untracked — simplest here is to delete it,
+    # matching the "no Dockerfile exists" trigger).
+    (leerie_dir / "Dockerfile").unlink()
+    (user_repo / "uv.lock").write_text("bumped-lockfile-content-changed\n")
+
+    result2 = _generate_dockerfile(tmp_path, user_repo, state_dir)
+    assert result2.returncode == 0, result2.stderr
+    hash2 = (state_dir / ".dockerfile-hash").read_text()
+
+    assert hash1 != hash2, "lockfile bump did not change .dockerfile-hash"
+
+
+# ---------------------------------------------------------------------------
+# Runtime BUNDLE_PATH env reconciliation (leerie:~6042 CACHE_MOUNTS):
+# must point at /opt/bundle only when the Dockerfile actually baked there,
+# else keep the pre-existing cache-mount fallback path.
+# ---------------------------------------------------------------------------
+
+def test_bundle_path_runtime_env_points_at_opt_when_baked():
+    """Coupling test: the CACHE_MOUNTS BUNDLE_PATH override must consult the
+    on-disk Dockerfile for the baked ENV line rather than hard-coding one
+    value, per the correctness risk found during implementation (a
+    hard-coded /opt/bundle would break `bundle install` for repos whose
+    image was NOT built with the Ruby bake — verified live: 'File system is
+    read-only' against a nonexistent, unmounted /opt/bundle)."""
+    launcher_text = _launcher_text()
+    assert "grep -q '^ENV BUNDLE_PATH=/opt/bundle'" in launcher_text, (
+        "BUNDLE_PATH runtime-env bake-detection changed — update this test"
+    )
+    assert 'CACHE_MOUNTS+=(-e "BUNDLE_PATH=/opt/bundle")' in launcher_text
+    assert 'CACHE_MOUNTS+=(-e "BUNDLE_PATH=/home/leerie/.cache/leerie/bundle")' in launcher_text
+
+
+# ---------------------------------------------------------------------------
+# Regression guard: the already-shipped consumer-half functions
+# (_is_baked_ecosystem_command, _is_node_offline_relink,
+# _format_provision_recipe_section, _filter_residual_deps) must remain
+# untouched by this feature — per prompts/fix-dep-capture-bake.md's
+# explicit constraint.
+# ---------------------------------------------------------------------------
+
+def test_consumer_half_functions_present_and_unmodified_markers():
+    """These four functions must still exist with their documented
+    docstrings/behavior — a byte-for-byte diff check belongs in `git diff`
+    at review time (see the plan's Verification section), but this test
+    guards that they were not accidentally deleted or renamed."""
+    orch_text = (REPO_ROOT / "orchestrator" / "leerie.py").read_text()
+    for fn in (
+        "def _is_baked_ecosystem_command(",
+        "def _is_node_offline_relink(",
+        "def _format_provision_recipe_section(",
+        "def _filter_residual_deps(",
+    ):
+        assert fn in orch_text, f"{fn} missing from orchestrator/leerie.py"

--- a/tests/test_dockerfile_autogen.py
+++ b/tests/test_dockerfile_autogen.py
@@ -406,9 +406,16 @@ def test_no_setup_packages_no_dockerfile_does_not_build(tmp_path):
 # ---------------------------------------------------------------------------
 
 def test_coupling_autogen_log_sentinel():
-    """The auto-gen log sentinel must be present verbatim in the launcher."""
+    """The auto-gen log sentinel must be present verbatim in the launcher.
+
+    Message changed from "...from setup_packages: $_sp_packages" to
+    "...(setup_packages=${_sp:-<none>})" when the $_sp gating bug was fixed
+    (generation can now fire on a lockfile / language_installs alone, with
+    setup_packages empty) — update this sentinel if the message changes
+    again.
+    """
     launcher = _launcher_text()
-    assert 'remote_log "auto-generating .leerie/Dockerfile from setup_packages' in launcher
+    assert 'remote_log "auto-generating .leerie/Dockerfile (setup_packages=' in launcher
 
 
 def test_coupling_arg_base_image_in_launcher():

--- a/tests/test_dockerfile_bake_from_capture.py
+++ b/tests/test_dockerfile_bake_from_capture.py
@@ -168,6 +168,11 @@ def test_pip_install_emits_copy_run_layer(tmp_path):
     assert result.returncode == 0, result.stderr
     assert "COPY requirements.txt ./" in result.stdout
     assert "RUN pip install -r requirements.txt" in result.stdout
+    # Out-of-repo bake (DESIGN §6½): the persisted-installs path routes
+    # through the same /opt/venv bake as the deterministic detection chain —
+    # not a bare /work-targeting RUN.
+    assert "WORKDIR /opt/python-build" in result.stdout
+    assert "ENV VIRTUAL_ENV=/opt/venv" in result.stdout
 
 
 def test_pip_install_emits_apt_layer_alongside(tmp_path):

--- a/tests/test_resolve_repo_image_tag.py
+++ b/tests/test_resolve_repo_image_tag.py
@@ -81,6 +81,41 @@ _leerie_repo_id() {
   printf '%s' "$sanitized"
 }
 
+_leerie_should_generate_dockerfile() {
+  local _repo="$1" _sp_val="$2"
+  if [ -n "$_sp_val" ]; then
+    return 0
+  fi
+  for _lf in package-lock.json pnpm-lock.yaml yarn.lock \
+             uv.lock poetry.lock Pipfile.lock \
+             Gemfile.lock Cargo.lock composer.lock \
+             packages.lock.json; do
+    if [ -f "$_repo/$_lf" ]; then
+      unset _lf
+      return 0
+    fi
+  done
+  unset _lf
+  if [ -f "$_repo/go.mod" ] && [ -f "$_repo/go.sum" ]; then
+    return 0
+  fi
+  local _li_cfg="$_repo/.leerie/config.toml"
+  if [ -f "$_li_cfg" ]; then
+    local _li
+    _li="$( { grep -E '^[[:space:]]*language_installs[[:space:]]*=' \
+                  "$_li_cfg" 2>/dev/null \
+              || true; } \
+            | head -1 \
+            | sed -E 's/^[[:space:]]*language_installs[[:space:]]*=[[:space:]]*//;
+                      s/[[:space:]]*$//')"
+    case "$_li" in
+      ""|'""'|"''"|'[]'|'"[]"'|"'[]'") : ;;
+      *) return 0 ;;
+    esac
+  fi
+  return 1
+}
+
 resolve_repo_image_tag() {
   local dockerfile="$USER_REPO/.leerie/Dockerfile"
   if [ ! -f "$dockerfile" ]; then
@@ -93,7 +128,7 @@ resolve_repo_image_tag() {
                     s/[[:space:]]*$//;
                     s/^"(.*)"$/\1/;
                     s/^'"'"'(.*)'"'"'$/\1/')"
-    if [ -z "$sp" ]; then
+    if ! _leerie_should_generate_dockerfile "$USER_REPO" "$sp"; then
       echo ""
       return
     fi
@@ -213,6 +248,45 @@ def test_no_dockerfile_no_setup_packages_repo_image_tag_empty(tmp_path: Path):
     )
     assert result.returncode == 0, result.stderr
     assert "repo_tag=EMPTY" in result.stdout
+
+
+# ---------------------------------------------------------------------------
+# ($_sp gating-bug fix) a lockfile present (no setup_packages) must still
+# resolve a non-empty tag — regression coverage for the bug this session
+# fixed: the early-return previously checked setup_packages ONLY.
+# ---------------------------------------------------------------------------
+
+def test_lockfile_without_setup_packages_resolves_nonempty_tag(tmp_path: Path):
+    """A lockfile-only repo (no setup_packages, no Dockerfile) must resolve a
+    real tag, not fall back to the empty string / base image."""
+    user_repo = tmp_path / "myrepo"
+    user_repo.mkdir()
+    (user_repo / "uv.lock").write_text("")
+    result = _run(
+        'echo "tag=$(resolve_repo_image_tag)"',
+        env={
+            "USER_REPO": str(user_repo),
+            "FAKE_GIT_REMOTE": "https://github.com/owner/myrepo.git",
+            "LEERIE_VERSION": "1.2.3",
+        },
+    )
+    assert result.returncode == 0, result.stderr
+    tag = result.stdout.strip().removeprefix("tag=")
+    assert tag == "leerie-repo/owner-myrepo:1.2.3", tag
+
+
+def test_bare_requirements_txt_without_setup_packages_returns_empty(tmp_path: Path):
+    """Negative control: bare requirements.txt (no lockfile) is deliberately
+    excluded — must still resolve empty, matching _lockfile_table_entries."""
+    user_repo = tmp_path / "myrepo"
+    user_repo.mkdir()
+    (user_repo / "requirements.txt").write_text("requests==2.31.0\n")
+    result = _run(
+        'echo "tag=$(resolve_repo_image_tag)"',
+        env={"USER_REPO": str(user_repo), "FAKE_GIT_REMOTE": ""},
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "tag="
 
 
 # ---------------------------------------------------------------------------
@@ -426,6 +500,10 @@ def test_resolve_repo_image_tag_harness_matches_launcher():
         # resolve_repo_image_tag function body
         'local dockerfile="$USER_REPO/.leerie/Dockerfile"',
         'echo "leerie-repo/${repo_id}:${LEERIE_VERSION}"',
+        'if ! _leerie_should_generate_dockerfile "$USER_REPO" "$sp"; then',
+        # _leerie_should_generate_dockerfile (the $_sp gating-bug fix)
+        '_leerie_should_generate_dockerfile() {',
+        'if [ -f "$_repo/go.mod" ] && [ -f "$_repo/go.sum" ]; then',
         # _leerie_repo_id function body
         'raw="$(git -C "$USER_REPO" remote get-url origin 2>/dev/null || true)"',
         'raw="$(basename "$USER_REPO")"',


### PR DESCRIPTION
## Summary

Commit `a7c0a793` (#136) shipped the **consumer** half of the out-of-repo
dependency bake redesign — `_is_baked_ecosystem_command`,
`_is_node_offline_relink`, `_format_provision_recipe_section` (filter the
`PROVISION_RECIPE` shown to implementer/conformer workers), and
`_filter_residual_deps` (narrows what `dep_capture` writes to
`.leerie/config.toml`) — on the premise that Python/Ruby/Rust/Go deps are
baked to `/opt/venv`, `/opt/bundle`, etc. The **producer** half never
existed, so every repo using those ecosystems got an install command
stripped from its `PROVISION_RECIPE` with no bake to fall back on — a live
regression, not just unfinished work. This PR implements the producer half.

- Dockerfile emitter bakes Python (`/opt/venv`), Ruby (`/opt/bundle`), Rust
  (`/opt/cargo-target`), and Go (`/opt/go-cache`) installs out of the
  `/work` bind-mount-shadowed tree. Node/pnpm unchanged — `node_modules`
  must live in the repo tree for resolution.
- `uv`/`poetry`/`pipenv` are installed into `/opt/venv` via `pip` at build
  time rather than relying on their own active-venv env-var detection,
  which was live-verified unreliable (`uv sync` silently ignores
  `VIRTUAL_ENV` without `--active`; `pipenv` has long-standing open bugs
  about not respecting an active venv).
- Rust and Go both need a discardable dummy source file at build time —
  neither toolchain populates its build-artifact cache against a
  manifest-only COPY context. **The Rust bake must NOT use `--release`**:
  Cargo keys its cache by profile, so a `--release` bake shares nothing
  with the debug-profile `cargo build`/`cargo test` workers actually run
  (caught and fixed during a post-implementation audit — live-reproduced
  as a real cache-miss defect: a real worktree's first build after a
  `--release` bake fully recompiled every dependency from scratch).
- Fixed the `$_sp` gating bug: Dockerfile auto-generation only fired when
  `setup_packages` was non-empty, so a lockfile-only repo got no bake at
  all. Broadened via a shared `_leerie_should_generate_dockerfile` helper
  (bare `requirements.txt` deliberately excluded, mirroring
  `_lockfile_table_entries`).
- Runtime `BUNDLE_PATH` env now checks whether the built image actually
  baked to `/opt/bundle` before overriding it — a hard-coded override
  would break `bundle install` for repos with `bake_language_deps`
  disabled or a language-dep build that fell back to apt-only.
- `prompts/implementer.md` documents the Python clone+delta procedure for
  worktrees that change dependencies: `python3 -m pip` (never `bin/pip`
  directly) against a private `cp -r` clone of `/opt/venv` — verified live
  that `bin/pip`'s hardcoded shebang otherwise silently corrupts the
  shared bake.
- `docs/DESIGN.md` §6½ and `docs/IMPLEMENTATION.md` §0.5 updated to match,
  including two spec gaps found during implementation (the dummy-source
  requirement, and the `--release` profile-mismatch trap).

`orchestrator/leerie.py` is untouched — the already-shipped consumer-half
functions (`_is_baked_ecosystem_command`, `_is_node_offline_relink`,
`_format_provision_recipe_section`, `_filter_residual_deps`) are
unmodified.

## Test plan

- [x] `tests/test_build_repo_image.py`, `tests/test_dockerfile_bake_from_capture.py`,
      `tests/test_dockerfile_autogen.py`, `tests/test_resolve_repo_image_tag.py` —
      71/71 pass (includes 12 new tests covering the `/opt/*` bake per
      ecosystem, the `$_sp` gating fix with a bare-`requirements.txt`
      negative control, cache-invalidation against the new bake target,
      and the `BUNDLE_PATH` reconciliation logic).
- [x] Live-verified (temp scratch repos, real `python3`/`cargo`/`go`/`bundle`
      toolchains) that each ecosystem's exact emitted command sequence
      produces a real cache hit from a second, independent build — not
      just Dockerfile-text inspection.
- [x] `bash -n leerie` and `shellcheck -S error leerie` clean.
- [x] `git diff orchestrator/leerie.py` is empty — the four consumer-half
      functions are confirmed byte-unchanged.
- [ ] Full container-level verification (build an image, start it, `git
      worktree add`, import a dep with zero `pip install`) is out of scope
      for this environment (no live nerdctl/Colima) — flagging as
      unverified-live rather than self-certifying.

🤖 Generated with [Claude Code](https://claude.com/claude-code)