### PR TITLE
chore: close outstanding items from the planning-gate investigation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,10 @@ venv/
 !.leerie/config.toml
 !.leerie/Dockerfile
 # Top-level log when the CLI is teed (`./leerie "..." | tee leerie.log`).
+# The `leerie-*.log` form covers per-task tees, e.g.
+# `leerie prompts/fix-x.md | tee leerie-fix-x.log`.
 leerie.log
+leerie-*.log
 
 # Local Claude Code settings / cache — per-machine, never tracked.
 .claude/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -625,6 +625,19 @@ export LEERIE_PROGRESS_INTERVAL_S=15
 
 ## Testing
 
+**Never run two copies of this suite concurrently on one host.** It has dense
+timing-sensitive coverage — real `fork()`s, PID reaping, subreaper races,
+cgroup probes, stalled-transport `timeout` paths — and CPU starvation makes
+dozens of them fail nondeterministically. Measured 2026-08-01 across six full
+runs: serial with the host to itself gave **0 failures** four times out of four
+(`main` twice, a feature branch twice), while two runs overlapping another
+pytest container gave **78** and then **57** failures. The counts are unstable
+and the individual tests pass in isolation — e.g.
+`tests/test_worktree_failure_not_fatal.py` is 3/3 alone. Treat any failure list
+gathered under concurrent load as unusable, and re-run alone before believing
+it. `-n 4` (xdist) is fine on an otherwise-idle host and matches the serial
+totals exactly; what breaks is *two suites at once*, not parallelism itself.
+
 `pytest tests/` from the repo root. Tests cover the deterministic
 enforcement functions (`resolve_leerie_root`, `resolve_source_of_truth`,
 `resolve_runtime`, `resolve_aws_region`, `resolve_aws_profile`,

--- a/prompts/fix-bare-verbs.md
+++ b/prompts/fix-bare-verbs.md
@@ -1,0 +1,152 @@
+# Make first-class commands bare subcommands (git-style) instead of `--` flags
+
+## Context
+
+leerie's top-level VERBS are currently `--`-prefixed flags (`--resume`, `--list`,
+`--kill`, etc.). First-class commands should be **bare subcommands** like git
+(`leerie resume`, `leerie list`, `leerie kill`) — the `config` verb is ALREADY bare
+(`leerie config --init`) and is the exact model to replicate. This is a bug in the
+leerie launcher (this repo). Read `CLAUDE.md` first and follow the three-layer rule.
+
+**No backwards compatibility.** Do NOT keep the old `--verb` forms as aliases, and
+DO hard-remove the five deprecated chain aliases entirely. This is a deliberate
+breaking CLI change; state that plainly in the PR body.
+
+> **Line numbers below are hints, not addresses.** They were accurate at the time of
+> writing and every one of them shifts the moment you start editing. Locate each site
+> with the `grep` given alongside it and treat a mismatch as drift in the prompt, not a
+> missing site.
+
+## What is a VERB vs a FLAG
+
+Convert ONLY the mutually-exclusive top-level VERBS to bare form. Keep `--` on all
+OPTIONS / modifiers.
+
+**Launcher VERBS to convert** — all in the main `case "${1:-}"` in `leerie` (~945).
+Locate them with `grep -n '^\s*--[a-z-]*)' leerie`:
+
+`--list` (~1191) · `--accept-blocked` (~1444) · `--re-seed` (~1742) · `--stop` (~1782) ·
+`--kill` (~1947) · `--finalize` (~2242) · `--status` (~2618) · `--attach` (~2757) ·
+`--resume` (~2807) · `--chain` (~2887, see item 2) · `--group` (~3296)
+
+`--version` (~946) is an info verb — convert it to bare `version` too for consistency
+(keeping `--version` working is NOT required). `config` (~950) is already bare — leave
+it, and use it as the dispatch template.
+
+**Keep `--` (these are FLAGS/OPTIONS, not verbs):** `--model`, `--effort`, `--runtime`,
+`--force`, `--pr-base-branch`, `--chain-id`, `--group-id`, `--wave`, `--repo`, `--brief`,
+`--inspect-dir`, `--max-workers`, `--max-parallel`, `--confidence-rounds`,
+`--source-of-truth`, and every other modifier in the value-taking-flag list (~3790–3797).
+
+**`--report` and `--phase` are NOT launcher verbs.** They are `orchestrator/leerie.py`
+argparse flags (`--report` ~24560, `--phase` ~24878) that pass through the launcher.
+Leave them exactly as they are.
+
+## Required changes
+
+1. **Dispatch:** convert each launcher verb to a bare subcommand exactly as `config` is
+   dispatched — the bare word must be handled in BOTH the ownership short-circuit
+   `case "${1:-}"` (~937) AND the main `case "${1:-}"` (~945). Study how `config`
+   appears in both (listed at ~937, own arm at ~950) and mirror that for every verb.
+
+2. **Hard-remove the five deprecated chain aliases entirely:** `--chain-submit`,
+   `--chain-status`, `--list-chains`, `--chain-kill`, `--chain-attach` (arms at ~2887,
+   ~3251, ~3265, ~3270, ~3283, plus their listing at ~937). `--chain-submit` is
+   currently fused with `--chain` as a single `--chain|--chain-submit)` pattern, so
+   splitting `--chain`→`chain` in item 1 and deleting `--chain-submit` here are the same
+   edit. No shim, no alias.
+
+3. **REWRITTEN_ARGS / value-flag filter — TWO separate loops, not one span:** the
+   `IS_RESUME` positional-run-id loop (~3756–3775; `IS_RESUME=false` at ~3756, the
+   `--resume)` arm at ~3769) and the `_value_flags` skip-loop (~3785–3801;
+   `_value_flags=` at ~3790, consumed via `case "$_value_flags" in` at ~3801). The
+   launcher's own coupling comment at ~943 says "~line 3097" — that is STALE (3097 is
+   inside a chain-resume echo hint); fix that comment while you are here. Every verb arm
+   that `exit`s must stay correctly guarded so a misplaced verb errors clearly instead of
+   leaking to the orchestrator. Update `IS_RESUME` detection to match bare `resume`.
+
+4. **Update the CLAUDE.md checklist grep guard** (~2642 — `grep -n "chain-submit)" CLAUDE.md`).
+   It currently *requires* the five alias arms to be present:
+   ```
+   grep -q -- '--chain-submit)\|--chain-status)\|--list-chains)\|--chain-kill)\|--chain-attach)' leerie
+   ```
+   Since those are being removed, rewrite it to assert their ABSENCE, or replace it with
+   a bare-verb-presence guard (assert `chain)`, `status)`, etc. exist). Keep the
+   checklist internally consistent.
+
+5. **Update the launcher tests.** Exactly one test file currently asserts the
+   deprecated-alias shim: `tests/test_chain_launcher_id_dispatch.py`. Confirm with
+   `grep -rln -- '--chain-submit\|--chain-status\|--list-chains\|--chain-kill\|--chain-attach' tests/`
+   and rewrite the ID-dispatch contract tests against the new bare verbs. Note that many
+   *other* test files invoke `leerie --<verb>` for unrelated reasons (`--finalize`,
+   `--stop`, `--kill`, …) — those must be updated too or they will exercise a verb form
+   that no longer dispatches.
+
+6. **Docs + every self-invocation + user-facing hint.** Run the sweep and update every
+   hit. At the time of writing it reported **434 hits across 40 files** (excluding
+   `tests/`, `.git/` and `*.log`) — treat that as a staleness check, not a target:
+   ```
+   grep -rn -- 'leerie --resume\|leerie --finalize\|leerie --kill\|leerie --stop\|leerie --status\|leerie --attach\|leerie --list\|leerie --accept-blocked\|leerie --re-seed\|leerie --chain\|leerie --group' . \
+     | grep -v '^./tests/' | grep -v '^./.git/' | grep -v '\.log:'
+   ```
+   The work is heavily concentrated — `docs/IMPLEMENTATION.md` (93), `leerie` itself
+   (66), `docs/DESIGN.md` (44), `README.md` (34), `docs/USAGE.md` (29),
+   `scripts/remote/provision.sh` (26), `CLAUDE.md` (26), `orchestrator/leerie.py` (25) —
+   with a long tail across `scripts/`, `commands/leerie.md` and `commands/chain.md`.
+   **`README.md` is in scope**; it is easy to miss because it is not under `docs/`.
+
+   User-facing recovery hints must keep using a **positional run-id**, never a
+   `--run-id` flag (repeated operator correction): `leerie resume <run-id>`, not
+   `leerie resume --run-id <id>`.
+
+## How to decompose this — read before planning
+
+**This is one atomic breaking change, not a set of independent ones.** Any intermediate
+state is broken: a converted launcher with unconverted docs ships wrong instructions, and
+converted tests against an unconverted launcher fail. Prefer **few, large subtasks** over
+many small ones, and require every subtask to leave the tree self-consistent.
+
+**Each subtask owns its code change, its tests, and its documentation.** Do not split one
+concern across a code subtask, a test subtask, and a docs subtask.
+
+This is not a style preference. Planners for different categories run blind and in
+parallel — a testing-domain subtask cannot declare a `requires` on a capability tag the
+refactoring planner has not invented yet, and two planners that both claim a file produce
+a surface collision the overlap judge has to resolve. Both failure modes have been
+observed on this exact task.
+
+Concretely:
+
+- **No separate `testing` subtasks.** The subtask that converts the launcher dispatch is
+  the same subtask that rewrites `tests/test_chain_launcher_id_dispatch.py` and fixes
+  every other test that invokes a `--verb` form.
+- **No separate `documentation` subtasks, and no per-doc-file subtasks.** The doc sweep
+  is one mechanical find/replace; splitting it per file produces several subtasks all
+  claiming the same change, which is what a cross-planner collision looks like.
+- **No cross-cutting "verify everything works" subtask.** Each subtask verifies its own
+  surface; the definition-of-done checks below belong to whichever subtask owns the
+  launcher dispatch.
+- A reasonable shape is **two or three subtasks**: (a) launcher dispatch + filter loops +
+  guards + launcher tests, (b) the docs/self-invocation sweep including `CLAUDE.md`'s
+  checklist guard, and optionally (c) `scripts/**` recovery hints. Fewer is fine.
+
+## Constraints
+
+- bash 3.2 portability (macOS `/bin/bash`): no `local -n` / `declare -n` namerefs.
+- Follow the three-layer rule: the CLI surface is documented in `docs/IMPLEMENTATION.md`
+  and `CLAUDE.md`; update those to match. DESIGN only if the command model itself is
+  described there.
+
+## Definition of done (verify each; do not self-certify on "tests pass" alone)
+
+- `leerie resume`, `leerie list`, `leerie status`, `leerie kill`, `leerie stop`,
+  `leerie finalize`, `leerie attach`, `leerie accept-blocked`, `leerie re-seed`,
+  `leerie chain`, `leerie group`, `leerie version` all dispatch correctly — demonstrate
+  by invoking each and observing the right code path, not just a unit test.
+- The five `--chain-*` aliases are GONE — `leerie --chain-submit` errors as an unknown
+  verb, and
+  `grep -rn -- '--chain-submit\|--chain-status\|--list-chains\|--chain-kill\|--chain-attach' .`
+  finds no live launcher arm or doc reference.
+- The item-6 sweep returns no `leerie --<verb>` forms (genuine flags excepted).
+- `pytest tests/` passes; the CLAUDE.md checklist grep guard passes in its new form;
+  `git diff --stat` matches the intended surface with no collateral edits.

--- a/prompts/fix-nl-regex-scoring.md
+++ b/prompts/fix-nl-regex-scoring.md
@@ -1,0 +1,134 @@
+# Migrate the remaining natural-language regex parsing to LLM + schema-JSON
+
+## Context
+
+CLAUDE.md is emphatic: **"All natural-language interpretation is done by an LLM worker
+returning schema-validated structured JSON — never by regex or hand-parsing in Python."**
+Python operates only on already-structured data (JSON fields, typed values). Regex is
+permitted **only** on *mechanical* strings (semver, shell commands, fixed CLI output,
+file paths) — never on task text, planner/worker prose, README/markdown content, or an
+LLM's response.
+
+An audit (2026-07, extended 2026-08-01) found several pre-existing sites in
+`orchestrator/leerie.py` that regex or hand-parse **prose / markdown / planner output** —
+genuine violations of this rule. They live in load-bearing, heavily-tested incident-fix
+code, and so were spun out here rather than fixed inline.
+
+Read `CLAUDE.md` (the rule + the `TestRegexPathAbsent` prior art in
+`tests/test_capture_deps.py` — dep-capture's own migration off a regex path onto
+LLM-structured output is the template for this whole task), `docs/DESIGN.md`
+§"Language-to-JSON: natural-language interpretation is never regex", and
+`docs/IMPLEMENTATION.md`. DESIGN-first; "prompts advisory, code enforces."
+
+## The violations to migrate
+
+| Site (`orchestrator/leerie.py`) | What it parses | Why it's a violation |
+|---|---|---|
+| `extract_task_file_structure` | `re.finditer` over `.md`/`.txt`/`.yaml` **file content** (CLAUDE.md, README, task-referenced files) to harvest headings / numbered items / YAML keys as "coverage items" | Regex over markdown/prose content |
+| `_is_uncoverable_convention_item` (`_BACKTICK_SPAN_RE`, `re.search(r'\bMUST\b')`) | the harvested heading **prose** | Regex over prose to classify it |
+| `check_planner_output`'s migration surface (`_MIGRATION_SIGNAL_RE`) | the **planner's `intent` / `investigation_notes` prose** ("replaces direct `X`", "extract `X` as the new seam") | Regex over an LLM worker's prose output — the most direct violation; DESIGN §5 even documents it as "regex-detected phrases". Observed live extracting English stopwords as symbol names (`with` → 332 files, `both` → 178, `task` → 168) and burning planner rounds on the resulting false `UNCOVERED_MIGRATION_SURFACE` warnings |
+| `gather_provision_fixtures` (`_README_SECTION_RE`, `_HEADER_DECOR_RE`) | **README section headings** | Regex over markdown headings. Softer: this is a *pre-filter feeding the provision LLM* (the worker still decides), but still regex over prose |
+| `check_overlap_judge_output`'s `_depunctuate` / `_path_shaped` (PHANTOM_ARTIFACT) | the **overlap judge's `artifact` field** — whitespace-tokenized, punctuation- and possessive-stripped, then each token tested for path shape | Hand-parsing an LLM's response. Not regex, but the same rule: `artifact` is a free-text logical name the prompt asks for (`AuthShell component`), and Python is mining paths out of it |
+
+Explicitly NOT in scope (these are permitted mechanical-string regex — leave them):
+semver (`re.match(r"(\d+)\.(\d+)\.(\d+)"`, `_GO_MOD_VERSION_RE`), shell/argv install
+shapes (`_DEPCAP_*`, the BLT command regexes), fixed CLI output (`_BG_ID_RE`,
+`_SESSION_LIMIT_*`, `_LEERIE_PREFIX_RE`), toml `key =` lines, the `{{include:}}` prompt
+fragment, workflow filenames.
+
+## Required fix — structured JSON per site
+
+For each violating site, replace the prose parsing with schema-validated structured
+output that Python then operates on — following the dep-capture migration precedent
+(`TestRegexPathAbsent` pins the deleted regex symbols so the regex path can never
+silently return). Two shapes are available and the cheaper one is usually right:
+
+- **Ask the worker that already runs** to emit one more structured field. No new worker,
+  no extra spend.
+- **Add a new worker** only where no existing worker owns the data.
+
+Per site:
+
+- **Task-file structure harvest** (`extract_task_file_structure` +
+  `_is_uncoverable_convention_item`): a new worker that reads the task-referenced files
+  and returns a structured list of coverage items (each with a `coverable` bool it
+  decides, replacing the `\bMUST\b`/backtick heuristic) — Python then does set/subset
+  comparison against the plan, never parsing headings itself.
+- **Migration surface** (`_MIGRATION_SIGNAL_RE`): the planner already produces `intent` /
+  `investigation_notes` as an LLM. Surface the signal as a **structured field on the
+  planner's own schema** (e.g. `migration_targets: [{old_pattern, ...}]`), so Python reads
+  a JSON field instead of regexing prose. No new worker.
+- **README section pre-filter** (`_README_SECTION_RE`): fold into the provision worker's
+  own reading of the README (it already reads fixtures) — let the LLM identify the
+  install-relevant sections rather than a keyword regex pre-selecting them.
+- **PHANTOM_ARTIFACT path extraction** (`_depunctuate` / `_path_shaped`): add an
+  `artifact_paths: [string]` field to `SCHEMAS["plan_overlap_judge"]`'s collision object
+  and have the judge name the repo-relative paths explicitly, keeping `artifact` as the
+  prose label. `check_overlap_judge_output` then compares `artifact_paths` against
+  `files_likely_touched` / the tree as plain set membership. Delete both helpers. No new
+  worker.
+
+New workers follow the CLAUDE.md conventions (**sonnet** — `MODEL_DEFAULT = "sonnet"`, so
+a new judgment worker should stay absent from `MODEL_DEFAULT_PER_WORKER` rather than
+being pinned to a different model — `EFFORT_DEFAULT_PER_WORKER = "medium"`,
+`WORKER_TYPES`, `SCHEMAS`, prompt file, `INSPECT_TOOLS`). Any check that needs a fact from
+natural language must get it as a JSON field from the owning worker.
+
+## How to decompose this — read before planning
+
+**Each site is ONE subtask that owns its code change, its tests, and its documentation.**
+Do not split a site's work across a code subtask, a test subtask, and a docs subtask. A
+subtask is done when its site is migrated, its tests are rewritten and passing, and the
+DESIGN/IMPLEMENTATION rows describing that site are updated.
+
+This is not a style preference. Planners for different categories run blind and in
+parallel: a testing-domain subtask cannot declare a `requires` on a capability tag the
+refactoring planner has not invented yet, and vice versa. Splitting one site's work
+across domains manufactures cross-domain dependencies that no planner can wire, and the
+plan-wiring gate then has to repair or reject them.
+
+Concretely:
+
+- **No separate `testing` subtasks.** The subtask that deletes `_MIGRATION_SIGNAL_RE` is
+  the same subtask that rewrites `tests/test_migration_surface.py`.
+- **No separate `documentation` subtasks.** The subtask that changes a site updates the
+  DESIGN/IMPLEMENTATION prose for that site, in the same change.
+- **No cross-cutting "verify the whole suite passes" subtask.** Every subtask runs
+  `pytest tests/` as part of its own success criteria. A standalone final verifier
+  depends on every other subtask's tests being finished, which is exactly the
+  un-wireable shape above.
+- The five sites are **independent of each other** — they touch different functions and
+  different test files. Expect a flat plan with no inter-subtask dependencies, not a
+  chain.
+
+## Constraints / risk
+
+These are load-bearing incident fixes — do not regress them:
+
+- `check_task_file_coverage` is the 2026-07-19 coverage-freeze fix
+  (`test_incident_2026_07_19.py`, `test_task_file_coverage_freeze.py`,
+  `test_task_file_extraction.py`). The gate must still fire on the incident shape and
+  stay silent on the uncoverable-convention shape after the migration.
+- The migration-surface check (DESIGN §5 *Migration-surface completeness*) has its own
+  tests. Preserve the `UNCOVERED_MIGRATION_SURFACE` behavior via the new structured field.
+- PHANTOM_ARTIFACT has a live regression suite in `tests/test_phase_overlap_judge.py`
+  covering descriptive artifact names, multi-path names, pure logical names, and invented
+  paths inside prose. All of it must still pass against `artifact_paths`; the judge's
+  prompt must be updated to populate the new field or every collision reads as pathless.
+
+## Tests
+
+Add a `TestRegexPathAbsent`-style guard per migrated site (assert the deleted symbols no
+longer exist on the module, so the prose-parsing path can never silently return), plus
+schema/wiring tests for each new worker or new structured field, and preserve every
+existing incident/behavior test — they must pass against the LLM-structured path.
+
+## Definition of done
+
+- No regex or hand-parsing in `orchestrator/leerie.py` operates on task text,
+  planner/worker prose, README/markdown content, or an LLM response (grep + per-site
+  absence guards).
+- Every NL fact a Python check needs is a JSON field from a schema-validated worker.
+- `pytest tests/` green (incl. the incident regression tests), verified within each
+  subtask rather than by a separate one.
+- DESIGN/IMPLEMENTATION updated first, per the three-layer rule.

