### PR TITLE
docs: record that collect-subtrees.sh embeds a second integrator schema

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1974,6 +1974,22 @@ and `MERGE_HEAD` are untouched, the temp index is cleaned up, refs are
 namespaced per run+subtask so two crashes cannot clobber each other, and a
 tree identical to `HEAD^{tree}` returns `None` rather than a ref naming an
 empty diff.
+**`scripts/remote/collect-subtrees.sh` embeds a second copy of
+`SCHEMAS["integrator"]`** as a single-quoted shell string, because it invokes
+`claude -p --json-schema` directly from bash on the remote machine and cannot
+import the orchestrator. **Any edit to that schema must update both.**
+`tests/test_collect_subtrees_integrator_schema.py` is the guard: it parses the
+`integrator_schema='{...}'` assignment out of the real script and asserts
+whole-object equality with the live `SCHEMAS["integrator"]` — deliberately
+whole-object rather than a spot-check of the fields that last drifted, since
+the next drift will be somewhere else. It exists because the copy **had already
+silently drifted in production** (measured 2026-08-03): it still carried
+`maxLength` 2000/500 on the confidence fields, values the live schema had moved
+off twice since (to 8000/2000, then deleted outright), so remote integrator
+runs were validating worker output against a materially different contract than
+local ones — invisibly, because nothing compared the two. A corpus fixture had
+even named this test file before it existed; the guard was planned and never
+landed, which is precisely how the drift went unnoticed.
 `tests/test_resolve_run_id_autopick.py` covers bare `--resume` auto-picking
 the newest resumable run (`in-progress`/`paused`/`incomplete`), including
 the two traps found by running the design against a real 58-run state dir:


### PR DESCRIPTION
Follow-up to #153/#154, from a post-merge audit. **Docs only** — no code, test or schema change.

## Why

`scripts/remote/collect-subtrees.sh` carries a copy of `SCHEMAS["integrator"]` as a shell string, because it invokes `claude -p --json-schema` directly from bash on the remote machine and cannot import the orchestrator. Nothing in CLAUDE.md said so — and CLAUDE.md is the file loaded into context every session, so a future edit to that schema had no way to learn the second copy exists.

That isn't hypothetical. The copy had **already silently drifted in production**: it still carried `maxLength` 2000/500 on the confidence fields, values the live schema had moved off twice since (to 8000/2000, then deleted outright). Remote integrator runs were therefore validating worker output against a materially different contract than local ones — invisibly, because nothing compared the two.

#153 resynced it and added `tests/test_collect_subtrees_integrator_schema.py`, which asserts **whole-object equality** rather than spot-checking the fields that last drifted, since the next drift will be somewhere else. A corpus fixture had even named that test file before it existed — the guard was planned and never landed, which is precisely how the drift went unnoticed.

This entry closes the remaining half: the guard now exists, and the constraint it enforces is written where the next session will actually read it.

## Scope note

Only 146 of 363 test files (40%) are catalogued in CLAUDE.md, so this is not a blanket "document every test" change — it names this one because it encodes a cross-file invariant that is otherwise undiscoverable from the schema definition alone.

## Verification

Every factual claim in the entry was checked against the artefacts rather than asserted:

- the embedded copy parses and currently equals the live `SCHEMAS["integrator"]` ✓
- the pre-#153 copy did carry `maxLength` 2000/500 ✓
- the corpus fixture does name the test file ✓
- the guard does whole-object equality ✓

14 related tests pass (`test_collect_subtrees_integrator_schema.py`, `test_collect_subtrees_sh.py`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)