### PR TITLE
refactor(logging): extract and pin the blocked-planner gap diagnostic

### DIFF
--- a/docs/IMPLEMENTATION.md
+++ b/docs/IMPLEMENTATION.md
@@ -2299,6 +2299,29 @@ undiagnosable from a log. The `InputValidationError` (unparseable JSON) path
 already logged its payload; this closes the gap for the parseable-but-invalid
 case. Recovering these by hand under `--output-format stream-json` is what
 disproved the 2026-08-03 investigation's leading hypothesis about their cause.
+
+#### Blocked-planner gap diagnostic
+
+`_format_blocked_gap(confidence) -> str` renders a blocked planner's stated
+gap for `phase_plan`'s per-category summary line, capped at
+`_BLOCKED_GAP_LOG_MAX = 400` chars with a visible `… [truncated; see log]`
+marker — never a silent cut, matching `_format_payload_for_log` above.
+
+Two transforms, both because the value is free prose. Whitespace is collapsed
+so an embedded newline cannot split a one-line summary across several rows,
+and the result is truncated: the gap moved from `confidence.gap_to_close` (a
+compact dict, frequently `{}`) to `confidence.basis` when the confidence block
+was flattened (DESIGN §8), and `basis` runs a **median of ~1.1k characters and
+up to 4.3k** across real planner submissions — so an untruncated line would put
+multiple KB on one row of the operator's terminal. The full text stays in the
+per-worker log, which the scheduling gate's own blocked-domain message already
+points at.
+
+Returns `""` rather than `None` for absent, empty or malformed input, so the
+caller interpolates an empty gap instead of the string `"None"`. The cap is
+much smaller than `_REJECTED_PAYLOAD_LOG_MAX` because this is one line inside a
+routine summary rather than a standalone failure dump. Pinned by
+`tests/test_schedule_blocked.py`.
 Pinned by `tests/test_rejected_payload_logging.py`.
 
 Resolution order (highest priority first):

--- a/orchestrator/leerie.py
+++ b/orchestrator/leerie.py
@@ -10917,6 +10917,32 @@ def _format_payload_for_log(payload: object) -> str | None:
     return text
 
 
+def _format_blocked_gap(confidence: object) -> str:
+    """Render a blocked planner's stated gap for `phase_plan`'s summary line.
+
+    The gap lives in `confidence.basis` — `gap_to_close` was removed from the
+    schema (DESIGN §8) and the prompts now direct a blocked planner to state
+    the missing artifact there instead.
+
+    Two transforms, both because `basis` is free prose rather than the compact
+    dict this line used to render. Whitespace is collapsed so an embedded
+    newline cannot break a one-line per-category summary into several, and the
+    result is truncated with a visible marker — never a silent cut, matching
+    `_format_payload_for_log` above. Measured across real planner submissions,
+    `basis` runs a median of ~1.1k characters and up to 4.3k, so an
+    untruncated line would put multiple KB on one row of the operator's
+    terminal; the full text stays in the per-worker log.
+
+    Returns `""` (not None) for absent, empty or malformed input, so the
+    caller interpolates an empty gap rather than the string "None"."""
+    if not isinstance(confidence, dict):
+        return ""
+    gap = " ".join((confidence.get("basis") or "").split())
+    if len(gap) > _BLOCKED_GAP_LOG_MAX:
+        gap = gap[:_BLOCKED_GAP_LOG_MAX] + "… [truncated; see log]"
+    return gap
+
+
 # Substrings that identify a *schema* rejection of a structured submission, as
 # opposed to any other errored tool result. Measured against real worker
 # streams: the CLI emits "Output does not match required schema: …" for a