--- a/tests/fixtures/wiring_repair_corpus/corpus.json
+++ b/tests/fixtures/wiring_repair_corpus/corpus.json
@@ -1,0 +1,3767 @@
+{
+ "29a6bf8e": {
+  "plans": [
+   {
+    "domain": "feature-implementation",
+    "status": "ready",
+    "subtasks": [
+     {
+      "depends_on": [
+       "docs-002-1",
+       "docs-002-2-1",
+       "docs-002-2-2-1",
+       "docs-002-2-2-3"
+      ],
+      "files_likely_touched": [
+       "docs/DESIGN.md",
+       "docs/IMPLEMENTATION.md"
+      ],
+      "id": "feat-001",
+      "intent": "",
+      "provides": [
+       "multi-token-design-spec",
+       "multi-token-design-documented",
+       "multi-token-implementation-spec"
+      ],
+      "requires": [
+       {
+        "extent": "in_plan",
+        "tag": "multi-token-architecture-designed"
+       }
+      ],
+      "runs_commands": [],
+      "size": "small",
+      "success_criteria_seed": "placeholder criteria (redacted)",
+      "title": "feat-001"
+     },
+     {
+      "depends_on": [
+       "feat-001"
+      ],
+      "files_likely_touched": [
+       "orchestrator/leerie.py"
+      ],
+      "id": "feat-002",
+      "intent": "",
+      "provides": [
+       "token-probe-ranking"
+      ],
+      "requires": [
+       {
+        "extent": "in_plan",
+        "tag": "multi-token-design-spec"
+       }
+      ],
+      "runs_commands": [],
+      "size": "small",
+      "success_criteria_seed": "placeholder criteria (redacted)",
+      "title": "feat-002"
+     },
+     {
+      "depends_on": [
+       "feat-001",
+       "feat-002",
+       "feat-005"
+      ],
+      "files_likely_touched": [
+       "orchestrator/leerie.py"
+      ],
+      "id": "feat-003",
+      "intent": "",
+      "provides": [],
+      "requires": [
+       {
+        "extent": "in_plan",
+        "tag": "multi-token-design-spec"
+       },
+       {
+        "extent": "in_plan",
+        "tag": "token-probe-ranking"
+       },
+       {
+        "extent": "in_plan",
+        "tag": "invoke-token-env"
+       }
+      ],
+      "runs_commands": [],
+      "size": "small",
+      "success_criteria_seed": "placeholder criteria (redacted)",
+      "title": "feat-003"
+     },
+     {
+      "depends_on": [
+       "feat-001",
+       "feat-002",
+       "feat-005"
+      ],
+      "files_likely_touched": [
+       "orchestrator/leerie.py"
+      ],
+      "id": "feat-004",
+      "intent": "",
+      "provides": [
+       "token-failover"
+      ],
+      "requires": [
+       {
+        "extent": "in_plan",
+        "tag": "multi-token-design-spec"
+       },
+       {
+        "extent": "in_plan",
+        "tag": "token-probe-ranking"
+       },
+       {
+        "extent": "in_plan",
+        "tag": "invoke-token-env"
+       }
+      ],
+      "runs_commands": [],
+      "size": "small",
+      "success_criteria_seed": "placeholder criteria (redacted)",
+      "title": "feat-004"
+     },
+     {
+      "depends_on": [
+       "feat-001"
+      ],
+      "files_likely_touched": [
+       "orchestrator/leerie.py"
+      ],
+      "id": "feat-005",
+      "intent": "",
+      "provides": [
+       "invoke-token-env"
+      ],
+      "requires": [
+       {
+        "extent": "in_plan",
+        "tag": "multi-token-design-spec"
+       }
+      ],
+      "runs_commands": [],
+      "size": "small",
+      "success_criteria_seed": "placeholder criteria (redacted)",
+      "title": "feat-005"
+     },
+     {
+      "depends_on": [
+       "feat-001"
+      ],
+      "files_likely_touched": [
+       "leerie"
+      ],
+      "id": "feat-006",
+      "intent": "",
+      "provides": [
+       "launcher-multi-token"
+      ],
+      "requires": [
+       {
+        "extent": "in_plan",
+        "tag": "multi-token-design-spec"
+       }
+      ],
+      "runs_commands": [],
+      "size": "small",
+      "success_criteria_seed": "placeholder criteria (redacted)",
+      "title": "feat-006"
+     },
+     {
+      "depends_on": [
+       "feat-006"
+      ],
+      "files_likely_touched": [
+       "scripts/remote/seed-auth.sh"
+      ],
+      "id": "feat-007",
+      "intent": "",
+      "provides": [],
+      "requires": [
+       {
+        "extent": "in_plan",
+        "tag": "launcher-multi-token"
+       }
+      ],
+      "runs_commands": [],
+      "size": "small",
+      "success_criteria_seed": "placeholder criteria (redacted)",
+      "title": "feat-007"
+     },
+     {
+      "depends_on": [
+       "feat-006"
+      ],
+      "files_likely_touched": [
+       "scripts/remote/ec2-seed-auth.sh"
+      ],
+      "id": "feat-008",
+      "intent": "",
+      "provides": [],
+      "requires": [
+       {
+        "extent": "in_plan",
+        "tag": "launcher-multi-token"
+       }
+      ],
+      "runs_commands": [],
+      "size": "small",
+      "success_criteria_seed": "placeholder criteria (redacted)",
+      "title": "feat-008"
+     }
+    ]
+   },
+   {
+    "domain": "testing",
+    "status": "ready",
+    "subtasks": [
+     {
+      "depends_on": [],
+      "files_likely_touched": [
+       "tests/test_multi_token_probe.py"
+      ],
+      "id": "test-001",
+      "intent": "",
+      "provides": [
+       "multi-token-probe-tests"
+      ],
+      "requires": [
+       {
+        "extent": "in_plan",
+        "tag": "token-probe-ranking"
+       }
+      ],
+      "runs_commands": [],
+      "size": "small",
+      "success_criteria_seed": "placeholder criteria (redacted)",
+      "title": "test-001"
+     },
+     {
+      "depends_on": [],
+      "files_likely_touched": [
+       "tests/test_multi_token_failover.py"
+      ],
+      "id": "test-002",
+      "intent": "",
+      "provides": [
+       "multi-token-failover-tests"
+      ],
+      "requires": [
+       {
+        "extent": "in_plan",
+        "tag": "token-failover"
+       }
+      ],
+      "runs_commands": [],
+      "size": "small",
+      "success_criteria_seed": "placeholder criteria (redacted)",
+      "title": "test-002"
+     },
+     {
+      "depends_on": [],
+      "files_likely_touched": [
+       "tests/test_launcher_multi_token.py"
+      ],
+      "id": "test-003",
+      "intent": "",
+      "provides": [
+       "launcher-multi-token-tests"
+      ],
+      "requires": [
+       {
+        "extent": "in_plan",
+        "tag": "launcher-multi-token"
+       }
+      ],
+      "runs_commands": [],
+      "size": "small",
+      "success_criteria_seed": "placeholder criteria (redacted)",
+      "title": "test-003"
+     },
+     {
+      "depends_on": [],
+      "files_likely_touched": [
+       "tests/test_invoke_token_env.py"
+      ],
+      "id": "test-004",
+      "intent": "",
+      "provides": [
+       "token-env-threading-tests"
+      ],
+      "requires": [
+       {
+        "extent": "in_plan",
+        "tag": "invoke-token-env"
+       }
+      ],
+      "runs_commands": [],
+      "size": "small",
+      "success_criteria_seed": "placeholder criteria (redacted)",
+      "title": "test-004"
+     },
+     {
+      "depends_on": [],
+      "files_likely_touched": [
+       "tests/test_multi_token_secrets.py"
+      ],
+      "id": "test-005",
+      "intent": "",
+      "provides": [
+       "multi-token-secrets-tests"
+      ],
+      "requires": [
+       {
+        "extent": "in_plan",
+        "tag": "token-probe-ranking"
+       },
+       {
+        "extent": "in_plan",
+        "tag": "token-failover"
+       }
+      ],
+      "runs_commands": [],
+      "size": "small",
+      "success_criteria_seed": "placeholder criteria (redacted)",
+      "title": "test-005"
+     }
+    ]
+   },
+   {
+    "domain": "documentation",
+    "status": "ready",
+    "subtasks": [
+     {
+      "depends_on": [],
+      "files_likely_touched": [],
+      "id": "docs-001",
+      "intent": "",
+      "provides": [
+       "current-credential-docs-mapped"
+      ],
+      "requires": [],
+      "runs_commands": [],
+      "size": "small",
+      "success_criteria_seed": "placeholder criteria (redacted)",
+      "title": "docs-001"
+     },
+     {
+      "depends_on": [
+       "docs-001"
+      ],
+      "files_likely_touched": [],
+      "id": "docs-002-1",
+      "intent": "",
+      "provides": [
+       "probe-mechanism-designed"
+      ],
+      "requires": [
+       {
+        "extent": "in_plan",
+        "tag": "current-credential-docs-mapped"
+       }
+      ],
+      "runs_commands": [],
+      "size": "small",
+      "success_criteria_seed": "placeholder criteria (redacted)",
+      "title": "docs-002-1"
+     },
+     {
+      "depends_on": [
+       "docs-002-1"
+      ],
+      "files_likely_touched": [],
+      "id": "docs-002-2-1",
+      "intent": "",
+      "provides": [
+       "token-ranking-algorithm-designed"
+      ],
+      "requires": [
+       {
+        "extent": "in_plan",
+        "reason": "Algorithm consumes probe output schema fields",
+        "tag": "probe-mechanism-designed"
+       }
+      ],
+      "runs_commands": [],
+      "size": "small",
+      "success_criteria_seed": "placeholder criteria (redacted)",
+      "title": "docs-002-2-1"
+     },
+     {
+      "depends_on": [
+       "docs-002-2-1"
+      ],
+      "files_likely_touched": [],
+      "id": "docs-002-2-2-1",
+      "intent": "",
+      "provides": [
+       "start-of-run-selection-designed"
+      ],
+      "requires": [
+       {
+        "extent": "in_plan",
+        "reason": "Initial selection consumes ranking algorithm's output",
+        "tag": "token-ranking-algorithm-designed"
+       }
+      ],
+      "runs_commands": [],
+      "size": "small",
+      "success_criteria_seed": "placeholder criteria (redacted)",
+      "title": "docs-002-2-2-1"
+     },
+     {
+      "depends_on": [
+       "docs-002-2-1"
+      ],
+      "files_likely_touched": [],
+      "id": "docs-002-2-2-3",
+      "intent": "",
+      "provides": [
+       "exhaustion-degradation-designed"
+      ],
+      "requires": [
+       {
+        "extent": "in_plan",
+        "reason": "Degradation strategy references ranking algorithm's empty/unavailable output",
+        "tag": "token-ranking-algorithm-designed"
+       }
+      ],
+      "runs_commands": [],
+      "size": "small",
+      "success_criteria_seed": "placeholder criteria (redacted)",
+      "title": "docs-002-2-2-3"
+     },
+     {
+      "depends_on": [
+       "feat-001"
+      ],
+      "files_likely_touched": [
+       "CLAUDE.md"
+      ],
+      "id": "docs-005",
+      "intent": "",
+      "provides": [
+       "multi-token-user-docs"
+      ],
+      "requires": [
+       {
+        "extent": "in_plan",
+        "tag": "multi-token-implementation-spec"
+       }
+      ],
+      "runs_commands": [],
+      "size": "small",
+      "success_criteria_seed": "placeholder criteria (redacted)",
+      "title": "docs-005"
+     }
+    ]
+   },
+   {
+    "domain": "_reconciler",
+    "status": "ready",
+    "subtasks": [
+     {
+      "depends_on": [
+       "docs-002-1",
+       "docs-002-2-1",
+       "docs-002-2-2-1",
+       "docs-002-2-2-3"
+      ],
+      "files_likely_touched": [],
+      "id": "docs-006",
+      "intent": "",
+      "provides": [
+       "multi-token-architecture-designed"
+      ],
+      "requires": [
+       {
+        "extent": "in_plan",
+        "tag": "probe-mechanism-designed"
+       },
+       {
+        "extent": "in_plan",
+        "tag": "token-ranking-algorithm-designed"
+       },
+       {
+        "extent": "in_plan",
+        "tag": "start-of-run-selection-designed"
+       },
+       {
+        "extent": "in_plan",
+        "tag": "exhaustion-degradation-designed"
+       }
+      ],
+      "runs_commands": [],
+      "size": "small",
+      "success_criteria_seed": "placeholder criteria (redacted)",
+      "title": "docs-006"
+     }
+    ]
+   }
+  ],
+  "wiring_defects": [
+   {
+    "concrete_reason": "redacted \u2014 only presence is asserted",
+    "kind": "missing_requires",
+    "severity": null,
+    "sid": "test-003",
+    "tag_or_dep": "multi-token-implementation-spec"
+   }
+  ]
+ },
+ "3a4abba3": {
+  "plans": [
+   {
+    "domain": "feature-implementation",
+    "status": "ready",
+    "subtasks": []
+   },
+   {
+    "domain": "refactoring",
+    "status": "ready",
+    "subtasks": [
+     {
+      "depends_on": [
+       "docs-001",
+       "docs-002"
+      ],
+      "files_likely_touched": [
+       "orchestrator/leerie.py",
+       "prompts/task_file_coverage.md"
+      ],
+      "id": "refactor-002",
+      "intent": "",
+      "provides": [
+       "task-file-coverage-worker",
+       "task-file-coverage-schema"
+      ],
+      "requires": [
+       {
+        "extent": "in_plan",
+        "tag": "nl-regex-migration-spec"
+       }
+      ],
+      "runs_commands": [],
+      "size": "small",
+      "success_criteria_seed": "placeholder criteria (redacted)",
+      "title": "refactor-002"
+     },
+     {
+      "depends_on": [
+       "refactor-002"
+      ],
+      "files_likely_touched": [
+       "orchestrator/leerie.py",
+       "prompts/planner.md"
+      ],
+      "id": "refactor-003",
+      "intent": "",
+      "provides": [
+       "planner-migration-targets-field"
+      ],
+      "requires": [
+       {
+        "extent": "in_plan",
+        "tag": "nl-regex-migration-spec"
+       }
+      ],
+      "runs_commands": [],
+      "size": "small",
+      "success_criteria_seed": "placeholder criteria (redacted)",
+      "title": "refactor-003"
+     },
+     {
+      "depends_on": [
+       "refactor-003"
+      ],
+      "files_likely_touched": [
+       "orchestrator/leerie.py",
+       "prompts/provision.md"
+      ],
+      "id": "refactor-004",
+      "intent": "",
+      "provides": [
+       "provision-readme-fold-in"
+      ],
+      "requires": [
+       {
+        "extent": "in_plan",
+        "tag": "nl-regex-migration-spec"
+       }
+      ],
+      "runs_commands": [],
+      "size": "small",
+      "success_criteria_seed": "placeholder criteria (redacted)",
+      "title": "refactor-004"
+     },
+     {
+      "depends_on": [
+       "refactor-004"
+      ],
+      "files_likely_touched": [
+       "tests/test_regex_migration_absent.py",
+       "tests/test_task_file_coverage_schema.py"
+      ],
+      "id": "refactor-005",
+      "intent": "",
+      "provides": [
+       "nl-regex-migration-verified"
+      ],
+      "requires": [
+       {
+        "extent": "in_plan",
+        "tag": "task-file-coverage-schema"
+       },
+       {
+        "extent": "in_plan",
+        "tag": "planner-migration-targets-field"
+       },
+       {
+        "extent": "in_plan",
+        "tag": "provision-readme-fold-in"
+       }
+      ],
+      "runs_commands": [],
+      "size": "small",
+      "success_criteria_seed": "placeholder criteria (redacted)",
+      "title": "refactor-005"
+     }
+    ]
+   },
+   {
+    "domain": "testing",
+    "status": "ready",
+    "subtasks": [
+     {
+      "depends_on": [],
+      "files_likely_touched": [
+       "tests/test_task_file_extraction.py"
+      ],
+      "id": "test-001",
+      "intent": "",
+      "provides": [
+       "task-file-extraction-tests-migrated"
+      ],
+      "requires": [
+       {
+        "extent": "in_plan",
+        "tag": "task-file-coverage-worker"
+       },
+       {
+        "extent": "in_plan",
+        "tag": "task-file-coverage-schema"
+       }
+      ],
+      "runs_commands": [],
+      "size": "small",
+      "success_criteria_seed": "placeholder criteria (redacted)",
+      "title": "test-001"
+     },
+     {
+      "depends_on": [],
+      "files_likely_touched": [
+       "tests/test_task_file_coverage_schema.py"
+      ],
+      "id": "test-002",
+      "intent": "",
+      "provides": [
+       "task-file-coverage-schema-tests"
+      ],
+      "requires": [
+       {
+        "extent": "in_plan",
+        "tag": "task-file-coverage-schema"
+       },
+       {
+        "extent": "in_plan",
+        "tag": "task-file-coverage-worker"
+       }
+      ],
+      "runs_commands": [],
+      "size": "small",
+      "success_criteria_seed": "placeholder criteria (redacted)",
+      "title": "test-002"
+     },
+     {
+      "depends_on": [],
+      "files_likely_touched": [
+       "tests/test_task_file_coverage_freeze.py"
+      ],
+      "id": "test-003",
+      "intent": "",
+      "provides": [
+       "task-file-coverage-freeze-migrated"
+      ],
+      "requires": [
+       {
+        "extent": "in_plan",
+        "tag": "task-file-coverage-worker"
+       }
+      ],
+      "runs_commands": [],
+      "size": "small",
+      "success_criteria_seed": "placeholder criteria (redacted)",
+      "title": "test-003"
+     },
+     {
+      "depends_on": [],
+      "files_likely_touched": [
+       "tests/test_incident_2026_07_19.py"
+      ],
+      "id": "test-004",
+      "intent": "",
+      "provides": [
+       "incident-2026-07-19-coverage-migrated"
+      ],
+      "requires": [
+       {
+        "extent": "in_plan",
+        "tag": "task-file-coverage-worker"
+       }
+      ],
+      "runs_commands": [],
+      "size": "small",
+      "success_criteria_seed": "placeholder criteria (redacted)",
+      "title": "test-004"
+     },
+     {
+      "depends_on": [],
+      "files_likely_touched": [
+       "tests/test_readme_extractor.py"
+      ],
+      "id": "test-005",
+      "intent": "",
+      "provides": [
+       "readme-extractor-tests-migrated"
+      ],
+      "requires": [],
+      "runs_commands": [],
+      "size": "small",
+      "success_criteria_seed": "placeholder criteria (redacted)",
+      "title": "test-005"
+     },
+     {
+      "depends_on": [],
+      "files_likely_touched": [
+       "tests/test_provision_fixtures.py"
+      ],
+      "id": "test-006",
+      "intent": "",
+      "provides": [
+       "provision-fixtures-tests-migrated"
+      ],
+      "requires": [],
+      "runs_commands": [],
+      "size": "small",
+      "success_criteria_seed": "placeholder criteria (redacted)",
+      "title": "test-006"
+     },
+     {
+      "depends_on": [],
+      "files_likely_touched": [
+       "tests/test_migration_surface.py"
+      ],
+      "id": "test-007",
+      "intent": "",
+      "provides": [
+       "migration-surface-tests-migrated"
+      ],
+      "requires": [
+       {
+        "extent": "in_plan",
+        "tag": "planner-migration-targets-field"
+       }
+      ],
+      "runs_commands": [],
+      "size": "small",
+      "success_criteria_seed": "placeholder criteria (redacted)",
+      "title": "test-007"
+     },
+     {
+      "depends_on": [],
+      "files_likely_touched": [
+       "tests/test_planner_migration_targets_schema.py"
+      ],
+      "id": "test-008",
+      "intent": "",
+      "provides": [
+       "planner-migration-targets-schema-tests"
+      ],
+      "requires": [
+       {
+        "extent": "in_plan",
+        "tag": "planner-migration-targets-field"
+       }
+      ],
+      "runs_commands": [],
+      "size": "small",
+      "success_criteria_seed": "placeholder criteria (redacted)",
+      "title": "test-008"
+     },
+     {
+      "depends_on": [],
+      "files_likely_touched": [
+       "tests/test_phase_plan_recursion_wiring.py",
+       "tests/test_decompose_snapshot.py",
+       "tests/test_replan_sid_scoping.py"
+      ],
+      "id": "test-009",
+      "intent": "",
+      "provides": [
+       "extract-task-file-structure-callsites-updated"
+      ],
+      "requires": [
+       {
+        "extent": "in_plan",
+        "tag": "task-file-coverage-worker"
+       }
+      ],
+      "runs_commands": [],
+      "size": "small",
+      "success_criteria_seed": "placeholder criteria (redacted)",
+      "title": "test-009"
+     }
+    ]
+   },
+   {
+    "domain": "documentation",
+    "status": "ready",
+    "subtasks": [
+     {
+      "depends_on": [],
+      "files_likely_touched": [
+       "docs/DESIGN.md"
+      ],
+      "id": "docs-001",
+      "intent": "",
+      "provides": [
+       "design-nlp-migration-spec",
+       "nl-regex-migration-spec"
+      ],
+      "requires": [],
+      "runs_commands": [],
+      "size": "small",
+      "success_criteria_seed": "placeholder criteria (redacted)",
+      "title": "docs-001"
+     },
+     {
+      "depends_on": [
+       "docs-001"
+      ],
+      "files_likely_touched": [
+       "docs/IMPLEMENTATION.md"
+      ],
+      "id": "docs-002",
+      "intent": "",
+      "provides": [
+       "implementation-nlp-migration-spec",
+       "nl-regex-migration-spec"
+      ],
+      "requires": [
+       {
+        "extent": "in_plan",
+        "tag": "design-nlp-migration-spec"
+       }
+      ],
+      "runs_commands": [],
+      "size": "small",
+      "success_criteria_seed": "placeholder criteria (redacted)",
+      "title": "docs-002"
+     }
+    ]
+   }
+  ],
+  "wiring_defects": [
+   {
+    "concrete_reason": "redacted \u2014 only presence is asserted",
+    "kind": "missing_requires",
+    "severity": "live_defect",
+    "sid": "test-005",
+    "tag_or_dep": "provision-readme-fold-in"
+   },
+   {
+    "concrete_reason": "redacted \u2014 only presence is asserted",
+    "kind": "missing_requires",
+    "severity": "live_defect",
+    "sid": "test-006",
+    "tag_or_dep": "provision-readme-fold-in"
+   }
+  ]
+ },
+ "6146bd2f": {
+  "plans": [
+   {
+    "domain": "refactoring",
+    "status": "ready",
+    "subtasks": [
+     {
+      "depends_on": [],
+      "files_likely_touched": [
+       "docs/DESIGN.md",
+       "docs/IMPLEMENTATION.md"
+      ],
+      "id": "refactor-001",
+      "intent": "",
+      "provides": [
+       "nl-regex-migration-design-documented",
+       "design-doc-updated-for-nl-regex-migration"
+      ],
+      "requires": [],
+      "runs_commands": [],
+      "size": "small",
+      "success_criteria_seed": "placeholder criteria (redacted)",
+      "title": "refactor-001"
+     },
+     {
+      "depends_on": [
+       "refactor-001"
+      ],
+      "files_likely_touched": [
+       "orchestrator/leerie.py",
+       "prompts/task_file_structure.md",
+       "tests/test_task_file_structure_worker.py"
+      ],
+      "id": "refactor-002",
+      "intent": "",
+      "provides": [
+       "task-file-structure-worker",
+       "task-file-structure-schema"
+      ],
+      "requires": [
+       {
+        "extent": "in_plan",
+        "tag": "nl-regex-migration-design-documented"
+       }
+      ],
+      "runs_commands": [],
+      "size": "small",
+      "success_criteria_seed": "placeholder criteria (redacted)",
+      "title": "refactor-002"
+     },
+     {
+      "depends_on": [
+       "refactor-001"
+      ],
+      "files_likely_touched": [
+       "orchestrator/leerie.py",
+       "prompts/planner.md",
+       "tests/test_planner_migration_targets.py"
+      ],
+      "id": "refactor-003",
+      "intent": "",
+      "provides": [
+       "planner-migration-targets-field"
+      ],
+      "requires": [
+       {
+        "extent": "in_plan",
+        "tag": "nl-regex-migration-design-documented"
+       }
+      ],
+      "runs_commands": [],
+      "size": "small",
+      "success_criteria_seed": "placeholder criteria (redacted)",
+      "title": "refactor-003"
+     },
+     {
+      "depends_on": [
+       "refactor-001"
+      ],
+      "files_likely_touched": [
+       "orchestrator/leerie.py",
+       "prompts/provision.md",
+       "tests/test_provision_readme_worker.py"
+      ],
+      "id": "refactor-004",
+      "intent": "",
+      "provides": [
+       "provision-readme-section-selection"
+      ],
+      "requires": [
+       {
+        "extent": "in_plan",
+        "tag": "nl-regex-migration-design-documented"
+       }
+      ],
+      "runs_commands": [],
+      "size": "small",
+      "success_criteria_seed": "placeholder criteria (redacted)",
+      "title": "refactor-004"
+     },
+     {
+      "depends_on": [
+       "refactor-002",
+       "refactor-003",
+       "refactor-004"
+      ],
+      "files_likely_touched": [
+       "tests/test_nl_regex_migration_complete.py"
+      ],
+      "id": "refactor-005",
+      "intent": "",
+      "provides": [
+       "nl-regex-migration-verified"
+      ],
+      "requires": [
+       {
+        "extent": "in_plan",
+        "tag": "task-file-structure-worker"
+       },
+       {
+        "extent": "in_plan",
+        "tag": "planner-migration-targets-field"
+       },
+       {
+        "extent": "in_plan",
+        "tag": "provision-readme-section-selection"
+       }
+      ],
+      "runs_commands": [],
+      "size": "small",
+      "success_criteria_seed": "placeholder criteria (redacted)",
+      "title": "refactor-005"
+     }
+    ]
+   },
+   {
+    "domain": "testing",
+    "status": "ready",
+    "subtasks": [
+     {
+      "depends_on": [],
+      "files_likely_touched": [
+       "tests/test_task_file_structure_schema.py"
+      ],
+      "id": "test-001",
+      "intent": "",
+      "provides": [
+       "task-file-structure-schema-tested"
+      ],
+      "requires": [
+       {
+        "extent": "in_plan",
+        "tag": "task-file-structure-worker"
+       },
+       {
+        "extent": "in_plan",
+        "tag": "task-file-structure-schema"
+       }
+      ],
+      "runs_commands": [],
+      "size": "small",
+      "success_criteria_seed": "placeholder criteria (redacted)",
+      "title": "test-001"
+     },
+     {
+      "depends_on": [],
+      "files_likely_touched": [
+       "tests/test_task_file_extraction.py"
+      ],
+      "id": "test-002",
+      "intent": "",
+      "provides": [
+       "task-file-extraction-tests-migrated"
+      ],
+      "requires": [
+       {
+        "extent": "in_plan",
+        "tag": "task-file-structure-worker"
+       }
+      ],
+      "runs_commands": [],
+      "size": "small",
+      "success_criteria_seed": "placeholder criteria (redacted)",
+      "title": "test-002"
+     },
+     {
+      "depends_on": [],
+      "files_likely_touched": [
+       "tests/test_task_file_coverage_freeze.py",
+       "tests/test_incident_2026_07_19.py",
+       "tests/fixtures/incident_2026_07_19/generate.py"
+      ],
+      "id": "test-003",
+      "intent": "",
+      "provides": [
+       "coverage-freeze-incident-preserved"
+      ],
+      "requires": [
+       {
+        "extent": "in_plan",
+        "tag": "task-file-structure-worker"
+       }
+      ],
+      "runs_commands": [],
+      "size": "small",
+      "success_criteria_seed": "placeholder criteria (redacted)",
+      "title": "test-003"
+     },
+     {
+      "depends_on": [],
+      "files_likely_touched": [
+       "tests/test_migration_surface.py"
+      ],
+      "id": "test-004",
+      "intent": "",
+      "provides": [
+       "migration-surface-tests-migrated"
+      ],
+      "requires": [
+       {
+        "extent": "in_plan",
+        "tag": "planner-migration-targets-field"
+       }
+      ],
+      "runs_commands": [],
+      "size": "small",
+      "success_criteria_seed": "placeholder criteria (redacted)",
+      "title": "test-004"
+     },
+     {
+      "depends_on": [],
+      "files_likely_touched": [
+       "tests/test_planner_migration_targets_schema.py"
+      ],
+      "id": "test-005",
+      "intent": "",
+      "provides": [
+       "planner-migration-targets-schema-tested"
+      ],
+      "requires": [
+       {
+        "extent": "in_plan",
+        "tag": "planner-migration-targets-field"
+       }
+      ],
+      "runs_commands": [],
+      "size": "small",
+      "success_criteria_seed": "placeholder criteria (redacted)",
+      "title": "test-005"
+     },
+     {
+      "depends_on": [],
+      "files_likely_touched": [
+       "tests/test_provision_fixtures.py"
+      ],
+      "id": "test-006",
+      "intent": "",
+      "provides": [
+       "provision-fixtures-tests-migrated"
+      ],
+      "requires": [
+       {
+        "extent": "in_plan",
+        "tag": "provision-readme-section-selection"
+       }
+      ],
+      "runs_commands": [],
+      "size": "small",
+      "success_criteria_seed": "placeholder criteria (redacted)",
+      "title": "test-006"
+     }
+    ]
+   },
+   {
+    "domain": "documentation",
+    "status": "ready",
+    "subtasks": [
+     {
+      "depends_on": [
+       "refactor-001"
+      ],
+      "files_likely_touched": [
+       "docs/IMPLEMENTATION.md"
+      ],
+      "id": "docs-002",
+      "intent": "",
+      "provides": [
+       "implementation-doc-updated-for-nl-regex-migration"
+      ],
+      "requires": [
+       {
+        "extent": "in_plan",
+        "tag": "task-file-structure-worker"
+       },
+       {
+        "extent": "in_plan",
+        "tag": "task-file-structure-schema"
+       },
+       {
+        "extent": "in_plan",
+        "tag": "planner-migration-targets-field"
+       },
+       {
+        "extent": "in_plan",
+        "tag": "provision-readme-section-selection"
+       }
+      ],
+      "runs_commands": [],
+      "size": "small",
+      "success_criteria_seed": "placeholder criteria (redacted)",
+      "title": "docs-002"
+     },
+     {
+      "depends_on": [
+       "docs-002"
+      ],
+      "files_likely_touched": [
+       "CLAUDE.md"
+      ],
+      "id": "docs-003",
+      "intent": "",
+      "provides": [
+       "claude-md-testing-section-updated-for-nl-regex-migration"
+      ],
+      "requires": [
+       {
+        "extent": "in_plan",
+        "tag": "task-file-extraction-tests-migrated"
+       },
+       {
+        "extent": "in_plan",
+        "tag": "migration-surface-tests-migrated"
+       },
+       {
+        "extent": "in_plan",
+        "tag": "provision-fixtures-tests-migrated"
+       }
+      ],
+      "runs_commands": [],
+      "size": "small",
+      "success_criteria_seed": "placeholder criteria (redacted)",
+      "title": "docs-003"
+     }
+    ]
+   }
+  ],
+  "wiring_defects": [
+   {
+    "concrete_reason": "redacted \u2014 only presence is asserted",
+    "kind": "missing_requires",
+    "severity": "live_defect",
+    "sid": "refactor-005",
+    "tag_or_dep": "task-file-extraction-tests-migrated"
+   },
+   {
+    "concrete_reason": "redacted \u2014 only presence is asserted",
+    "kind": "missing_requires",
+    "severity": "live_defect",
+    "sid": "refactor-005",
+    "tag_or_dep": "coverage-freeze-incident-preserved"
+   },
+   {
+    "concrete_reason": "redacted \u2014 only presence is asserted",
+    "kind": "missing_requires",
+    "severity": "live_defect",
+    "sid": "refactor-005",
+    "tag_or_dep": "migration-surface-tests-migrated"
+   },
+   {
+    "concrete_reason": "redacted \u2014 only presence is asserted",
+    "kind": "missing_requires",
+    "severity": "live_defect",
+    "sid": "refactor-005",
+    "tag_or_dep": "provision-fixtures-tests-migrated"
+   }
+  ]
+ },
+ "62a19deb": {
+  "plans": [
+   {
+    "domain": "feature-implementation",
+    "status": "ready",
+    "subtasks": [
+     {
+      "depends_on": [],
+      "files_likely_touched": [
+       "leerie"
+      ],
+      "id": "feat-001-r1",
+      "intent": "",
+      "provides": [
+       "opt-bake-implemented",
+       "dockerfile-generates-opt-paths",
+       "runtime-env-configured",
+       "python-opt-venv-baked",
+       "ruby-opt-bundle-baked",
+       "lockfile-hash-invalidation-preserved"
+      ],
+      "requires": [],
+      "runs_commands": [],
+      "size": "small",
+      "success_criteria_seed": "placeholder criteria (redacted)",
+      "title": "feat-001-r1"
+     },
+     {
+      "depends_on": [],
+      "files_likely_touched": [
+       "leerie"
+      ],
+      "id": "feat-001-r2",
+      "intent": "",
+      "provides": [
+       "opt-bake-implemented",
+       "dockerfile-generates-opt-paths",
+       "runtime-env-configured",
+       "python-opt-venv-baked",
+       "ruby-opt-bundle-baked",
+       "lockfile-hash-invalidation-preserved"
+      ],
+      "requires": [],
+      "runs_commands": [],
+      "size": "small",
+      "success_criteria_seed": "placeholder criteria (redacted)",
+      "title": "feat-001-r2"
+     },
+     {
+      "depends_on": [],
+      "files_likely_touched": [
+       "leerie"
+      ],
+      "id": "feat-001-r3",
+      "intent": "",
+      "provides": [
+       "opt-bake-implemented",
+       "dockerfile-generates-opt-paths",
+       "runtime-env-configured",
+       "python-opt-venv-baked",
+       "ruby-opt-bundle-baked",
+       "lockfile-hash-invalidation-preserved"
+      ],
+      "requires": [],
+      "runs_commands": [],
+      "size": "small",
+      "success_criteria_seed": "placeholder criteria (redacted)",
+      "title": "feat-001-r3"
+     },
+     {
+      "depends_on": [],
+      "files_likely_touched": [
+       "leerie"
+      ],
+      "id": "feat-001-r4",
+      "intent": "",
+      "provides": [
+       "opt-bake-implemented",
+       "dockerfile-generates-opt-paths",
+       "runtime-env-configured",
+       "python-opt-venv-baked",
+       "ruby-opt-bundle-baked",
+       "lockfile-hash-invalidation-preserved"
+      ],
+      "requires": [],
+      "runs_commands": [],
+      "size": "small",
+      "success_criteria_seed": "placeholder criteria (redacted)",
+      "title": "feat-001-r4"
+     },
+     {
+      "depends_on": [],
+      "files_likely_touched": [
+       "leerie"
+      ],
+      "id": "feat-001-r5",
+      "intent": "",
+      "provides": [
+       "opt-bake-implemented",
+       "dockerfile-generates-opt-paths",
+       "runtime-env-configured",
+       "python-opt-venv-baked",
+       "ruby-opt-bundle-baked",
+       "lockfile-hash-invalidation-preserved"
+      ],
+      "requires": [],
+      "runs_commands": [],
+      "size": "small",
+      "success_criteria_seed": "placeholder criteria (redacted)",
+      "title": "feat-001-r5"
+     },
+     {
+      "depends_on": [],
+      "files_likely_touched": [
+       "leerie"
+      ],
+      "id": "feat-001-r6",
+      "intent": "",
+      "provides": [
+       "opt-bake-implemented",
+       "dockerfile-generates-opt-paths",
+       "runtime-env-configured",
+       "python-opt-venv-baked",
+       "ruby-opt-bundle-baked",
+       "lockfile-hash-invalidation-preserved"
+      ],
+      "requires": [],
+      "runs_commands": [],
+      "size": "small",
+      "success_criteria_seed": "placeholder criteria (redacted)",
+      "title": "feat-001-r6"
+     },
+     {
+      "depends_on": [],
+      "files_likely_touched": [
+       "leerie"
+      ],
+      "id": "feat-001-r7",
+      "intent": "",
+      "provides": [
+       "opt-bake-implemented",
+       "dockerfile-generates-opt-paths",
+       "runtime-env-configured",
+       "python-opt-venv-baked",
+       "ruby-opt-bundle-baked",
+       "lockfile-hash-invalidation-preserved"
+      ],
+      "requires": [],
+      "runs_commands": [],
+      "size": "small",
+      "success_criteria_seed": "placeholder criteria (redacted)",
+      "title": "feat-001-r7"
+     },
+     {
+      "depends_on": [],
+      "files_likely_touched": [
+       "leerie"
+      ],
+      "id": "feat-001-r9",
+      "intent": "",
+      "provides": [
+       "opt-bake-implemented",
+       "dockerfile-generates-opt-paths",
+       "runtime-env-configured",
+       "python-opt-venv-baked",
+       "ruby-opt-bundle-baked",
+       "lockfile-hash-invalidation-preserved"
+      ],
+      "requires": [],
+      "runs_commands": [],
+      "size": "small",
+      "success_criteria_seed": "placeholder criteria (redacted)",
+      "title": "feat-001-r9"
+     },
+     {
+      "depends_on": [],
+      "files_likely_touched": [
+       "leerie"
+      ],
+      "id": "feat-001-r10",
+      "intent": "",
+      "provides": [
+       "opt-bake-implemented",
+       "dockerfile-generates-opt-paths",
+       "runtime-env-configured",
+       "python-opt-venv-baked",
+       "ruby-opt-bundle-baked",
+       "lockfile-hash-invalidation-preserved"
+      ],
+      "requires": [],
+      "runs_commands": [],
+      "size": "small",
+      "success_criteria_seed": "placeholder criteria (redacted)",
+      "title": "feat-001-r10"
+     },
+     {
+      "depends_on": [],
+      "files_likely_touched": [
+       "leerie"
+      ],
+      "id": "feat-001-r11",
+      "intent": "",
+      "provides": [
+       "opt-bake-implemented",
+       "dockerfile-generates-opt-paths",
+       "runtime-env-configured",
+       "python-opt-venv-baked",
+       "ruby-opt-bundle-baked",
+       "lockfile-hash-invalidation-preserved"
+      ],
+      "requires": [],
+      "runs_commands": [],
+      "size": "small",
+      "success_criteria_seed": "placeholder criteria (redacted)",
+      "title": "feat-001-r11"
+     },
+     {
+      "depends_on": [
+       "feat-001-r1",
+       "feat-001-r2",
+       "feat-001-r3",
+       "feat-001-r4",
+       "feat-001-r5",
+       "feat-001-r6",
+       "feat-001-r7",
+       "feat-001-r9",
+       "feat-001-r10",
+       "feat-001-r11"
+      ],
+      "files_likely_touched": [
+       "orchestrator/leerie.py"
+      ],
+      "id": "feat-002-r1",
+      "intent": "",
+      "provides": [
+       "python-venv-clone-delta-implemented",
+       "worktree-venv-isolation-working"
+      ],
+      "requires": [
+       {
+        "extent": "in_plan",
+        "tag": "python-opt-venv-baked"
+       }
+      ],
+      "runs_commands": [],
+      "size": "small",
+      "success_criteria_seed": "placeholder criteria (redacted)",
+      "title": "feat-002-r1"
+     },
+     {
+      "depends_on": [
+       "feat-001-r1",
+       "feat-001-r2",
+       "feat-001-r3",
+       "feat-001-r4",
+       "feat-001-r5",
+       "feat-001-r6",
+       "feat-001-r7",
+       "feat-001-r9",
+       "feat-001-r10",
+       "feat-001-r11"
+      ],
+      "files_likely_touched": [
+       "orchestrator/leerie.py"
+      ],
+      "id": "feat-002-r2",
+      "intent": "",
+      "provides": [
+       "python-venv-clone-delta-implemented",
+       "worktree-venv-isolation-working"
+      ],
+      "requires": [
+       {
+        "extent": "in_plan",
+        "tag": "python-opt-venv-baked"
+       }
+      ],
+      "runs_commands": [],
+      "size": "small",
+      "success_criteria_seed": "placeholder criteria (redacted)",
+      "title": "feat-002-r2"
+     },
+     {
+      "depends_on": [
+       "feat-001-r1",
+       "feat-001-r2",
+       "feat-001-r3",
+       "feat-001-r4",
+       "feat-001-r5",
+       "feat-001-r6",
+       "feat-001-r7",
+       "feat-001-r9",
+       "feat-001-r10",
+       "feat-001-r11"
+      ],
+      "files_likely_touched": [
+       "orchestrator/leerie.py"
+      ],
+      "id": "feat-002-r3-r1",
+      "intent": "",
+      "provides": [
+       "python-venv-clone-delta-implemented",
+       "worktree-venv-isolation-working"
+      ],
+      "requires": [
+       {
+        "extent": "in_plan",
+        "tag": "python-opt-venv-baked"
+       }
+      ],
+      "runs_commands": [],
+      "size": "small",
+      "success_criteria_seed": "placeholder criteria (redacted)",
+      "title": "feat-002-r3-r1"
+     },
+     {
+      "depends_on": [
+       "feat-001-r1",
+       "feat-001-r2",
+       "feat-001-r3",
+       "feat-001-r4",
+       "feat-001-r5",
+       "feat-001-r6",
+       "feat-001-r7",
+       "feat-001-r9",
+       "feat-001-r10",
+       "feat-001-r11"
+      ],
+      "files_likely_touched": [
+       "orchestrator/leerie.py"
+      ],
+      "id": "feat-002-r3-r2",
+      "intent": "",
+      "provides": [
+       "python-venv-clone-delta-implemented",
+       "worktree-venv-isolation-working"
+      ],
+      "requires": [
+       {
+        "extent": "in_plan",
+        "tag": "python-opt-venv-baked"
+       }
+      ],
+      "runs_commands": [],
+      "size": "small",
+      "success_criteria_seed": "placeholder criteria (redacted)",
+      "title": "feat-002-r3-r2"
+     },
+     {
+      "depends_on": [
+       "feat-001-r1",
+       "feat-001-r2",
+       "feat-001-r3",
+       "feat-001-r4",
+       "feat-001-r5",
+       "feat-001-r6",
+       "feat-001-r7",
+       "feat-001-r9",
+       "feat-001-r10",
+       "feat-001-r11"
+      ],
+      "files_likely_touched": [
+       "orchestrator/leerie.py"
+      ],
+      "id": "feat-002-r4",
+      "intent": "",
+      "provides": [
+       "python-venv-clone-delta-implemented",
+       "worktree-venv-isolation-working"
+      ],
+      "requires": [
+       {
+        "extent": "in_plan",
+        "tag": "python-opt-venv-baked"
+       }
+      ],
+      "runs_commands": [],
+      "size": "small",
+      "success_criteria_seed": "placeholder criteria (redacted)",
+      "title": "feat-002-r4"
+     },
+     {
+      "depends_on": [
+       "feat-001-r1",
+       "feat-001-r2",
+       "feat-001-r3",
+       "feat-001-r4",
+       "feat-001-r5",
+       "feat-001-r6",
+       "feat-001-r7",
+       "feat-001-r9",
+       "feat-001-r10",
+       "feat-001-r11"
+      ],
+      "files_likely_touched": [
+       "orchestrator/leerie.py"
+      ],
+      "id": "feat-002-r5",
+      "intent": "",
+      "provides": [
+       "python-venv-clone-delta-implemented",
+       "worktree-venv-isolation-working"
+      ],
+      "requires": [
+       {
+        "extent": "in_plan",
+        "tag": "python-opt-venv-baked"
+       }
+      ],
+      "runs_commands": [],
+      "size": "small",
+      "success_criteria_seed": "placeholder criteria (redacted)",
+      "title": "feat-002-r5"
+     },
+     {
+      "depends_on": [
+       "feat-001-r1",
+       "feat-001-r2",
+       "feat-001-r3",
+       "feat-001-r4",
+       "feat-001-r5",
+       "feat-001-r6",
+       "feat-001-r7",
+       "feat-001-r9",
+       "feat-001-r10",
+       "feat-001-r11"
+      ],
+      "files_likely_touched": [
+       "orchestrator/leerie.py"
+      ],
+      "id": "feat-002-r6",
+      "intent": "",
+      "provides": [
+       "python-venv-clone-delta-implemented",
+       "worktree-venv-isolation-working"
+      ],
+      "requires": [
+       {
+        "extent": "in_plan",
+        "tag": "python-opt-venv-baked"
+       }
+      ],
+      "runs_commands": [],
+      "size": "small",
+      "success_criteria_seed": "placeholder criteria (redacted)",
+      "title": "feat-002-r6"
+     },
+     {
+      "depends_on": [
+       "feat-001-r1",
+       "feat-001-r2",
+       "feat-001-r3",
+       "feat-001-r4",
+       "feat-001-r5",
+       "feat-001-r6",
+       "feat-001-r7",
+       "feat-001-r9",
+       "feat-001-r10",
+       "feat-001-r11"
+      ],
+      "files_likely_touched": [
+       "orchestrator/leerie.py"
+      ],
+      "id": "feat-002-r7",
+      "intent": "",
+      "provides": [
+       "python-venv-clone-delta-implemented",
+       "worktree-venv-isolation-working"
+      ],
+      "requires": [
+       {
+        "extent": "in_plan",
+        "tag": "python-opt-venv-baked"
+       }
+      ],
+      "runs_commands": [],
+      "size": "small",
+      "success_criteria_seed": "placeholder criteria (redacted)",
+      "title": "feat-002-r7"
+     },
+     {
+      "depends_on": [
+       "feat-001-r1",
+       "feat-001-r2",
+       "feat-001-r3",
+       "feat-001-r4",
+       "feat-001-r5",
+       "feat-001-r6",
+       "feat-001-r7",
+       "feat-001-r9",
+       "feat-001-r10",
+       "feat-001-r11"
+      ],
+      "files_likely_touched": [
+       "orchestrator/leerie.py"
+      ],
+      "id": "feat-002-r8",
+      "intent": "",
+      "provides": [
+       "python-venv-clone-delta-implemented",
+       "worktree-venv-isolation-working"
+      ],
+      "requires": [
+       {
+        "extent": "in_plan",
+        "tag": "python-opt-venv-baked"
+       }
+      ],
+      "runs_commands": [],
+      "size": "small",
+      "success_criteria_seed": "placeholder criteria (redacted)",
+      "title": "feat-002-r8"
+     },
+     {
+      "depends_on": [
+       "feat-001-r1",
+       "feat-001-r2",
+       "feat-001-r3",
+       "feat-001-r4",
+       "feat-001-r5",
+       "feat-001-r6",
+       "feat-001-r7",
+       "feat-001-r9",
+       "feat-001-r10",
+       "feat-001-r11"
+      ],
+      "files_likely_touched": [
+       "orchestrator/leerie.py"
+      ],
+      "id": "feat-002-r9",
+      "intent": "",
+      "provides": [
+       "python-venv-clone-delta-implemented",
+       "worktree-venv-isolation-working"
+      ],
+      "requires": [
+       {
+        "extent": "in_plan",
+        "tag": "python-opt-venv-baked"
+       }
+      ],
+      "runs_commands": [],
+      "size": "small",
+      "success_criteria_seed": "placeholder criteria (redacted)",
+      "title": "feat-002-r9"
+     },
+     {
+      "depends_on": [
+       "feat-001-r1",
+       "feat-001-r2",
+       "feat-001-r3",
+       "feat-001-r4",
+       "feat-001-r5",
+       "feat-001-r6",
+       "feat-001-r7",
+       "feat-001-r9",
+       "feat-001-r10",
+       "feat-001-r11"
+      ],
+      "files_likely_touched": [
+       "orchestrator/leerie.py"
+      ],
+      "id": "feat-002-r10",
+      "intent": "",
+      "provides": [
+       "python-venv-clone-delta-implemented",
+       "worktree-venv-isolation-working"
+      ],
+      "requires": [
+       {
+        "extent": "in_plan",
+        "tag": "python-opt-venv-baked"
+       }
+      ],
+      "runs_commands": [],
+      "size": "small",
+      "success_criteria_seed": "placeholder criteria (redacted)",
+      "title": "feat-002-r10"
+     },
+     {
+      "depends_on": [
+       "feat-001-r1",
+       "feat-001-r2",
+       "feat-001-r3",
+       "feat-001-r4",
+       "feat-001-r5",
+       "feat-001-r6",
+       "feat-001-r7",
+       "feat-001-r9",
+       "feat-001-r10",
+       "feat-001-r11"
+      ],
+      "files_likely_touched": [
+       "orchestrator/leerie.py"
+      ],
+      "id": "feat-002-r11",
+      "intent": "",
+      "provides": [
+       "python-venv-clone-delta-implemented",
+       "worktree-venv-isolation-working"
+      ],
+      "requires": [
+       {
+        "extent": "in_plan",
+        "tag": "python-opt-venv-baked"
+       }
+      ],
+      "runs_commands": [],
+      "size": "small",
+      "success_criteria_seed": "placeholder criteria (redacted)",
+      "title": "feat-002-r11"
+     },
+     {
+      "depends_on": [
+       "feat-001-r1",
+       "feat-001-r2",
+       "feat-001-r3",
+       "feat-001-r4",
+       "feat-001-r5",
+       "feat-001-r6",
+       "feat-001-r7",
+       "feat-001-r9",
+       "feat-001-r10",
+       "feat-001-r11"
+      ],
+      "files_likely_touched": [
+       "orchestrator/leerie.py"
+      ],
+      "id": "feat-002-r12",
+      "intent": "",
+      "provides": [
+       "python-venv-clone-delta-implemented",
+       "worktree-venv-isolation-working"
+      ],
+      "requires": [
+       {
+        "extent": "in_plan",
+        "tag": "python-opt-venv-baked"
+       }
+      ],
+      "runs_commands": [],
+      "size": "small",
+      "success_criteria_seed": "placeholder criteria (redacted)",
+      "title": "feat-002-r12"
+     },
+     {
+      "depends_on": [
+       "feat-001-r1",
+       "feat-001-r2",
+       "feat-001-r3",
+       "feat-001-r4",
+       "feat-001-r5",
+       "feat-001-r6",
+       "feat-001-r7",
+       "feat-001-r9",
+       "feat-001-r10",
+       "feat-001-r11"
+      ],
+      "files_likely_touched": [
+       "orchestrator/leerie.py"
+      ],
+      "id": "feat-002-r13",
+      "intent": "",
+      "provides": [
+       "python-venv-clone-delta-implemented",
+       "worktree-venv-isolation-working"
+      ],
+      "requires": [
+       {
+        "extent": "in_plan",
+        "tag": "python-opt-venv-baked"
+       }
+      ],
+      "runs_commands": [],
+      "size": "small",
+      "success_criteria_seed": "placeholder criteria (redacted)",
+      "title": "feat-002-r13"
+     },
+     {
+      "depends_on": [
+       "feat-001-r1",
+       "feat-001-r2",
+       "feat-001-r3",
+       "feat-001-r4",
+       "feat-001-r5",
+       "feat-001-r6",
+       "feat-001-r7",
+       "feat-001-r9",
+       "feat-001-r10",
+       "feat-001-r11"
+      ],
+      "files_likely_touched": [
+       "orchestrator/leerie.py"
+      ],
+      "id": "feat-002-r14",
+      "intent": "",
+      "provides": [
+       "python-venv-clone-delta-implemented",
+       "worktree-venv-isolation-working"
+      ],
+      "requires": [
+       {
+        "extent": "in_plan",
+        "tag": "python-opt-venv-baked"
+       }
+      ],
+      "runs_commands": [],
+      "size": "small",
+      "success_criteria_seed": "placeholder criteria (redacted)",
+      "title": "feat-002-r14"
+     },
+     {
+      "depends_on": [
+       "feat-001-r1",
+       "feat-001-r2",
+       "feat-001-r3",
+       "feat-001-r4",
+       "feat-001-r5",
+       "feat-001-r6",
+       "feat-001-r7",
+       "feat-001-r9",
+       "feat-001-r10",
+       "feat-001-r11"
+      ],
+      "files_likely_touched": [
+       "orchestrator/leerie.py"
+      ],
+      "id": "feat-002-r16",
+      "intent": "",
+      "provides": [
+       "python-venv-clone-delta-implemented",
+       "worktree-venv-isolation-working"
+      ],
+      "requires": [
+       {
+        "extent": "in_plan",
+        "tag": "python-opt-venv-baked"
+       }
+      ],
+      "runs_commands": [],
+      "size": "small",
+      "success_criteria_seed": "placeholder criteria (redacted)",
+      "title": "feat-002-r16"
+     },
+     {
+      "depends_on": [
+       "feat-001-r1",
+       "feat-001-r2",
+       "feat-001-r3",
+       "feat-001-r4",
+       "feat-001-r5",
+       "feat-001-r6",
+       "feat-001-r7",
+       "feat-001-r9",
+       "feat-001-r10",
+       "feat-001-r11"
+      ],
+      "files_likely_touched": [
+       "orchestrator/leerie.py"
+      ],
+      "id": "feat-002-r17",
+      "intent": "",
+      "provides": [
+       "python-venv-clone-delta-implemented",
+       "worktree-venv-isolation-working"
+      ],
+      "requires": [
+       {
+        "extent": "in_plan",
+        "tag": "python-opt-venv-baked"
+       }
+      ],
+      "runs_commands": [],
+      "size": "small",
+      "success_criteria_seed": "placeholder criteria (redacted)",
+      "title": "feat-002-r17"
+     },
+     {
+      "depends_on": [
+       "feat-001-r1",
+       "feat-001-r2",
+       "feat-001-r3",
+       "feat-001-r4",
+       "feat-001-r5",
+       "feat-001-r6",
+       "feat-001-r7",
+       "feat-001-r9",
+       "feat-001-r10",
+       "feat-001-r11"
+      ],
+      "files_likely_touched": [
+       "orchestrator/leerie.py"
+      ],
+      "id": "feat-002-r18",
+      "intent": "",
+      "provides": [
+       "python-venv-clone-delta-implemented",
+       "worktree-venv-isolation-working"
+      ],
+      "requires": [
+       {
+        "extent": "in_plan",
+        "tag": "python-opt-venv-baked"
+       }
+      ],
+      "runs_commands": [],
+      "size": "small",
+      "success_criteria_seed": "placeholder criteria (redacted)",
+      "title": "feat-002-r18"
+     },
+     {
+      "depends_on": [
+       "feat-001-r1",
+       "feat-001-r2",
+       "feat-001-r3",
+       "feat-001-r4",
+       "feat-001-r5",
+       "feat-001-r6",
+       "feat-001-r7",
+       "feat-001-r9",
+       "feat-001-r10",
+       "feat-001-r11"
+      ],
+      "files_likely_touched": [
+       "orchestrator/leerie.py"
+      ],
+      "id": "feat-002-r19",
+      "intent": "",
+      "provides": [
+       "python-venv-clone-delta-implemented",
+       "worktree-venv-isolation-working"
+      ],
+      "requires": [
+       {
+        "extent": "in_plan",
+        "tag": "python-opt-venv-baked"
+       }
+      ],
+      "runs_commands": [],
+      "size": "small",
+      "success_criteria_seed": "placeholder criteria (redacted)",
+      "title": "feat-002-r19"
+     },
+     {
+      "depends_on": [
+       "feat-001-r1",
+       "feat-001-r2",
+       "feat-001-r3",
+       "feat-001-r4",
+       "feat-001-r5",
+       "feat-001-r6",
+       "feat-001-r7",
+       "feat-001-r9",
+       "feat-001-r10",
+       "feat-001-r11"
+      ],
+      "files_likely_touched": [
+       "orchestrator/leerie.py"
+      ],
+      "id": "feat-002-r20",
+      "intent": "",
+      "provides": [
+       "python-venv-clone-delta-implemented",
+       "worktree-venv-isolation-working"
+      ],
+      "requires": [
+       {
+        "extent": "in_plan",
+        "tag": "python-opt-venv-baked"
+       }
+      ],
+      "runs_commands": [],
+      "size": "small",
+      "success_criteria_seed": "placeholder criteria (redacted)",
+      "title": "feat-002-r20"
+     },
+     {
+      "depends_on": [
+       "feat-001-r1",
+       "feat-001-r2",
+       "feat-001-r3",
+       "feat-001-r4",
+       "feat-001-r5",
+       "feat-001-r6",
+       "feat-001-r7",
+       "feat-001-r9",
+       "feat-001-r10",
+       "feat-001-r11"
+      ],
+      "files_likely_touched": [
+       "orchestrator/leerie.py"
+      ],
+      "id": "feat-002-r21",
+      "intent": "",
+      "provides": [
+       "python-venv-clone-delta-implemented",
+       "worktree-venv-isolation-working"
+      ],
+      "requires": [
+       {
+        "extent": "in_plan",
+        "tag": "python-opt-venv-baked"
+       }
+      ],
+      "runs_commands": [],
+      "size": "small",
+      "success_criteria_seed": "placeholder criteria (redacted)",
+      "title": "feat-002-r21"
+     },
+     {
+      "depends_on": [
+       "feat-001-r1",
+       "feat-001-r2",
+       "feat-001-r3",
+       "feat-001-r4",
+       "feat-001-r5",
+       "feat-001-r6",
+       "feat-001-r7",
+       "feat-001-r9",
+       "feat-001-r10",
+       "feat-001-r11"
+      ],
+      "files_likely_touched": [
+       "orchestrator/leerie.py"
+      ],
+      "id": "feat-002-r22",
+      "intent": "",
+      "provides": [
+       "python-venv-clone-delta-implemented",
+       "worktree-venv-isolation-working"
+      ],
+      "requires": [
+       {
+        "extent": "in_plan",
+        "tag": "python-opt-venv-baked"
+       }
+      ],
+      "runs_commands": [],
+      "size": "small",
+      "success_criteria_seed": "placeholder criteria (redacted)",
+      "title": "feat-002-r22"
+     },
+     {
+      "depends_on": [
+       "feat-001-r1",
+       "feat-001-r2",
+       "feat-001-r3",
+       "feat-001-r4",
+       "feat-001-r5",
+       "feat-001-r6",
+       "feat-001-r7",
+       "feat-001-r9",
+       "feat-001-r10",
+       "feat-001-r11"
+      ],
+      "files_likely_touched": [
+       "orchestrator/leerie.py"
+      ],
+      "id": "feat-002-r23",
+      "intent": "",
+      "provides": [
+       "python-venv-clone-delta-implemented",
+       "worktree-venv-isolation-working"
+      ],
+      "requires": [
+       {
+        "extent": "in_plan",
+        "tag": "python-opt-venv-baked"
+       }
+      ],
+      "runs_commands": [],
+      "size": "small",
+      "success_criteria_seed": "placeholder criteria (redacted)",
+      "title": "feat-002-r23"
+     },
+     {
+      "depends_on": [
+       "feat-001-r1",
+       "feat-001-r2",
+       "feat-001-r3",
+       "feat-001-r4",
+       "feat-001-r5",
+       "feat-001-r6",
+       "feat-001-r7",
+       "feat-001-r9",
+       "feat-001-r10",
+       "feat-001-r11"
+      ],
+      "files_likely_touched": [
+       "orchestrator/leerie.py"
+      ],
+      "id": "feat-002-r24",
+      "intent": "",
+      "provides": [
+       "python-venv-clone-delta-implemented",
+       "worktree-venv-isolation-working"
+      ],
+      "requires": [
+       {
+        "extent": "in_plan",
+        "tag": "python-opt-venv-baked"
+       }
+      ],
+      "runs_commands": [],
+      "size": "small",
+      "success_criteria_seed": "placeholder criteria (redacted)",
+      "title": "feat-002-r24"
+     },
+     {
+      "depends_on": [
+       "feat-001-r1",
+       "feat-001-r2",
+       "feat-001-r3",
+       "feat-001-r4",
+       "feat-001-r5",
+       "feat-001-r6",
+       "feat-001-r7",
+       "feat-001-r9",
+       "feat-001-r10",
+       "feat-001-r11"
+      ],
+      "files_likely_touched": [
+       "orchestrator/leerie.py"
+      ],
+      "id": "feat-002-r25",
+      "intent": "",
+      "provides": [
+       "python-venv-clone-delta-implemented",
+       "worktree-venv-isolation-working"
+      ],
+      "requires": [
+       {
+        "extent": "in_plan",
+        "tag": "python-opt-venv-baked"
+       }
+      ],
+      "runs_commands": [],
+      "size": "small",
+      "success_criteria_seed": "placeholder criteria (redacted)",
+      "title": "feat-002-r25"
+     },
+     {
+      "depends_on": [
+       "feat-001-r1",
+       "feat-001-r2",
+       "feat-001-r3",
+       "feat-001-r4",
+       "feat-001-r5",
+       "feat-001-r6",
+       "feat-001-r7",
+       "feat-001-r9",
+       "feat-001-r10",
+       "feat-001-r11"
+      ],
+      "files_likely_touched": [
+       "orchestrator/leerie.py"
+      ],
+      "id": "feat-002-r26",
+      "intent": "",
+      "provides": [
+       "python-venv-clone-delta-implemented",
+       "worktree-venv-isolation-working"
+      ],
+      "requires": [
+       {
+        "extent": "in_plan",
+        "tag": "python-opt-venv-baked"
+       }
+      ],
+      "runs_commands": [],
+      "size": "small",
+      "success_criteria_seed": "placeholder criteria (redacted)",
+      "title": "feat-002-r26"
+     },
+     {
+      "depends_on": [
+       "feat-001-r1",
+       "feat-001-r2",
+       "feat-001-r3",
+       "feat-001-r4",
+       "feat-001-r5",
+       "feat-001-r6",
+       "feat-001-r7",
+       "feat-001-r9",
+       "feat-001-r10",
+       "feat-001-r11"
+      ],
+      "files_likely_touched": [
+       "orchestrator/leerie.py"
+      ],
+      "id": "feat-002-r27",
+      "intent": "",
+      "provides": [
+       "python-venv-clone-delta-implemented",
+       "worktree-venv-isolation-working"
+      ],
+      "requires": [
+       {
+        "extent": "in_plan",
+        "tag": "python-opt-venv-baked"
+       }
+      ],
+      "runs_commands": [],
+      "size": "small",
+      "success_criteria_seed": "placeholder criteria (redacted)",
+      "title": "feat-002-r27"
+     },
+     {
+      "depends_on": [
+       "feat-001-r1",
+       "feat-001-r2",
+       "feat-001-r3",
+       "feat-001-r4",
+       "feat-001-r5",
+       "feat-001-r6",
+       "feat-001-r7",
+       "feat-001-r9",
+       "feat-001-r10",
+       "feat-001-r11"
+      ],
+      "files_likely_touched": [
+       "orchestrator/leerie.py"
+      ],
+      "id": "feat-002-r28",
+      "intent": "",
+      "provides": [
+       "python-venv-clone-delta-implemented",
+       "worktree-venv-isolation-working"
+      ],
+      "requires": [
+       {
+        "extent": "in_plan",
+        "tag": "python-opt-venv-baked"
+       }
+      ],
+      "runs_commands": [],
+      "size": "small",
+      "success_criteria_seed": "placeholder criteria (redacted)",
+      "title": "feat-002-r28"
+     },
+     {
+      "depends_on": [
+       "feat-001-r1",
+       "feat-001-r2",
+       "feat-001-r3",
+       "feat-001-r4",
+       "feat-001-r5",
+       "feat-001-r6",
+       "feat-001-r7",
+       "feat-001-r9",
+       "feat-001-r10",
+       "feat-001-r11"
+      ],
+      "files_likely_touched": [
+       "orchestrator/leerie.py"
+      ],
+      "id": "feat-002-r29",
+      "intent": "",
+      "provides": [
+       "python-venv-clone-delta-implemented",
+       "worktree-venv-isolation-working"
+      ],
+      "requires": [
+       {
+        "extent": "in_plan",
+        "tag": "python-opt-venv-baked"
+       }
+      ],
+      "runs_commands": [],
+      "size": "small",
+      "success_criteria_seed": "placeholder criteria (redacted)",
+      "title": "feat-002-r29"
+     },
+     {
+      "depends_on": [
+       "feat-001-r1",
+       "feat-001-r2",
+       "feat-001-r3",
+       "feat-001-r4",
+       "feat-001-r5",
+       "feat-001-r6",
+       "feat-001-r7",
+       "feat-001-r9",
+       "feat-001-r10",
+       "feat-001-r11"
+      ],
+      "files_likely_touched": [
+       "orchestrator/leerie.py"
+      ],
+      "id": "feat-002-r30",
+      "intent": "",
+      "provides": [
+       "python-venv-clone-delta-implemented",
+       "worktree-venv-isolation-working"
+      ],
+      "requires": [
+       {
+        "extent": "in_plan",
+        "tag": "python-opt-venv-baked"
+       }
+      ],
+      "runs_commands": [],
+      "size": "small",
+      "success_criteria_seed": "placeholder criteria (redacted)",
+      "title": "feat-002-r30"
+     },
+     {
+      "depends_on": [
+       "feat-001-r1",
+       "feat-001-r2",
+       "feat-001-r3",
+       "feat-001-r4",
+       "feat-001-r5",
+       "feat-001-r6",
+       "feat-001-r7",
+       "feat-001-r9",
+       "feat-001-r10",
+       "feat-001-r11"
+      ],
+      "files_likely_touched": [
+       "orchestrator/leerie.py"
+      ],
+      "id": "feat-002-r31",
+      "intent": "",
+      "provides": [
+       "python-venv-clone-delta-implemented",
+       "worktree-venv-isolation-working"
+      ],
+      "requires": [
+       {
+        "extent": "in_plan",
+        "tag": "python-opt-venv-baked"
+       }
+      ],
+      "runs_commands": [],
+      "size": "small",
+      "success_criteria_seed": "placeholder criteria (redacted)",
+      "title": "feat-002-r31"
+     },
+     {
+      "depends_on": [
+       "feat-001-r1",
+       "feat-001-r2",
+       "feat-001-r3",
+       "feat-001-r4",
+       "feat-001-r5",
+       "feat-001-r6",
+       "feat-001-r7",
+       "feat-001-r9",
+       "feat-001-r10",
+       "feat-001-r11"
+      ],
+      "files_likely_touched": [
+       "orchestrator/leerie.py"
+      ],
+      "id": "feat-002-r32",
+      "intent": "",
+      "provides": [
+       "python-venv-clone-delta-implemented",
+       "worktree-venv-isolation-working"
+      ],
+      "requires": [
+       {
+        "extent": "in_plan",
+        "tag": "python-opt-venv-baked"
+       }
+      ],
+      "runs_commands": [],
+      "size": "small",
+      "success_criteria_seed": "placeholder criteria (redacted)",
+      "title": "feat-002-r32"
+     },
+     {
+      "depends_on": [
+       "feat-001-r1",
+       "feat-001-r2",
+       "feat-001-r3",
+       "feat-001-r4",
+       "feat-001-r5",
+       "feat-001-r6",
+       "feat-001-r7",
+       "feat-001-r9",
+       "feat-001-r10",
+       "feat-001-r11"
+      ],
+      "files_likely_touched": [
+       "orchestrator/leerie.py"
+      ],
+      "id": "feat-002-r33",
+      "intent": "",
+      "provides": [
+       "python-venv-clone-delta-implemented",
+       "worktree-venv-isolation-working"
+      ],
+      "requires": [
+       {
+        "extent": "in_plan",
+        "tag": "python-opt-venv-baked"
+       }
+      ],
+      "runs_commands": [],
+      "size": "small",
+      "success_criteria_seed": "placeholder criteria (redacted)",
+      "title": "feat-002-r33"
+     },
+     {
+      "depends_on": [
+       "feat-001-r1",
+       "feat-001-r2",
+       "feat-001-r3",
+       "feat-001-r4",
+       "feat-001-r5",
+       "feat-001-r6",
+       "feat-001-r7",
+       "feat-001-r9",
+       "feat-001-r10",
+       "feat-001-r11"
+      ],
+      "files_likely_touched": [
+       "orchestrator/leerie.py"
+      ],
+      "id": "feat-002-r34",
+      "intent": "",
+      "provides": [
+       "python-venv-clone-delta-implemented",
+       "worktree-venv-isolation-working"
+      ],
+      "requires": [
+       {
+        "extent": "in_plan",
+        "tag": "python-opt-venv-baked"
+       }
+      ],
+      "runs_commands": [],
+      "size": "small",
+      "success_criteria_seed": "placeholder criteria (redacted)",
+      "title": "feat-002-r34"
+     },
+     {
+      "depends_on": [
+       "feat-001-r1",
+       "feat-001-r2",
+       "feat-001-r3",
+       "feat-001-r4",
+       "feat-001-r5",
+       "feat-001-r6",
+       "feat-001-r7",
+       "feat-001-r9",
+       "feat-001-r10",
+       "feat-001-r11"
+      ],
+      "files_likely_touched": [
+       "orchestrator/leerie.py"
+      ],
+      "id": "feat-002-r35",
+      "intent": "",
+      "provides": [
+       "python-venv-clone-delta-implemented",
+       "worktree-venv-isolation-working"
+      ],
+      "requires": [
+       {
+        "extent": "in_plan",
+        "tag": "python-opt-venv-baked"
+       }
+      ],
+      "runs_commands": [],
+      "size": "small",
+      "success_criteria_seed": "placeholder criteria (redacted)",
+      "title": "feat-002-r35"
+     },
+     {
+      "depends_on": [
+       "feat-001-r1",
+       "feat-001-r2",
+       "feat-001-r3",
+       "feat-001-r4",
+       "feat-001-r5",
+       "feat-001-r6",
+       "feat-001-r7",
+       "feat-001-r9",
+       "feat-001-r10",
+       "feat-001-r11"
+      ],
+      "files_likely_touched": [
+       "orchestrator/leerie.py"
+      ],
+      "id": "feat-002-r36",
+      "intent": "",
+      "provides": [
+       "python-venv-clone-delta-implemented",
+       "worktree-venv-isolation-working"
+      ],
+      "requires": [
+       {
+        "extent": "in_plan",
+        "tag": "python-opt-venv-baked"
+       }
+      ],
+      "runs_commands": [],
+      "size": "small",
+      "success_criteria_seed": "placeholder criteria (redacted)",
+      "title": "feat-002-r36"
+     },
+     {
+      "depends_on": [
+       "feat-001-r1",
+       "feat-001-r2",
+       "feat-001-r3",
+       "feat-001-r4",
+       "feat-001-r5",
+       "feat-001-r6",
+       "feat-001-r7",
+       "feat-001-r9",
+       "feat-001-r10",
+       "feat-001-r11"
+      ],
+      "files_likely_touched": [
+       "orchestrator/leerie.py"
+      ],
+      "id": "feat-002-r37",
+      "intent": "",
+      "provides": [
+       "python-venv-clone-delta-implemented",
+       "worktree-venv-isolation-working"
+      ],
+      "requires": [
+       {
+        "extent": "in_plan",
+        "tag": "python-opt-venv-baked"
+       }
+      ],
+      "runs_commands": [],
+      "size": "small",
+      "success_criteria_seed": "placeholder criteria (redacted)",
+      "title": "feat-002-r37"
+     },
+     {
+      "depends_on": [
+       "feat-001-r1",
+       "feat-001-r2",
+       "feat-001-r3",
+       "feat-001-r4",
+       "feat-001-r5",
+       "feat-001-r6",
+       "feat-001-r7",
+       "feat-001-r9",
+       "feat-001-r10",
+       "feat-001-r11"
+      ],
+      "files_likely_touched": [
+       "orchestrator/leerie.py"
+      ],
+      "id": "feat-002-r38-r1",
+      "intent": "",
+      "provides": [
+       "python-venv-clone-delta-implemented",
+       "worktree-venv-isolation-working"
+      ],
+      "requires": [
+       {
+        "extent": "in_plan",
+        "tag": "python-opt-venv-baked"
+       }
+      ],
+      "runs_commands": [],
+      "size": "small",
+      "success_criteria_seed": "placeholder criteria (redacted)",
+      "title": "feat-002-r38-r1"
+     },
+     {
+      "depends_on": [
+       "feat-001-r1",
+       "feat-001-r2",
+       "feat-001-r3",
+       "feat-001-r4",
+       "feat-001-r5",
+       "feat-001-r6",
+       "feat-001-r7",
+       "feat-001-r9",
+       "feat-001-r10",
+       "feat-001-r11"
+      ],
+      "files_likely_touched": [
+       "orchestrator/leerie.py"
+      ],
+      "id": "feat-002-r38-r2",
+      "intent": "",
+      "provides": [
+       "python-venv-clone-delta-implemented",
+       "worktree-venv-isolation-working"
+      ],
+      "requires": [
+       {
+        "extent": "in_plan",
+        "tag": "python-opt-venv-baked"
+       }
+      ],
+      "runs_commands": [],
+      "size": "small",
+      "success_criteria_seed": "placeholder criteria (redacted)",
+      "title": "feat-002-r38-r2"
+     }
+    ]
+   },
+   {
+    "domain": "bug-fixing",
+    "status": "ready",
+    "subtasks": [
+     {
+      "depends_on": [],
+      "files_likely_touched": [
+       "leerie"
+      ],
+      "id": "bugfix-001",
+      "intent": "",
+      "provides": [
+       "dockerfile-generation-gates-broadened"
+      ],
+      "requires": [],
+      "runs_commands": [],
+      "size": "small",
+      "success_criteria_seed": "placeholder criteria (redacted)",
+      "title": "bugfix-001"
+     }
+    ]
+   },
+   {
+    "domain": "testing",
+    "status": "ready",
+    "subtasks": [
+     {
+      "depends_on": [],
+      "files_likely_touched": [
+       "tests/test_build_repo_image.py"
+      ],
+      "id": "test-001",
+      "intent": "",
+      "provides": [
+       "dockerfile-emitter-unit-tests"
+      ],
+      "requires": [
+       {
+        "extent": "in_plan",
+        "reason": "",
+        "tag": "dockerfile-generates-opt-paths"
+       },
+       {
+        "extent": "in_plan",
+        "reason": "",
+        "tag": "dockerfile-generation-gates-broadened"
+       }
+      ],
+      "runs_commands": [],
+      "size": "small",
+      "success_criteria_seed": "placeholder criteria (redacted)",
+      "title": "test-001"
+     },
+     {
+      "depends_on": [],
+      "files_likely_touched": [
+       "tests/test_provision_bake.py"
+      ],
+      "id": "test-002",
+      "intent": "",
+      "provides": [
+       "provision-bake-integration-test"
+      ],
+      "requires": [
+       {
+        "extent": "in_plan",
+        "reason": "",
+        "tag": "dockerfile-generates-opt-paths"
+       },
+       {
+        "extent": "in_plan",
+        "reason": "",
+        "tag": "python-venv-clone-delta-implemented"
+       },
+       {
+        "extent": "in_plan",
+        "reason": "",
+        "tag": "dockerfile-generation-gates-broadened"
+       }
+      ],
+      "runs_commands": [],
+      "size": "small",
+      "success_criteria_seed": "placeholder criteria (redacted)",
+      "title": "test-002"
+     }
+    ]
+   }
+  ],
+  "wiring_defects": [
+   {
+    "concrete_reason": "redacted \u2014 only presence is asserted",
+    "kind": "missing_requires",
+    "severity": null,
+    "sid": "test-002",
+    "tag_or_dep": "bugfix-001"
+   },
+   {
+    "concrete_reason": "redacted \u2014 only presence is asserted",
+    "kind": "missing_requires",
+    "severity": null,
+    "sid": "test-001",
+    "tag_or_dep": "bugfix-001"
+   },
+   {
+    "concrete_reason": "redacted \u2014 only presence is asserted",
+    "kind": "missing_requires",
+    "severity": null,
+    "sid": "test-002",
+    "tag_or_dep": "feat-001-r1"
+   },
+   {
+    "concrete_reason": "redacted \u2014 only presence is asserted",
+    "kind": "missing_requires",
+    "severity": null,
+    "sid": "test-002",
+    "tag_or_dep": "feat-001-r2"
+   },
+   {
+    "concrete_reason": "redacted \u2014 only presence is asserted",
+    "kind": "missing_requires",
+    "severity": null,
+    "sid": "test-002",
+    "tag_or_dep": "feat-001-r3"
+   },
+   {
+    "concrete_reason": "redacted \u2014 only presence is asserted",
+    "kind": "missing_requires",
+    "severity": null,
+    "sid": "test-002",
+    "tag_or_dep": "feat-001-r4"
+   },
+   {
+    "concrete_reason": "redacted \u2014 only presence is asserted",
+    "kind": "missing_requires",
+    "severity": null,
+    "sid": "test-002",
+    "tag_or_dep": "feat-001-r5"
+   },
+   {
+    "concrete_reason": "redacted \u2014 only presence is asserted",
+    "kind": "missing_requires",
+    "severity": null,
+    "sid": "test-002",
+    "tag_or_dep": "feat-001-r6"
+   },
+   {
+    "concrete_reason": "redacted \u2014 only presence is asserted",
+    "kind": "missing_requires",
+    "severity": null,
+    "sid": "test-002",
+    "tag_or_dep": "feat-001-r7"
+   },
+   {
+    "concrete_reason": "redacted \u2014 only presence is asserted",
+    "kind": "missing_requires",
+    "severity": null,
+    "sid": "test-002",
+    "tag_or_dep": "feat-001-r9"
+   },
+   {
+    "concrete_reason": "redacted \u2014 only presence is asserted",
+    "kind": "missing_requires",
+    "severity": null,
+    "sid": "test-002",
+    "tag_or_dep": "feat-001-r10"
+   },
+   {
+    "concrete_reason": "redacted \u2014 only presence is asserted",
+    "kind": "missing_requires",
+    "severity": null,
+    "sid": "test-002",
+    "tag_or_dep": "feat-001-r11"
+   },
+   {
+    "concrete_reason": "redacted \u2014 only presence is asserted",
+    "kind": "missing_requires",
+    "severity": null,
+    "sid": "test-001",
+    "tag_or_dep": "feat-001-r1"
+   },
+   {
+    "concrete_reason": "redacted \u2014 only presence is asserted",
+    "kind": "missing_requires",
+    "severity": null,
+    "sid": "test-001",
+    "tag_or_dep": "feat-001-r2"
+   },
+   {
+    "concrete_reason": "redacted \u2014 only presence is asserted",
+    "kind": "missing_requires",
+    "severity": null,
+    "sid": "test-001",
+    "tag_or_dep": "feat-001-r3"
+   },
+   {
+    "concrete_reason": "redacted \u2014 only presence is asserted",
+    "kind": "missing_requires",
+    "severity": null,
+    "sid": "test-001",
+    "tag_or_dep": "feat-001-r4"
+   },
+   {
+    "concrete_reason": "redacted \u2014 only presence is asserted",
+    "kind": "missing_requires",
+    "severity": null,
+    "sid": "test-001",
+    "tag_or_dep": "feat-001-r5"
+   },
+   {
+    "concrete_reason": "redacted \u2014 only presence is asserted",
+    "kind": "missing_requires",
+    "severity": null,
+    "sid": "test-001",
+    "tag_or_dep": "feat-001-r6"
+   },
+   {
+    "concrete_reason": "redacted \u2014 only presence is asserted",
+    "kind": "missing_requires",
+    "severity": null,
+    "sid": "test-001",
+    "tag_or_dep": "feat-001-r7"
+   },
+   {
+    "concrete_reason": "redacted \u2014 only presence is asserted",
+    "kind": "missing_requires",
+    "severity": null,
+    "sid": "test-001",
+    "tag_or_dep": "feat-001-r9"
+   },
+   {
+    "concrete_reason": "redacted \u2014 only presence is asserted",
+    "kind": "missing_requires",
+    "severity": null,
+    "sid": "test-001",
+    "tag_or_dep": "feat-001-r10"
+   },
+   {
+    "concrete_reason": "redacted \u2014 only presence is asserted",
+    "kind": "missing_requires",
+    "severity": null,
+    "sid": "test-001",
+    "tag_or_dep": "feat-001-r11"
+   }
+  ]
+ },
+ "ad69057f": {
+  "plans": [
+   {
+    "domain": "feature-implementation",
+    "status": "ready",
+    "subtasks": [
+     {
+      "depends_on": [],
+      "files_likely_touched": [
+       "leerie"
+      ],
+      "id": "feat-001",
+      "intent": "",
+      "provides": [
+       "python-venv-baked"
+      ],
+      "requires": [],
+      "runs_commands": [],
+      "size": "small",
+      "success_criteria_seed": "placeholder criteria (redacted)",
+      "title": "feat-001"
+     },
+     {
+      "depends_on": [
+       "feat-001"
+      ],
+      "files_likely_touched": [
+       "scripts/new-worktree.sh"
+      ],
+      "id": "feat-002",
+      "intent": "",
+      "provides": [
+       "python-venv-isolation"
+      ],
+      "requires": [
+       {
+        "extent": "in_plan",
+        "tag": "python-venv-baked"
+       }
+      ],
+      "runs_commands": [],
+      "size": "small",
+      "success_criteria_seed": "placeholder criteria (redacted)",
+      "title": "feat-002"
+     },
+     {
+      "depends_on": [],
+      "files_likely_touched": [
+       "leerie"
+      ],
+      "id": "feat-003",
+      "intent": "",
+      "provides": [
+       "ruby-bundle-baked"
+      ],
+      "requires": [],
+      "runs_commands": [],
+      "size": "small",
+      "success_criteria_seed": "placeholder criteria (redacted)",
+      "title": "feat-003"
+     },
+     {
+      "depends_on": [
+       "feat-003"
+      ],
+      "files_likely_touched": [
+       "scripts/new-worktree.sh"
+      ],
+      "id": "feat-004",
+      "intent": "",
+      "provides": [
+       "ruby-bundle-isolation"
+      ],
+      "requires": [
+       {
+        "extent": "in_plan",
+        "tag": "ruby-bundle-baked"
+       }
+      ],
+      "runs_commands": [],
+      "size": "small",
+      "success_criteria_seed": "placeholder criteria (redacted)",
+      "title": "feat-004"
+     },
+     {
+      "depends_on": [],
+      "files_likely_touched": [
+       "leerie"
+      ],
+      "id": "feat-005-r1",
+      "intent": "",
+      "provides": [
+       "node-pnpm-baked",
+       "rust-cargo-baked",
+       "go-cache-baked"
+      ],
+      "requires": [],
+      "runs_commands": [],
+      "size": "small",
+      "success_criteria_seed": "placeholder criteria (redacted)",
+      "title": "feat-005-r1"
+     },
+     {
+      "depends_on": [],
+      "files_likely_touched": [
+       "leerie"
+      ],
+      "id": "feat-005-r2",
+      "intent": "",
+      "provides": [
+       "node-pnpm-baked",
+       "rust-cargo-baked",
+       "go-cache-baked"
+      ],
+      "requires": [],
+      "runs_commands": [],
+      "size": "small",
+      "success_criteria_seed": "placeholder criteria (redacted)",
+      "title": "feat-005-r2"
+     },
+     {
+      "depends_on": [],
+      "files_likely_touched": [
+       "leerie"
+      ],
+      "id": "feat-005-r3",
+      "intent": "",
+      "provides": [
+       "node-pnpm-baked",
+       "rust-cargo-baked",
+       "go-cache-baked"
+      ],
+      "requires": [],
+      "runs_commands": [],
+      "size": "small",
+      "success_criteria_seed": "placeholder criteria (redacted)",
+      "title": "feat-005-r3"
+     },
+     {
+      "depends_on": [],
+      "files_likely_touched": [
+       "leerie"
+      ],
+      "id": "feat-005-r4",
+      "intent": "",
+      "provides": [
+       "node-pnpm-baked",
+       "rust-cargo-baked",
+       "go-cache-baked"
+      ],
+      "requires": [],
+      "runs_commands": [],
+      "size": "small",
+      "success_criteria_seed": "placeholder criteria (redacted)",
+      "title": "feat-005-r4"
+     },
+     {
+      "depends_on": [],
+      "files_likely_touched": [
+       "leerie"
+      ],
+      "id": "feat-005-r5",
+      "intent": "",
+      "provides": [
+       "node-pnpm-baked",
+       "rust-cargo-baked",
+       "go-cache-baked"
+      ],
+      "requires": [],
+      "runs_commands": [],
+      "size": "small",
+      "success_criteria_seed": "placeholder criteria (redacted)",
+      "title": "feat-005-r5"
+     },
+     {
+      "depends_on": [],
+      "files_likely_touched": [
+       "leerie"
+      ],
+      "id": "feat-005-r6",
+      "intent": "",
+      "provides": [
+       "node-pnpm-baked",
+       "rust-cargo-baked",
+       "go-cache-baked"
+      ],
+      "requires": [],
+      "runs_commands": [],
+      "size": "small",
+      "success_criteria_seed": "placeholder criteria (redacted)",
+      "title": "feat-005-r6"
+     },
+     {
+      "depends_on": [],
+      "files_likely_touched": [
+       "leerie"
+      ],
+      "id": "feat-005-r7",
+      "intent": "",
+      "provides": [
+       "node-pnpm-baked",
+       "rust-cargo-baked",
+       "go-cache-baked"
+      ],
+      "requires": [],
+      "runs_commands": [],
+      "size": "small",
+      "success_criteria_seed": "placeholder criteria (redacted)",
+      "title": "feat-005-r7"
+     },
+     {
+      "depends_on": [],
+      "files_likely_touched": [
+       "leerie"
+      ],
+      "id": "feat-005-r8",
+      "intent": "",
+      "provides": [
+       "node-pnpm-baked",
+       "rust-cargo-baked",
+       "go-cache-baked"
+      ],
+      "requires": [],
+      "runs_commands": [],
+      "size": "small",
+      "success_criteria_seed": "placeholder criteria (redacted)",
+      "title": "feat-005-r8"
+     },
+     {
+      "depends_on": [],
+      "files_likely_touched": [
+       "leerie"
+      ],
+      "id": "feat-005-r9",
+      "intent": "",
+      "provides": [
+       "node-pnpm-baked",
+       "rust-cargo-baked",
+       "go-cache-baked"
+      ],
+      "requires": [],
+      "runs_commands": [],
+      "size": "small",
+      "success_criteria_seed": "placeholder criteria (redacted)",
+      "title": "feat-005-r9"
+     },
+     {
+      "depends_on": [],
+      "files_likely_touched": [
+       "leerie"
+      ],
+      "id": "feat-005-r10",
+      "intent": "",
+      "provides": [
+       "node-pnpm-baked",
+       "rust-cargo-baked",
+       "go-cache-baked"
+      ],
+      "requires": [],
+      "runs_commands": [],
+      "size": "small",
+      "success_criteria_seed": "placeholder criteria (redacted)",
+      "title": "feat-005-r10"
+     },
+     {
+      "depends_on": [],
+      "files_likely_touched": [
+       "leerie"
+      ],
+      "id": "feat-005-r11",
+      "intent": "",
+      "provides": [
+       "node-pnpm-baked",
+       "rust-cargo-baked",
+       "go-cache-baked"
+      ],
+      "requires": [],
+      "runs_commands": [],
+      "size": "small",
+      "success_criteria_seed": "placeholder criteria (redacted)",
+      "title": "feat-005-r11"
+     }
+    ]
+   },
+   {
+    "domain": "bug-fixing",
+    "status": "ready",
+    "subtasks": [
+     {
+      "depends_on": [],
+      "files_likely_touched": [
+       "leerie"
+      ],
+      "id": "bugfix-001",
+      "intent": "",
+      "provides": [
+       "dockerfile-gate-fix"
+      ],
+      "requires": [],
+      "runs_commands": [],
+      "size": "small",
+      "success_criteria_seed": "placeholder criteria (redacted)",
+      "title": "bugfix-001"
+     },
+     {
+      "depends_on": [
+       "bugfix-001"
+      ],
+      "files_likely_touched": [
+       "tests/test_build_repo_image.py"
+      ],
+      "id": "bugfix-002",
+      "intent": "",
+      "provides": [
+       "dockerfile-gate-test"
+      ],
+      "requires": [
+       {
+        "extent": "in_plan",
+        "tag": "dockerfile-gate-fix"
+       }
+      ],
+      "runs_commands": [],
+      "size": "small",
+      "success_criteria_seed": "placeholder criteria (redacted)",
+      "title": "bugfix-002"
+     }
+    ]
+   },
+   {
+    "domain": "testing",
+    "status": "ready",
+    "subtasks": [
+     {
+      "depends_on": [],
+      "files_likely_touched": [
+       "tests/test_build_repo_image.py"
+      ],
+      "id": "test-001",
+      "intent": "",
+      "provides": [
+       "dockerfile-emitter-unit-tests"
+      ],
+      "requires": [],
+      "runs_commands": [],
+      "size": "small",
+      "success_criteria_seed": "placeholder criteria (redacted)",
+      "title": "test-001"
+     },
+     {
+      "depends_on": [],
+      "files_likely_touched": [
+       "tests/test_out_of_repo_bake.py"
+      ],
+      "id": "test-002",
+      "intent": "",
+      "provides": [
+       "bake-integration-test"
+      ],
+      "requires": [
+       {
+        "extent": "in_plan",
+        "reason": "The test must build an image with the /opt/venv bake actually present, which requires feat-001's Dockerfile emitter changes to have landed.",
+        "tag": "python-venv-baked"
+       }
+      ],
+      "runs_commands": [],
+      "size": "small",
+      "success_criteria_seed": "placeholder criteria (redacted)",
+      "title": "test-002"
+     },
+     {
+      "depends_on": [],
+      "files_likely_touched": [
+       "tests/test_provision_recipe_bake_filter.py"
+      ],
+      "id": "test-003",
+      "intent": "",
+      "provides": [
+       "recipe-filter-correctness-verified"
+      ],
+      "requires": [
+       {
+        "extent": "in_plan",
+        "reason": "The test fixture must have a real /opt/venv bake to verify the filter's assumption is now true.",
+        "tag": "python-venv-baked"
+       },
+       {
+        "extent": "in_plan",
+        "reason": "test-002 proves the bake itself works; this test verifies the recipe filter correctly assumes it. Sequencing: bake correctness before filter correctness.",
+        "tag": "bake-integration-test"
+       }
+      ],
+      "runs_commands": [],
+      "size": "small",
+      "success_criteria_seed": "placeholder criteria (redacted)",
+      "title": "test-003"
+     },
+     {
+      "depends_on": [],
+      "files_likely_touched": [
+       "tests/test_python_venv_isolation.py"
+      ],
+      "id": "test-004",
+      "intent": "",
+      "provides": [
+       "python-venv-isolation-verified"
+      ],
+      "requires": [
+       {
+        "extent": "in_plan",
+        "reason": "The test exercises the worktree-level clone+delta mechanism that feat-002 implements in new-worktree.sh.",
+        "tag": "python-venv-isolation"
+       }
+      ],
+      "runs_commands": [],
+      "size": "small",
+      "success_criteria_seed": "placeholder criteria (redacted)",
+      "title": "test-004"
+     },
+     {
+      "depends_on": [],
+      "files_likely_touched": [
+       "tests/test_ruby_bundle_isolation.py"
+      ],
+      "id": "test-005",
+      "intent": "",
+      "provides": [
+       "ruby-bundle-isolation-verified"
+      ],
+      "requires": [
+       {
+        "extent": "in_plan",
+        "reason": "The test exercises the worktree-level Ruby bundle clone+delta mechanism that feat-005 (the Ruby equivalent of feat-002) implements.",
+        "tag": "ruby-bundle-isolation"
+       }
+      ],
+      "runs_commands": [],
+      "size": "small",
+      "success_criteria_seed": "placeholder criteria (redacted)",
+      "title": "test-005"
+     }
+    ]
+   }
+  ],
+  "wiring_defects": [
+   {
+    "concrete_reason": "redacted \u2014 only presence is asserted",
+    "kind": "missing_requires",
+    "severity": "live_defect",
+    "sid": "feat-002",
+    "tag_or_dep": "dockerfile-gate-fix"
+   },
+   {
+    "concrete_reason": "redacted \u2014 only presence is asserted",
+    "kind": "missing_requires",
+    "severity": "live_defect",
+    "sid": "feat-004",
+    "tag_or_dep": "dockerfile-gate-fix"
+   },
+   {
+    "concrete_reason": "redacted \u2014 only presence is asserted",
+    "kind": "missing_requires",
+    "severity": "live_defect",
+    "sid": "test-002",
+    "tag_or_dep": "dockerfile-gate-fix"
+   },
+   {
+    "concrete_reason": "redacted \u2014 only presence is asserted",
+    "kind": "missing_requires",
+    "severity": "live_defect",
+    "sid": "test-003",
+    "tag_or_dep": "dockerfile-gate-fix"
+   },
+   {
+    "concrete_reason": "redacted \u2014 only presence is asserted",
+    "kind": "missing_requires",
+    "severity": "live_defect",
+    "sid": "bugfix-002",
+    "tag_or_dep": "python-venv-baked"
+   },
+   {
+    "concrete_reason": "redacted \u2014 only presence is asserted",
+    "kind": "missing_requires",
+    "severity": "live_defect",
+    "sid": "test-001",
+    "tag_or_dep": "python-venv-baked"
+   },
+   {
+    "concrete_reason": "redacted \u2014 only presence is asserted",
+    "kind": "missing_requires",
+    "severity": "live_defect",
+    "sid": "test-001",
+    "tag_or_dep": "ruby-bundle-baked"
+   },
+   {
+    "concrete_reason": "redacted \u2014 only presence is asserted",
+    "kind": "missing_requires",
+    "severity": "live_defect",
+    "sid": "test-001",
+    "tag_or_dep": "node-pnpm-baked"
+   },
+   {
+    "concrete_reason": "redacted \u2014 only presence is asserted",
+    "kind": "missing_requires",
+    "severity": "live_defect",
+    "sid": "test-001",
+    "tag_or_dep": "rust-cargo-baked"
+   },
+   {
+    "concrete_reason": "redacted \u2014 only presence is asserted",
+    "kind": "missing_requires",
+    "severity": "live_defect",
+    "sid": "test-001",
+    "tag_or_dep": "go-cache-baked"
+   },
+   {
+    "concrete_reason": "redacted \u2014 only presence is asserted",
+    "kind": "missing_requires",
+    "severity": "live_defect",
+    "sid": "test-001",
+    "tag_or_dep": "dockerfile-gate-fix"
+   }
+  ]
+ },
+ "eed1153d": {
+  "plans": [
+   {
+    "domain": "bug-fixing",
+    "status": "ready",
+    "subtasks": [
+     {
+      "depends_on": [],
+      "files_likely_touched": [
+       "scripts/remote/collect-subtrees.sh"
+      ],
+      "id": "bugfix-001",
+      "intent": "",
+      "provides": [
+       "integrator-schema-drift-fixed"
+      ],
+      "requires": [],
+      "runs_commands": [],
+      "size": "small",
+      "success_criteria_seed": "placeholder criteria (redacted)",
+      "title": "bugfix-001"
+     },
+     {
+      "depends_on": [],
+      "files_likely_touched": [
+       "orchestrator/leerie.py"
+      ],
+      "id": "bugfix-002",
+      "intent": "",
+      "provides": [
+       "size-field-enum-enforced"
+      ],
+      "requires": [],
+      "runs_commands": [],
+      "size": "small",
+      "success_criteria_seed": "placeholder criteria (redacted)",
+      "title": "bugfix-002"
+     },
+     {
+      "depends_on": [
+       "bugfix-002"
+      ],
+      "files_likely_touched": [
+       "docs/IMPLEMENTATION.md"
+      ],
+      "id": "bugfix-003",
+      "intent": "",
+      "provides": [
+       "size-field-docs-corrected",
+       "size-enum-doc-updated"
+      ],
+      "requires": [
+       {
+        "extent": "in_plan",
+        "tag": "size-field-enum-enforced"
+       }
+      ],
+      "runs_commands": [],
+      "size": "small",
+      "success_criteria_seed": "placeholder criteria (redacted)",
+      "title": "bugfix-003"
+     }
+    ]
+   },
+   {
+    "domain": "testing",
+    "status": "ready",
+    "subtasks": [
+     {
+      "depends_on": [],
+      "files_likely_touched": [
+       "tests/test_size_enum_schema.py"
+      ],
+      "id": "test-001",
+      "intent": "",
+      "provides": [
+       "size-enum-schema-tested"
+      ],
+      "requires": [],
+      "runs_commands": [],
+      "size": "small",
+      "success_criteria_seed": "placeholder criteria (redacted)",
+      "title": "test-001"
+     },
+     {
+      "depends_on": [],
+      "files_likely_touched": [
+       "tests/test_reconciler_size_gate.py"
+      ],
+      "id": "test-002",
+      "intent": "",
+      "provides": [
+       "size-gate-exact-match-tested"
+      ],
+      "requires": [],
+      "runs_commands": [],
+      "size": "small",
+      "success_criteria_seed": "placeholder criteria (redacted)",
+      "title": "test-002"
+     },
+     {
+      "depends_on": [],
+      "files_likely_touched": [
+       "tests/test_check_functions.py"
+      ],
+      "id": "test-003",
+      "intent": "",
+      "provides": [
+       "oversized-gates-exact-match-tested"
+      ],
+      "requires": [
+       {
+        "extent": "in_plan",
+        "tag": "size-enum-schema-tested"
+       }
+      ],
+      "runs_commands": [],
+      "size": "small",
+      "success_criteria_seed": "placeholder criteria (redacted)",
+      "title": "test-003"
+     },
+     {
+      "depends_on": [],
+      "files_likely_touched": [
+       "tests/test_collect_subtrees_integrator_schema.py"
+      ],
+      "id": "test-004",
+      "intent": "",
+      "provides": [
+       "integrator-schema-sync-tested"
+      ],
+      "requires": [],
+      "runs_commands": [],
+      "size": "small",
+      "success_criteria_seed": "placeholder criteria (redacted)",
+      "title": "test-004"
+     },
+     {
+      "depends_on": [
+       "test-001",
+       "test-002",
+       "test-003",
+       "test-004"
+      ],
+      "files_likely_touched": [],
+      "id": "test-005",
+      "intent": "",
+      "provides": [
+       "prescribed-verification-run-clean"
+      ],
+      "requires": [
+       {
+        "extent": "in_plan",
+        "tag": "size-enum-schema-tested"
+       },
+       {
+        "extent": "in_plan",
+        "tag": "size-gate-exact-match-tested"
+       },
+       {
+        "extent": "in_plan",
+        "tag": "oversized-gates-exact-match-tested"
+       },
+       {
+        "extent": "in_plan",
+        "tag": "integrator-schema-sync-tested"
+       },
+       {
+        "extent": "external",
+        "reason": "The actual `\"size\": {\"type\": \"string\", \"enum\": [...]}\"` edits to orchestrator/leerie.py:1177,1277,1940 and the simplified `==` comparisons at :6433,:7551,:14925 are made by the bug-fixing/refactoring domain's subtasks, not this testing plan; this subtask only runs verification against the composed result.",
+        "tag": "size-enum-added-to-schemas"
+       }
+      ],
+      "runs_commands": [],
+      "size": "small",
+      "success_criteria_seed": "placeholder criteria (redacted)",
+      "title": "test-005"
+     }
+    ]
+   },
+   {
+    "domain": "documentation",
+    "status": "ready",
+    "subtasks": []
+   }
+  ],
+  "wiring_defects": [
+   {
+    "concrete_reason": "redacted \u2014 only presence is asserted",
+    "kind": "missing_requires",
+    "severity": null,
+    "sid": "test-001",
+    "tag_or_dep": "size-field-enum-enforced"
+   },
+   {
+    "concrete_reason": "redacted \u2014 only presence is asserted",
+    "kind": "missing_requires",
+    "severity": null,
+    "sid": "test-002",
+    "tag_or_dep": "size-field-enum-enforced"
+   },
+   {
+    "concrete_reason": "redacted \u2014 only presence is asserted",
+    "kind": "missing_requires",
+    "severity": null,
+    "sid": "test-003",
+    "tag_or_dep": "size-field-enum-enforced"
+   },
+   {
+    "concrete_reason": "redacted \u2014 only presence is asserted",
+    "kind": "missing_requires",
+    "severity": null,
+    "sid": "test-004",
+    "tag_or_dep": "integrator-schema-drift-fixed"
+   },
+   {
+    "concrete_reason": "redacted \u2014 only presence is asserted",
+    "kind": "missing_requires",
+    "severity": null,
+    "sid": "test-005",
+    "tag_or_dep": "size-field-enum-enforced / integrator-schema-drift-fixed"
+   }
+  ]
+ }
+}

--- a/tests/test_wiring_repair_corpus.py
+++ b/tests/test_wiring_repair_corpus.py
@@ -1,0 +1,139 @@
+"""Corpus regression lock for the wiring-gate auto-repair (DESIGN §5).
+
+`tests/test_wiring_gate_repair.py` pins the repair's *rules* against synthetic
+plans — one shape per rule. This file pins its *measured effect* against every
+run in the corpus that ever died at the wiring gate, so the numbers quoted in
+DESIGN/IMPLEMENTATION and in the PR that shipped the feature stay reproducible
+after this session's scratchpad is gone.
+
+Why it matters: the justification for repairing at all is "3 of the 6 historical
+deaths proceed, and the other 3 are refused for principled reasons." That claim
+drove a DESIGN contract change (detect-and-die → detect-repair-then-die). If a
+future edit to `_repair_missing_requires` quietly widens or narrows what it
+accepts, the per-rule tests may all still pass while this ratio moves — which is
+the signal that the trade-off underneath the feature has changed.
+
+The fixture is the real recorded `wiring_judge` output and the real post-filter
+plans from six runs, reduced to the fields the repair actually reads
+(`id`/`provides`/`requires`/`depends_on`/`files_likely_touched`, and each
+defect's `kind`/`sid`/`tag_or_dep`/`severity`). Every `concrete_reason` is
+redacted to a constant — the repair never reads it, only its non-emptiness
+gates, so the fixture asserts presence without carrying prose from real runs.
+"""
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+
+import pytest
+
+_FIXTURE = (Path(__file__).resolve().parent
+            / "fixtures" / "wiring_repair_corpus" / "corpus.json")
+
+# run -> (live defects, repairable defects). Measured 2026-08-01 against the
+# shipped `_repair_missing_requires`. The three that repair fully are the
+# feature's whole justification; the three that do not are refused for reasons
+# the rule is deliberately built to respect (see the per-run comments).
+EXPECTED = {
+    "29a6bf8e": (1, 1),    # fully repairable -> run proceeds
+    "3a4abba3": (2, 2),    # fully repairable -> run proceeds
+    "6146bd2f": (4, 4),    # fully repairable -> run proceeds
+    "eed1153d": (5, 4),    # 1 tag has NO in-plan provider
+    "ad69057f": (11, 8),   # 3 tags have several providers (ambiguous)
+    "62a19deb": (22, 0),   # every tag has NO provider — correctly refused
+}
+
+
+def _corpus() -> dict:
+    return json.loads(_FIXTURE.read_text())
+
+
+def test_fixture_covers_every_expected_run():
+    """Guard the guard: a fixture that silently lost runs would make every
+    per-run assertion below vacuous."""
+    assert set(_corpus()) == set(EXPECTED)
+
+
+@pytest.mark.parametrize("run", sorted(EXPECTED))
+def test_repair_counts_match_the_measured_corpus(leerie, run):
+    data = _corpus()[run]
+    plans = copy.deepcopy(data["plans"])
+    live = leerie._live_wiring_defects(
+        {"wiring_defects": data["wiring_defects"]})
+    repairs, unrepaired = leerie._repair_missing_requires(plans, live)
+
+    exp_live, exp_rep = EXPECTED[run]
+    assert len(live) == exp_live, (
+        f"{run}: live-defect count drifted — the gating filter changed")
+    assert len(repairs) == exp_rep, (
+        f"{run}: repaired {len(repairs)} of {len(live)}, expected {exp_rep}. "
+        "The repair rule's acceptance criteria have moved; confirm that is "
+        "intended before updating this number")
+    assert len(repairs) + len(unrepaired) <= len(live)
+
+
+@pytest.mark.parametrize("run", ["29a6bf8e", "3a4abba3", "6146bd2f"])
+def test_fully_repaired_runs_schedule_with_producers_first(leerie, run):
+    """The three runs the feature exists for: after repair the plan schedules,
+    and every added edge actually orders the consumer behind its producer."""
+    data = _corpus()[run]
+    plans = copy.deepcopy(data["plans"])
+    live = leerie._live_wiring_defects(
+        {"wiring_defects": data["wiring_defects"]})
+    repairs, unrepaired = leerie._repair_missing_requires(plans, live)
+    assert not unrepaired, f"{run} is expected to repair fully"
+
+    subtasks, waves = leerie.schedule(copy.deepcopy(plans))
+    pos = {sid: i for i, w in enumerate(waves) for sid in w}
+    for r in repairs:
+        assert pos[r["provider"]] < pos[r["sid"]], (
+            f"{run}: {r['sid']} must be scheduled after {r['provider']}, "
+            f"the sole provider of {r['tag']!r}")
+    assert not leerie.check_plan_wiring(subtasks)
+    leerie.validate_plan(subtasks)
+
+
+def test_unrepairable_runs_are_refused_for_principled_reasons(leerie):
+    """The three that still die must fail the rule for the documented
+    reasons — no provider, or several — not because the repair silently
+    stopped working."""
+    reasons = {}
+    for run in ("eed1153d", "ad69057f", "62a19deb"):
+        data = _corpus()[run]
+        plans = copy.deepcopy(data["plans"])
+        by_id = {s["id"]: s for p in plans for s in p.get("subtasks", [])}
+        providers: dict[str, list[str]] = {}
+        for sid, s in by_id.items():
+            for tag in s.get("provides") or []:
+                providers.setdefault(tag, []).append(sid)
+        live = leerie._live_wiring_defects(
+            {"wiring_defects": data["wiring_defects"]})
+        _repairs, unrepaired = leerie._repair_missing_requires(plans, live)
+        for d in unrepaired:
+            n = len(providers.get((d.get("tag_or_dep") or "").strip(), []))
+            reasons.setdefault(run, set()).add(
+                "no_provider" if n == 0 else
+                "several_providers" if n > 1 else "other")
+    assert reasons["62a19deb"] == {"no_provider"}
+    assert reasons["eed1153d"] == {"no_provider"}
+    assert reasons["ad69057f"] == {"several_providers"}
+    assert "other" not in set().union(*reasons.values()), (
+        "an unrepaired defect fell through for a reason the rule does not "
+        "document — investigate before accepting")
+
+
+def test_headline_ratio_is_three_of_six(leerie):
+    """The number DESIGN, IMPLEMENTATION and PR #145 all quote."""
+    full = 0
+    for run, data in _corpus().items():
+        plans = copy.deepcopy(data["plans"])
+        live = leerie._live_wiring_defects(
+            {"wiring_defects": data["wiring_defects"]})
+        _r, unrepaired = leerie._repair_missing_requires(plans, live)
+        if live and not unrepaired:
+            full += 1
+    assert full == 3, (
+        f"{full}/6 runs now repair fully, not 3/6. The documented trade-off "
+        "behind detect-repair-then-die has moved; update DESIGN §5 and "
+        "IMPLEMENTATION if that is intended")