@@ -16066,23 +16092,7 @@ async def phase_plan(task: str, st: State, caps: dict,
         n = len(plan.get("subtasks", []))
         status = plan.get("status", "ready")
         if status == "blocked":
-            # The gap analysis now lives in `basis` — `gap_to_close` was
-            # removed from the confidence schema (DESIGN §8), and the
-            # prompts direct a blocked planner to state the missing
-            # artifact there instead.
-            #
-            # Truncated because `basis` is prose, not the compact dict this
-            # line used to print: measured across real planner submissions it
-            # runs a median of ~1.1k characters and up to 4.3k, which would put
-            # a multi-KB paragraph on one line. Same discipline as
-            # `_format_payload_for_log` (explicit marker, never a silent cut)
-            # and `last_bash_cmd` (first line only) — the untruncated text
-            # stays in the per-worker log, which the operator messages at the
-            # scheduling gate already point at.
-            gap = " ".join(
-                ((plan.get("confidence", {}) or {}).get("basis") or "").split())
-            if len(gap) > _BLOCKED_GAP_LOG_MAX:
-                gap = gap[:_BLOCKED_GAP_LOG_MAX] + "… [truncated; see log]"
+            gap = _format_blocked_gap(plan.get("confidence"))
             log(f"  {category}: BLOCKED (planner gate) — {n} subtask(s); "
                 f"gap: {gap}")
         else:

--- a/tests/test_schedule_blocked.py
+++ b/tests/test_schedule_blocked.py
@@ -345,3 +345,75 @@ def test_orchestrate_resume_guard_for_no_work_required():
         assert return_after_guard < next_section, (
             "the `return` must be inside the no_work_required guard "
             "block, not after it.")
+
+
+# ----- the blocked-planner gap diagnostic -----------------------------------
+#
+# `phase_plan`'s per-category summary renders a blocked planner's gap via
+# `_format_blocked_gap`. The gap moved from `confidence.gap_to_close` (a
+# compact dict, frequently `{}`) to `confidence.basis` when the confidence
+# block was flattened (DESIGN §8) — and `basis` is prose, so the line needs
+# collapsing and truncating that the dict never did. Lives here rather than in
+# its own file because this module already owns what the operator sees when
+# planners block.
+
+# The largest `confidence.basis` observed across the run corpus. Imported
+# rather than redefined: `test_confidence_length_caps` owns that measurement
+# (it is the file about basis lengths), and duplicating it would give a single
+# measured fact two places to be updated. Cross-test-file import is the
+# established pattern here — see `tests/test_ec2_launcher_credentials.py` and
+# `tests/test_fetch_branch_leerie_streamback.py`.
+from tests.test_confidence_length_caps import _MEASURED_MAX_BASIS
+
+
+def test_short_gap_passes_through_verbatim(leerie):
+    """The common case must not be mangled by the truncation machinery."""
+    text = "need a deterministic repro for the timeout"
+    assert leerie._format_blocked_gap({"basis": text}) == text
+
+
+def test_a_maximal_basis_is_cut_with_a_visible_marker(leerie):
+    """A silent cut would read as a planner that stopped mid-sentence."""
+    out = leerie._format_blocked_gap({"basis": "x" * _MEASURED_MAX_BASIS})
+    assert out.endswith("… [truncated; see log]")
+    assert len(out) < _MEASURED_MAX_BASIS
+    assert out.startswith("x" * 50)
+
+
+def test_embedded_newlines_collapse_to_one_line(leerie):
+    """`basis` is prose and routinely contains newlines. The summary is one
+    line per category, so a raw newline would split one domain's status across
+    several rows and desynchronise the block."""
+    out = leerie._format_blocked_gap({"basis": "line one\n\nline two\ttabbed"})
+    assert "\n" not in out and "\t" not in out
+    assert out == "line one line two tabbed"
+
+
+@pytest.mark.parametrize("conf", [None, {}, {"basis": ""}, {"basis": None},
+                                  {"fit": 9.0}, "not-a-dict", []])
+def test_absent_or_malformed_confidence_yields_empty_string(leerie, conf):
+    """`""`, never None and never a raise: the caller interpolates this into an
+    f-string, so returning None would print the literal "None" and a raise
+    would kill a run over a diagnostic."""
+    assert leerie._format_blocked_gap(conf) == ""
+
+
+def test_the_cap_still_binds_on_real_output(leerie):
+    """Anti-vacuity, and the whole reason this file exists.
+
+    A cap set above the real distribution is inert — exactly the failure the
+    deleted `maxLength` caps demonstrated (measured non-binding at 0.00%, see
+    `tests/test_confidence_length_caps.py`). Raising this constant past the
+    measured maximum would silently disable the truncation while every other
+    test here kept passing."""
+    assert leerie._BLOCKED_GAP_LOG_MAX < _MEASURED_MAX_BASIS
+
+
+def test_phase_plan_uses_the_helper(leerie):
+    """Source-coupling guard: the helper is inert if the call site inlines its
+    own copy again, which is how this logic shipped untested in the first
+    place."""
+    import inspect
+    src = inspect.getsource(leerie.phase_plan)
+    assert "_format_blocked_gap(" in src
+    assert "BLOCKED (planner gate)" in src


### PR DESCRIPTION
Follow-up to #153, from a post-merge audit.

#153 added `_BLOCKED_GAP_LOG_MAX = 400` and a truncation branch inline in `phase_plan`, and shipped both with **no doc entry and no test** — while the sibling constant they were modelled on, `_REJECTED_PAYLOAD_LOG_MAX`, has both (IMPLEMENTATION.md §*Rejected-payload diagnostic*, plus three assertions in `tests/test_rejected_payload_logging.py`). IMPLEMENTATION.md is the code-surface spec, so a new constant plus a new branch belongs in it.

**Not a coverage regression.** No test ever covered the `BLOCKED (planner gate)` line, before or after. But #153 changed that line's semantics: the gap moved from `confidence.gap_to_close` (a compact dict, frequently `{}`) to `confidence.basis` when the confidence block was flattened — and `basis` is prose, measured at a **median ~1.1k characters and up to 4.3k**, so an untruncated line would put multiple KB on one row of the operator's terminal.

## Changes

**Extract `_format_blocked_gap(confidence: object) -> str`** beside `_format_payload_for_log`. The sibling is a standalone function precisely so it can be unit-tested; the inline version couldn't be reached without driving a whole phase. The hint is `object`, not `dict | None`, because the body's own `isinstance` guard accepts any type by design — it now matches both the behaviour and the sibling.

**Documented** beside the rejected-payload diagnostic, with the measured reason for the value and the note that the full text stays in the per-worker log.

**Pinned** in `tests/test_schedule_blocked.py`, which already owns what the operator sees when planners block.

## Verification

- **Pure refactor, proven:** behaviour captured *before* the edit across nine cases (short, measured-max, multiline, exact-cap, cap-plus-1, empty, missing key, `None` confidence, `None` basis) matches afterwards exactly.
- **Both guards falsified live:** raising the cap to 9000 fails 2 tests; re-inlining at the call site fails the source-coupling guard.
- **Anti-vacuity:** asserts the cap still binds below the measured maximum. A cap set above the real distribution is inert — exactly how the deleted `maxLength` caps failed (non-binding at 0.00%).
- Targeted tests only, per standing instruction. 49 pass across the affected files.

## Note

`_MEASURED_MAX_BASIS` is imported from `tests/test_confidence_length_caps.py` rather than redefined — that file owns the measurement, and duplicating it would give one measured fact two places to be updated. It was the only cross-file duplicated numeric test constant in the suite; there are now none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)