### PR DESCRIPTION
## Summary

Four loose ends from the #144 / #145 / #146 sequence. No orchestrator behaviour changes.

**1. Lock the wiring-repair corpus result in a test.** DESIGN §5, IMPLEMENTATION and PR #145 all quote *"3 of the 6 historical wiring-gate deaths now proceed"*, but that number was only reproducible from a throwaway script. `tests/fixtures/wiring_repair_corpus/corpus.json` captures the real recorded `wiring_judge` output and post-filter plans from all six runs, reduced to the fields `_repair_missing_requires` actually reads, with every `concrete_reason` redacted to a constant (the repair never reads it — only its non-emptiness gates).

`tests/test_wiring_repair_corpus.py` pins the per-run repair counts, that the three fully-repaired runs schedule with each producer ahead of its consumer, that the three refusals fail for the two *documented* reasons (no provider / several providers) and not for any third, and the 3/6 headline itself. If a future edit widens or narrows what the repair accepts, the per-rule tests in `test_wiring_gate_repair.py` may all still pass while this ratio moves — that ratio is the trade-off the DESIGN contract change rests on.

**2. Record that this suite cannot be run concurrently with itself.** Measured across six full runs: serial with the host to itself gave **0 failures four times out of four**; two runs overlapping another pytest container gave **78** and then **57**. Counts are unstable and the individual tests pass in isolation (`test_worktree_failure_not_fatal.py` is 3/3 alone). This cost three rounds of false alarms during the investigation and was written down nowhere. `-n 4` on an idle host is fine and matches serial totals exactly — what breaks is *two suites at once*.

**3. `.gitignore` `leerie-*.log`** — the per-task tee form, alongside the existing `leerie.log`.

**4. Track the two task prompts under `prompts/`.** They were untracked, so the corrected line references and decomposition guidance in them would not survive a clean checkout.

## Which layer(s) does this PR touch?

- [ ] `docs/DESIGN.md`
- [ ] `docs/IMPLEMENTATION.md`
- [ ] `orchestrator/leerie.py`
- [x] docs (`CLAUDE.md`)
- [x] tests (`tests/`)
- [ ] CI / repo meta

Single-layer plus tests — no propagation needed.

## Task-completion checklist

- [x] `docs/IMPLEMENTATION.md` updated if code surface changed — n/a, no code change
- [x] `docs/DESIGN.md` updated if architecture changed — n/a
- [x] `pytest tests/` passes — **5009 passed, 0 failed, 125 skipped**
- [x] `python3 -c "import ast; ast.parse(open('orchestrator/leerie.py').read())"` — n/a, unchanged
- [x] `git diff --stat` reviewed for scope

## Testing notes

12 new tests, all driven by real recorded run data rather than synthetic fixtures. `test_fixture_covers_every_expected_run` is the guard-the-guard: a fixture that silently lost runs would make every per-run assertion vacuous.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
