### PR TITLE
feat(strict-output): force constrained decoding behind an opt-in flag

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -518,6 +518,23 @@ export LEERIE_BAKE_LANGUAGE_DEPS=0
 # `dangerously_allow_uncapped = true` in leerie.toml:
 ./leerie "task" --dangerously-allow-uncapped
 
+# Force constrained decoding on worker structured output. Off by default.
+# `claude -p --json-schema` validates the model's output AFTER generation and
+# re-prompts on a miss; it does not constrain sampling. This flag starts a
+# per-run loopback proxy, points workers at it via ANTHROPIC_BASE_URL, and
+# rewrites the CLI's injected StructuredOutput tool to carry `strict: true`
+# (hardening the schema so the grammar compiles). DANGEROUS: it edits requests
+# leerie does not own — the CLI's injected tool is a private interface with no
+# compatibility guarantee, and schema keywords the grammar cannot express are
+# stripped (see docs/IMPLEMENTATION.md for the full disclosure). Fail-open:
+# anything unexpected forwards the request untouched. Collides with a
+# pre-set ANTHROPIC_BASE_URL, and with Bedrock (AWS_BEARER_TOKEN_BEDROCK /
+# CLAUDE_CODE_USE_BEDROCK, which route to a different endpoint) — die()s in
+# both cases rather than silently running without the guarantee.
+# Also LEERIE_DANGEROUSLY_FORCE_STRICT_OUTPUT=1 or
+# `dangerously_force_strict_output = true` in leerie.toml:
+./leerie "task" --dangerously-force-strict-output
+
 # Pick a PR template when the repo has multiple in PULL_REQUEST_TEMPLATE/.
 # Also LEERIE_PR_TEMPLATE or `pr_template` in leerie.toml.
 ./leerie "task" --pr-template feature

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -4820,6 +4820,52 @@ worker communicate through a strict contract:
 - A worker that fails to produce a schema-valid result is retried once with the
   violation pointed out. A second failure is a hard worker error.
 
+**Validation is post-hoc, not constrained — and that is the dominant source of
+worker failure.** `claude -p --json-schema` does not constrain generation. The
+CLI injects the schema as a synthetic `StructuredOutput` *tool* and checks the
+result afterwards, re-prompting on mismatch; its own reference calls the flag
+"structured output **validation**". Captured from the wire (2026-08-04): the
+outbound request carries `tools[n].name == "StructuredOutput"` with **`strict`
+absent** and no `output_config`.
+
+The consequence is measured, not theoretical. Across the run corpus — every
+`StructuredOutput` submission in every run — **2,861 of 9,924 submissions
+(28.8%) are malformed**, in exactly the three shapes the vendor documents as the
+cost of omitting strict mode: the payload wrapped in a protocol-vocabulary
+container key (`{"input": …}`, `{"output": …}`, 1,648), the decoder flipping to
+legacy XML mid-value (136), bytes the CLI cannot parse at all (261), and
+required fields simply absent (752). None of these is a model being unable to do
+the work — the answers are usually correct and merely unreachable, which is why
+the CLI's own re-prompt loop recovers most of them at the cost of regenerating
+the payload.
+
+**Optional counter-measure: grammar-constrained decoding.** The API can compile
+a schema into a grammar that restricts token sampling, making every one of those
+shapes *unrepresentable* rather than merely rarer. The CLI exposes no way to ask
+for it. leerie can, behind
+`--dangerously-force-strict-output` (§ *Forcing constrained decoding*), by
+routing worker traffic through a loopback proxy that sets `strict: true` on the
+injected tool. It is **off by default**: it rewrites outbound requests to reach
+a capability the CLI does not expose and that is undocumented for subscription
+auth, and it depends on an internal tool name that carries no compatibility
+guarantee.
+
+Because that mechanism works by owning `ANTHROPIC_BASE_URL`, it **cannot
+coexist with an operator-supplied one**. A user who has already pointed that
+variable at a gateway, proxy, or alternative endpoint has a configuration leerie
+must not silently take over — and silently declining to enable the flag would be
+equally wrong, since the run would then lack the guarantee it was asked for.
+leerie therefore refuses to start when both are present, naming both and leaving
+the choice to the operator.
+
+The same reasoning rules out **Bedrock**. `ANTHROPIC_BASE_URL` is the
+first-party endpoint override; Bedrock routes through its own, and the proxy's
+upstream is the first-party API. So under Bedrock the flag is either inert — the
+proxy is never contacted and the operator is silently handed the post-hoc
+validation they explicitly asked to replace — or it misroutes every worker call.
+Since a run cannot tell those apart from a healthy one, leerie refuses that
+combination too rather than guessing.
+
 What happens after a hard worker error depends on whether partial progress can
 be salvaged. An **implementer** has a worktree branch and possibly a checkpoint,
 so its failure is converted into a handoff: a fresh implementer can continue.
@@ -4852,6 +4898,52 @@ the integrator's considered judgment that the merge should not stand, and
 still aborts and discards, exactly as *When integration cannot succeed*
 describes. Salvaging a crash does not weaken that: a verdict is a fact about
 the work, a crash is a fact about the machine.
+
+### Forcing constrained decoding
+
+`--dangerously-force-strict-output` converts the schema contract above from
+checked-afterwards into enforced-during-generation. It is off by default.
+
+The mechanism is a **loopback proxy, one per run, started by the orchestrator**.
+Because the orchestrator is PID 1 inside the container and every worker is its
+child (§6 *Worker subtree termination*), they share a network namespace: a
+listener on `127.0.0.1` is reachable by workers with no port mapping and no host
+networking, and the container boundary reaps it if the run dies abnormally. The
+port is chosen by binding to `0` and reading back what the OS assigned, so
+concurrent leerie runs on one host never collide and no port scan is needed.
+
+The proxy rewrites exactly one thing: on a request carrying a single tool named
+`StructuredOutput`, it sets `strict: true` and normalises the schema to the
+subset grammar compilation accepts — `additionalProperties: false` on every
+object, and removal of the keywords strict cannot express. Of that keyword set,
+only four occur in leerie's own schemas today (`minLength`, `maxLength`,
+`minimum`, `maximum`); the rest are stripped defensively against future schema
+edits. Everything else in the request is forwarded untouched.
+
+Two properties make that safe to run in the path of every worker call.
+
+**It fails open.** If the tool is renamed, absent, duplicated, or shaped
+unexpectedly — all of which an upstream release may do without notice — the
+request is forwarded unmodified. The run continues exactly as it would without
+the flag; the guarantee is lost, not the run. That loss is logged, because the
+dangerous failure here is a silent one.
+
+**It fails closed at startup.** If the listener cannot bind, the run dies rather
+than proceeding unconstrained, so an operator who asked for the guarantee is
+never quietly given the old behaviour.
+
+The normalisation has a real cost: those stripped keywords were carrying
+validation. Sixteen of the twenty-one are string-length bounds (fifteen
+`minLength`, one `maxLength`) on strings whose consumers already test
+truthiness, so nothing changes. The remaining five are numeric bounds that
+**fail permissively** if dropped — `fit_judge`'s score is compared against a
+threshold with no range check, so an out-of-range value would read as well-fit —
+and leerie therefore re-checks those in Python. That re-check is
+*unconditional*, not gated on the flag: a value outside its declared range was
+always a worker bug, and distrusting it is right whether or not strict mode is
+what removed the bound. The trade is deliberate: structural malformation is what
+actually breaks runs, and value-range violations are both rarer and cheaply
+re-checked.
 
 ---
 

--- a/docs/IMPLEMENTATION.md
+++ b/docs/IMPLEMENTATION.md
@@ -3341,6 +3341,112 @@ The validated payload is read from `structured_output` on the envelope. On a
 missing or schema-invalid payload, `claude_p()` retries once with the violation
 quoted into the prompt; a second failure raises `WorkerError`.
 
+#### Forced constrained decoding — `--dangerously-force-strict-output`
+
+Off by default. Resolved by `resolve_dangerously_force_strict_output(repo_root,
+cli_value)` with
+the standard CLI > env (`LEERIE_DANGEROUSLY_FORCE_STRICT_OUTPUT`) > `leerie.toml`
+(`dangerously_force_strict_output`) precedence.
+
+**Why it exists.** `--json-schema` is *validated*, not constrained: the CLI
+injects the schema as a synthetic `StructuredOutput` tool with **no
+`strict: true`** and no `output_config` (confirmed from a captured outbound
+request, 2026-08-04). Measured across the run corpus, **2,861 of 9,924
+submissions (28.8%)** are malformed as a result. Setting `strict: true` compiles
+the schema into a sampling grammar and makes those shapes unrepresentable.
+
+**Mechanism.** `_StrictOutputProxy` — an `asyncio.start_server` listener on
+`127.0.0.1`, **one per run**, started in `_orchestrate()` before the first
+worker and closed in its `finally` — which covers normal completion, `die()`,
+and SIGINT. There is deliberately no `_cleanup_on_abnormal_exit` hook: on
+SIGKILL the container boundary reaps the listener (DESIGN §6), which is the same
+guarantee every other worker resource relies on. Workers
+reach it via `ANTHROPIC_BASE_URL` injected into `worker_env`. The orchestrator
+is PID 1 in the container and workers are its children, so loopback needs no
+port mapping.
+
+| property | value | why |
+|---|---|---|
+| port | bind `0`, read back from `server.sockets[0].getsockname()[1]` | no scan, no race, concurrent runs never collide |
+| executor | dedicated `ThreadPoolExecutor(max_parallel + 8)` | the default pool saturates: measured 34/40 connections at 40 concurrent, 40/40 once bounded |
+| socket | `reuse_address=True`, `backlog=256` | without it the port is not rebindable after shutdown |
+| shutdown | close listener, drain tracked writers, `_pool.shutdown(wait=False, cancel_futures=True)` | verified port is rebindable afterwards. `wait=False` keeps Ctrl-C responsive — a blocking join could hold the finally open for a full upstream timeout. Residual: `ThreadPoolExecutor` registers an atexit join, so an upstream call still in flight at exit can delay the interpreter by up to `_STRICT_PROXY_TIMEOUT_SEC`; in the container the boundary reaps first |
+| `ConnectionResetError` / `BrokenPipeError` | caught per connection, non-fatal | normal client hang-up |
+| upstream | executor-bridged `urllib` | leerie has no async HTTP dependency; hand-rolled HTTP/1.1 is where the bugs are. Verified to 80 concurrent (16× default `max_parallel`) |
+| method | parsed from the request line and threaded to `_upstream` | only POST bodies are rewritten; every other verb the CLI issues must reach upstream as itself |
+| chunked request body | decoded by `_read_chunked`, never rewritten | a chunked body carries no `content-length`, so a length-driven read forwards only the first packet — a silently truncated request, which reads downstream as a model error rather than a proxy bug |
+
+**Logging.** The proxy runs in the orchestrator process, so `log()` from the
+handler interleaves with every other leerie line — there is no separate proxy
+log to go find. Three levels, emitted by `_log_exchange`:
+
+| when | verbosity | line |
+|---|---|---|
+| listener starts | all | `strict output: rewriting worker API requests via 127.0.0.1:<port> …` |
+| upstream ≥ 400 | **all, including `quiet`** | `strict-output proxy: upstream <status> on <method> <path> (<what was changed>) — <response body>` |
+| upstream < 400 | `debug` (`-vv`) only | `strict-output proxy: <method> <path> -> <status> (<what was changed>)` |
+| run ends | all | rewritten / passed-through / upstream-error counts |
+
+The error line is deliberately not verbosity-gated. This proxy is the only thing
+in the path that rewrites a request, so a 4xx is most likely leerie's own edit
+being rejected — and the response body names the offending schema path. Without
+it the operator sees only workers retrying, which is precisely the
+misattribution this flag's failure mode consists of. Echoes are capped at
+`_STRICT_PROXY_ERROR_LOG_MAX` (3) bodies of `_STRICT_PROXY_ERROR_BODY_MAX` (400)
+chars, because a rejected rewrite is systematic — every worker call fails the
+same way — after which they are counted, not echoed. The count is complete
+regardless, so the end-of-run summary never under-reports.
+
+**Transform** (`_strictify_request(body) -> tuple[bytes, str] | None` — the
+second element describes what changed and is what the log lines below report),
+applied only when
+exactly one tool is named `StructuredOutput` and carries an `input_schema`:
+sets `strict: true`; adds `additionalProperties: false` to every object node
+including inside array `items`; strips `minLength` / `maxLength` / `minimum` /
+`maximum`; clamps `minItems > 1` to `1`. Verified against all 23 entries in
+`SCHEMAS`: **zero residual violations**, 64 `additionalProperties` added, 21
+keywords stripped across 8 schemas.
+
+**Fail-open / fail-closed.** Tool renamed, absent, duplicated, or wrong shape →
+request forwarded byte-identical and the no-op logged (a silent loss of the
+guarantee is the dangerous case). Listener cannot bind → `die()`, never a quiet
+downgrade to unconstrained.
+
+**Two fatal collisions, same contract.** The flag works by owning
+`ANTHROPIC_BASE_URL`, so leerie `die()`s rather than proceed when that ownership
+is contested:
+
+1. **An operator-set `ANTHROPIC_BASE_URL`.** Overriding a user's gateway
+   silently and silently skipping the requested guarantee are both wrong, so
+   leerie names both and lets the operator unset one or drop the flag.
+2. **Bedrock** (`AWS_BEARER_TOKEN_BEDROCK`, or a truthy `CLAUDE_CODE_USE_BEDROCK`
+   — the same spellings the launcher's `detect_bedrock_mode()` accepts).
+   `ANTHROPIC_BASE_URL` is the *first-party* endpoint override; Bedrock has its
+   own (`ANTHROPIC_BEDROCK_BASE_URL`) and the proxy's upstream is hardcoded to
+   `api.anthropic.com`. So the flag under Bedrock either does nothing — the CLI
+   never contacts the proxy and the operator is silently handed post-hoc
+   validation, the exact failure case 1 exists to prevent — or misroutes every
+   worker call. Neither is distinguishable from a healthy run in the log, so
+   this is a `die()`, not a warning.
+
+**Stripped numeric bounds are re-checked in Python.** Of the 21 stripped
+keywords, 16 are string-length bounds (15 `minLength`, 1 `maxLength`) whose
+consumers already test truthiness. The 5 numeric ones (3 `minimum`, 2 `maximum`)
+do not and fail permissively — `score = judge_result.get("score", 0.0)` then
+`if score >= threshold` would read an out-of-range score as well-fit — so
+`fit_judge.score` (0–1, `_recursive_decompose`),
+`adherence_judge.instruction_adherence` (0–10, `phase_adherence_gate`) and
+`provision.recipe[].timeout_s` (≥1, `_recipe_timeout_s`, used by both the
+prompt-rendering and the baseline-install call sites) go through
+`_bounded_or_conservative`.
+
+These guards run **unconditionally, not only under the flag**: a value outside
+its declared range was always a worker bug, and distrusting it is right whether
+or not strict mode is what removed the bound. `timeout_s` additionally has a
+pre-existing `or 1800` fallback that already absorbed `0`; the guard adds the
+negative case, which is truthy and would otherwise reach
+`wait_for(timeout=-5.0)` and fire instantly.
+
 #### User prompt transport — stdin, not argv
 
 `build()` emits `["claude", "-p", ...]` with **no positional argument

--- a/orchestrator/leerie.py
+++ b/orchestrator/leerie.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import concurrent.futures
 import contextlib
 import copy
 import ctypes
@@ -775,6 +776,10 @@ DANGEROUS_SKIP_PERMS_FILE = SOURCE_OF_TRUTH_FILE
 # leerie.toml → False.
 DANGEROUS_ALLOW_UNCAPPED_ENV = "LEERIE_DANGEROUSLY_ALLOW_UNCAPPED"
 DANGEROUS_ALLOW_UNCAPPED_FILE = SOURCE_OF_TRUTH_FILE
+
+# --dangerously-force-strict-output (DESIGN §7 *Forcing constrained decoding*).
+DANGEROUS_FORCE_STRICT_OUTPUT_ENV = "LEERIE_DANGEROUSLY_FORCE_STRICT_OUTPUT"
+DANGEROUS_FORCE_STRICT_OUTPUT_FILE = SOURCE_OF_TRUTH_FILE
 
 # --skip-overlap-judge bypass (DESIGN §5 *Cross-domain surface overlap*).
 # Skips the phase 2¾ `plan_overlap_judge` worker even on multi-planner
@@ -4845,6 +4850,28 @@ def resolve_dangerously_allow_uncapped(
         file_name=DANGEROUS_ALLOW_UNCAPPED_FILE)
 
 
+def resolve_dangerously_force_strict_output(
+        repo_root: Path, cli_value: bool) -> bool:
+    """Resolve the --dangerously-force-strict-output preference. Order:
+    --dangerously-force-strict-output CLI flag (action='store_true') →
+    LEERIE_DANGEROUSLY_FORCE_STRICT_OUTPUT env var →
+    dangerously_force_strict_output in leerie.toml → False.
+
+    When True, worker API traffic is routed through a per-run loopback proxy
+    that sets `strict: true` on the `StructuredOutput` tool Claude Code
+    injects, turning post-hoc schema validation into grammar-constrained
+    decoding (DESIGN §7 *Forcing constrained decoding*).
+
+    Off by default. It reaches an API capability the CLI does not expose and
+    that is undocumented for subscription auth, and it depends on an internal
+    tool name carrying no compatibility guarantee."""
+    return _resolve_bool_pref(
+        repo_root, cli_value,
+        env_var=DANGEROUS_FORCE_STRICT_OUTPUT_ENV,
+        file_key="dangerously_force_strict_output",
+        file_name=DANGEROUS_FORCE_STRICT_OUTPUT_FILE)
+
+
 def resolve_skip_overlap_judge(repo_root: Path, cli_value: bool) -> bool:
     """Resolve the --skip-overlap-judge preference. Order:
     --skip-overlap-judge CLI flag (action='store_true') →
@@ -6413,7 +6440,12 @@ async def _recursive_decompose(
         log(f"_recursive_decompose: fit_judge crashed for "
             f"{subtask.get('id', '?')}; accepting as leaf")
         return [subtask]
-    score: float = judge_result.get("score", 0.0)
+    # Range re-imposed in Python: grammar compilation cannot express
+    # `minimum`/`maximum`, and the comparison below has no bound of its
+    # own — an out-of-range score would read as well-fit (DESIGN §7).
+    score: float = _bounded_or_conservative(
+        judge_result.get("score", 0.0), 0.0, 1.0, 0.0,
+        f"fit_judge {subtask.get('id', '?')} score")
 
     # --- leaf check ----------------------------------------------------------
     if score >= threshold or depth >= max_depth:
@@ -10943,6 +10975,413 @@ def _format_blocked_gap(confidence: object) -> str:
     return gap
 
 
+# --- forced constrained decoding (--dangerously-force-strict-output) --------
+#
+# `claude -p --json-schema` is VALIDATED, not constrained: the CLI injects the
+# schema as a synthetic `StructuredOutput` tool with no `strict: true` and no
+# `output_config` (confirmed from a captured outbound request, 2026-08-04), then
+# checks the result and re-prompts on mismatch. Measured across the run corpus,
+# 2,861 of 9,924 submissions (28.8%) are malformed as a result. Setting
+# `strict: true` compiles the schema into a sampling grammar, which makes those
+# shapes unrepresentable rather than merely rarer. See DESIGN §7 *Forcing
+# constrained decoding*.
+
+# Keywords grammar compilation cannot express. Present in leerie's own schemas
+# 21 times (15 minLength, 1 maxLength, 3 minimum, 2 maximum), so stripping them
+# is not hypothetical. The five numeric bounds are the ones whose loss matters —
+# their consumers compare against a threshold with no range check of their own —
+# so those are re-imposed in Python via `_bounded_or_conservative`.
+_STRICT_UNSUPPORTED_KEYWORDS = frozenset({
+    "minLength", "maxLength", "minimum", "maximum", "multipleOf", "pattern",
+    "oneOf", "not", "if", "then", "else", "dependentSchemas",
+    "patternProperties", "propertyNames", "uniqueItems", "maxItems",
+    "contains", "minProperties", "maxProperties",
+})
+
+# The name Claude Code gives the tool it synthesises from `--json-schema`.
+# Private, unversioned, and may change in any release — which is why every
+# transform below is fail-open rather than assertive.
+_STRICT_OUTPUT_TOOL_NAME = "StructuredOutput"
+
+# Upstream read timeout for the proxy. Matched to `worker_timeout_sec` so the
+# proxy is never the component that gives up first — a shorter bound would kill
+# requests the worker is still legitimately waiting on, converting a slow call
+# into an unexplained worker failure.
+_STRICT_PROXY_TIMEOUT_SEC = DEFAULT_CAPS["worker_timeout_sec"]
+
+# The run's proxy, or None when --dangerously-force-strict-output is off (the
+# default). Module-level because `claude_p` builds each worker's env deep in
+# the call stack and threading it through every caller would touch far more
+# surface than the feature warrants. One per run, owned by `_orchestrate`.
+_STRICT_PROXY: "_StrictOutputProxy | None" = None
+
+# How many upstream error responses get their body echoed before the proxy
+# falls back to counting them. A rejected rewrite is systematic — every worker
+# call fails the same way — so the first few carry all the diagnostic value and
+# the rest would bury the run log they share with every other leerie line.
+_STRICT_PROXY_ERROR_LOG_MAX = 3
+_STRICT_PROXY_ERROR_BODY_MAX = 400
+
+
+def _bounded_or_conservative(value: object, low: float, high: float,
+                             conservative: float, what: str) -> float:
+    """Re-impose a numeric bound that grammar compilation cannot express.
+
+    Strict mode drops `minimum`/`maximum`, and the consumers that read those
+    values compare them against a threshold with no range check of their own —
+    `if score >= threshold` reads an out-of-range score as well-fit. They
+    therefore fail *permissively*, which is the wrong direction for a gate, so
+    the bound moves into Python rather than being lost.
+
+    An out-of-range value returns `conservative`, it is **not clamped to the
+    nearest bound**. Clamping was tried and rejected: on a 0–1 axis it maps 5.0
+    to 1.0, which still clears every threshold and so preserves exactly the
+    permissive failure this exists to prevent. The corpus shows the confusion is
+    real — `fit_judge` emitted `"fit": 8.5` on an axis declared 0–1 — and while
+    that plausibly *meant* 0.85, inferring intent from a malformed number is
+    guessing. A gate must not be cleared by a value it cannot interpret, so the
+    caller passes the safe end of its own range and the run pays a split or a
+    re-plan instead of shipping on a reading nobody can justify.
+
+    Applied unconditionally rather than only under the flag: a value outside the
+    declared range was always a worker bug, and distrusting it is right either
+    way.
+    """
+    try:
+        num = float(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return conservative
+    if num != num or num in (float("inf"), float("-inf")):  # NaN / ±inf
+        return conservative
+    if num < low or num > high:
+        log(f"  {what}: value {num!r} outside [{low}, {high}] — treating as "
+            f"{conservative} (untrusted, not clamped)")
+        return conservative
+    return num
+
+
+def _strictify_schema(node: object) -> tuple[int, int]:
+    """In-place: make one schema acceptable to grammar compilation.
+
+    Returns `(objects_hardened, keywords_stripped)`.
+
+    Two edits. Every object node gains `additionalProperties: false`, which
+    strict mode requires — the API rejects the request otherwise, naming the
+    offending path. And keywords the grammar cannot express are removed;
+    `minItems` survives only at 0 or 1.
+
+    Recurses through `items` as well as `properties`, because leerie nests
+    objects inside arrays (`collisions[]`, `subtasks[]`, `wiring_defects[]`)
+    and a top-level-only pass would leave those unhardened.
+    """
+    hardened = stripped = 0
+    if isinstance(node, dict):
+        for key in list(node):
+            if key in _STRICT_UNSUPPORTED_KEYWORDS:
+                del node[key]
+                stripped += 1
+                continue
+            if key == "minItems" and node[key] not in (0, 1):
+                node[key] = 1
+                stripped += 1
+        if node.get("type") == "object" and node.get("additionalProperties") is not False:
+            node["additionalProperties"] = False
+            hardened += 1
+        for value in node.values():
+            h, s = _strictify_schema(value)
+            hardened += h
+            stripped += s
+    elif isinstance(node, list):
+        for value in node:
+            h, s = _strictify_schema(value)
+            hardened += h
+            stripped += s
+    return hardened, stripped
+
+
+def _strictify_request(body: bytes) -> tuple[bytes, str] | None:
+    """Rewrite one outbound Messages request to force constrained decoding.
+
+    Returns `(new_body, description)`, or None when the request should be
+    forwarded byte-identical.
+
+    Deliberately fail-open. The tool name and shape are a private interface
+    with no compatibility guarantee, so anything unexpected — renamed, absent,
+    duplicated, missing its schema, or a body that is not JSON at all — leaves
+    the request untouched. The run then behaves exactly as it would without the
+    flag: the guarantee is lost, not the run. Callers log the no-op, because a
+    silent loss is the failure mode worth catching.
+    """
+    try:
+        payload = json.loads(body)
+    except Exception:
+        return None
+    if not isinstance(payload, dict):
+        return None
+    tools = payload.get("tools")
+    if not isinstance(tools, list):
+        return None
+    hits = [t for t in tools
+            if isinstance(t, dict) and t.get("name") == _STRICT_OUTPUT_TOOL_NAME]
+    if len(hits) != 1:
+        return None
+    tool = hits[0]
+    if not isinstance(tool.get("input_schema"), dict):
+        return None
+    tool["strict"] = True
+    hardened, stripped = _strictify_schema(tool["input_schema"])
+    return (json.dumps(payload).encode(),
+            f"strict:true (+{hardened} additionalProperties, -{stripped} unsupported)")
+
+
+class _StrictOutputProxy:
+    """One loopback proxy per run, forcing constrained decoding.
+
+    Workers reach it through `ANTHROPIC_BASE_URL`. The orchestrator is PID 1
+    inside the container and every worker is its child (DESIGN §6 *Worker
+    subtree termination*), so they share a network namespace: a `127.0.0.1`
+    listener needs no port mapping, and the container boundary reaps it if the
+    run dies abnormally.
+
+    Every design choice below was forced by a measured failure in a load test of
+    this exact shape, not chosen on taste:
+
+    * **Ephemeral port.** Bind `0` and read back what the OS assigned, so
+      concurrent leerie runs on one host cannot collide and nothing scans.
+    * **Dedicated executor.** asyncio's default pool saturates: 34 of 40
+      concurrent connections survived, the rest died with
+      `ConnectionResetError`. Sized to the wave width plus headroom, it is
+      40/40 and 80/80.
+    * **`reuse_address` + drain on shutdown.** Without closing tracked writers
+      and joining the executor, the port stays unbindable afterwards and a
+      second run in the same container fails to start.
+    * **Client hang-ups are normal.** `ConnectionResetError` / `BrokenPipeError`
+      are caught per connection and never escalate; the CLI hangs up routinely
+      once it has what it needs.
+
+    Upstream is bridged through `urllib` on that executor rather than spoken
+    natively over `asyncio.open_connection`. leerie has no async HTTP dependency
+    (CLAUDE.md: stdlib-preferred), and hand-rolling HTTP/1.1 — chunked encoding,
+    keep-alive, partial reads — is exactly where a proxy in the path of every
+    worker call would acquire subtle bugs.
+    """
+
+    _UPSTREAM = "https://api.anthropic.com"
+
+    def __init__(self, max_parallel: int,
+                 verbosity: str = VERBOSITY_DEFAULT) -> None:
+        self._server: asyncio.base_events.Server | None = None
+        self._writers: set[asyncio.StreamWriter] = set()
+        # +8 so the pool is never the ceiling: a wave's workers plus the
+        # occasional out-of-band call (token probe, smoke test) must all fit.
+        self._pool = concurrent.futures.ThreadPoolExecutor(
+            max_workers=max_parallel + 8, thread_name_prefix="strict-proxy")
+        self._verbosity = verbosity
+        self.port = 0
+        self.rewritten = 0
+        self.passed_through = 0
+        self.upstream_errors = 0
+
+    async def start(self) -> int:
+        self._server = await asyncio.start_server(
+            self._handle, "127.0.0.1", 0, reuse_address=True, backlog=256)
+        self.port = self._server.sockets[0].getsockname()[1]
+        return self.port
+
+    async def stop(self) -> None:
+        if self._server is not None:
+            self._server.close()
+            with contextlib.suppress(Exception):
+                await self._server.wait_closed()
+        for writer in list(self._writers):
+            with contextlib.suppress(Exception):
+                writer.close()
+        self._writers.clear()
+        self._pool.shutdown(wait=False, cancel_futures=True)
+
+    @staticmethod
+    async def _read_chunked(reader: asyncio.StreamReader, rest: bytes) -> bytes:
+        """Decode a chunked request body into its real bytes.
+
+        urllib recomputes `content-length` for the upstream hop, so forwarding
+        the raw framing would describe a body that is not what it says it is.
+        Decoding here keeps the untested-path fallback a correct request rather
+        than a differently-corrupt one.
+        """
+        buf = bytearray(rest)
+        out = bytearray()
+        while True:
+            # `find` + slice rather than `bytes(buf).partition(...)`: the latter
+            # copies the whole remaining buffer once per chunk, which is
+            # quadratic in chunk count — and this path exists precisely for a
+            # large body arriving in many small chunks.
+            cut = buf.find(b"\r\n")
+            while cut == -1:
+                chunk = await reader.read(65536)
+                if not chunk:
+                    return bytes(out)
+                buf += chunk
+                cut = buf.find(b"\r\n")
+            line = bytes(buf[:cut])
+            del buf[:cut + 2]
+            try:
+                size = int(line.split(b";", 1)[0].strip() or b"0", 16)
+            except ValueError:
+                return bytes(out)
+            if size == 0:
+                return bytes(out)
+            while len(buf) < size + 2:
+                chunk = await reader.read(size + 2 - len(buf))
+                if not chunk:
+                    out += buf[:size]
+                    return bytes(out)
+                buf += chunk
+            out += buf[:size]
+            del buf[:size + 2]
+
+    def _upstream(self, method: str, path: str, body: bytes,
+                  headers: dict) -> tuple[int, list, bytes]:
+        """Blocking round-trip, run on the dedicated pool.
+
+        `method` is threaded through rather than assumed: only POST bodies are
+        ever rewritten, but every other verb the CLI issues must reach upstream
+        as itself. Replaying a GET as a POST would corrupt requests this proxy
+        is supposed to pass through untouched.
+        """
+        req = urllib.request.Request(self._UPSTREAM + path,
+                                     data=body if body else None,
+                                     headers=headers, method=method)
+        try:
+            with urllib.request.urlopen(req, timeout=_STRICT_PROXY_TIMEOUT_SEC) as r:
+                return r.status, list(r.headers.items()), r.read()
+        except urllib.error.HTTPError as e:
+            return e.code, list(e.headers.items()), e.read()
+
+    def _log_exchange(self, method: str, path: str, status: int,
+                      desc: str, payload: bytes) -> None:
+        """Surface one proxied exchange on the orchestrator's own log stream.
+
+        The proxy runs in the orchestrator process, so `log()` here interleaves
+        with every other leerie line — no separate file to go find.
+
+        An upstream error is logged at *every* verbosity, with its body. This
+        proxy is the only thing in the path that rewrites a request, so a 4xx
+        here is most likely leerie's own edit being rejected — and the response
+        names the offending schema path. Without it the operator sees only
+        workers retrying, which is precisely the misattribution this flag's
+        whole failure mode consists of. Per-request success lines are debug-only
+        (`-vv`): one per worker API call is far too much for normal output.
+        """
+        if status >= 400:
+            self.upstream_errors += 1
+            if self.upstream_errors <= _STRICT_PROXY_ERROR_LOG_MAX:
+                snippet = " ".join(
+                    payload[:_STRICT_PROXY_ERROR_BODY_MAX]
+                    .decode("utf-8", "replace").split())
+                log(f"  strict-output proxy: upstream {status} on {method} "
+                    f"{path} ({desc or 'not rewritten'}) — {snippet}")
+                if self.upstream_errors == _STRICT_PROXY_ERROR_LOG_MAX:
+                    log("  strict-output proxy: further upstream errors will "
+                        "be counted, not echoed (see the end-of-run summary)")
+        elif self._verbosity == "debug":
+            log(f"  strict-output proxy: {method} {path} -> {status} "
+                f"({desc or 'forwarded unmodified'})")
+
+    async def _handle(self, reader: asyncio.StreamReader,
+                      writer: asyncio.StreamWriter) -> None:
+        self._writers.add(writer)
+        try:
+            desc = ""
+            head = b""
+            while b"\r\n\r\n" not in head:
+                chunk = await reader.read(8192)
+                if not chunk:
+                    return
+                head += chunk
+            raw_head, _, rest = head.partition(b"\r\n\r\n")
+            lines = raw_head.split(b"\r\n")
+            request_line = lines[0].decode("latin-1")
+            method, _, tail = request_line.partition(" ")
+            path = tail.rsplit(" ", 1)[0]
+            headers = {}
+            length = 0
+            chunked = False
+            for line in lines[1:]:
+                name, _, value = line.decode("latin-1").partition(":")
+                name, value = name.strip(), value.strip()
+                if name.lower() == "content-length":
+                    length = int(value or 0)
+                if name.lower() == "transfer-encoding" and "chunked" in value.lower():
+                    chunked = True
+                # Host/length/encoding are recomputed by urllib for the
+                # upstream hop; forwarding ours would describe the wrong body.
+                # `transfer-encoding` is in this list rather than popped later
+                # because header names are case-insensitive on the wire: a
+                # `TRANSFER-ENCODING` that survived would reach upstream beside
+                # urllib's computed content-length, and a request carrying both
+                # framing headers is a smuggling shape servers reject.
+                if name.lower() not in ("host", "content-length",
+                                        "accept-encoding", "connection",
+                                        "transfer-encoding"):
+                    headers[name] = value
+
+            # A chunked request body carries no `content-length`, so the
+            # length-driven read below would take whatever landed in the first
+            # packet and forward it as the whole body — a silently truncated
+            # request, which reads downstream as a model error rather than a
+            # proxy bug. Today's CLI always sends `content-length`, but that is
+            # an observation about one client version, not a guarantee. Decode
+            # the framing so the upstream hop gets the real bytes, and never
+            # rewrite a body that arrived on this untested path.
+            if chunked:
+                body = await self._read_chunked(reader, rest)
+                # Counted only for POST, matching the branch below: the counter
+                # drives an operator warning that the constrained-decoding
+                # guarantee was lost, and a GET was never a candidate for it.
+                if method.upper() == "POST":
+                    self.passed_through += 1
+            else:
+                body = rest
+                while len(body) < length:
+                    chunk = await reader.read(length - len(body))
+                    if not chunk:
+                        break
+                    body += chunk
+
+                if method.upper() == "POST":
+                    swap = _strictify_request(body)
+                    if swap is not None:
+                        body, desc = swap
+                        self.rewritten += 1
+                    else:
+                        self.passed_through += 1
+
+            status, up_headers, payload = await asyncio.get_running_loop().run_in_executor(
+                self._pool, self._upstream, method.upper(), path, body, headers)
+            self._log_exchange(method.upper(), path, status, desc, payload)
+
+            out = [f"HTTP/1.1 {status} X".encode("latin-1")]
+            for name, value in up_headers:
+                if name.lower() in ("content-length", "transfer-encoding",
+                                    "content-encoding", "connection"):
+                    continue
+                out.append(f"{name}: {value}".encode("latin-1"))
+            out.append(f"content-length: {len(payload)}".encode("latin-1"))
+            out.append(b"connection: close")
+            writer.write(b"\r\n".join(out) + b"\r\n\r\n" + payload)
+            await writer.drain()
+        except (ConnectionResetError, BrokenPipeError, asyncio.IncompleteReadError):
+            # The CLI hangs up routinely once it has what it needs. Normal.
+            pass
+        except Exception as e:  # noqa: BLE001 - one bad connection must not
+            # take down the listener that every other worker depends on.
+            log(f"  strict-output proxy: connection error ({type(e).__name__}: {e})")
+        finally:
+            self._writers.discard(writer)
+            with contextlib.suppress(Exception):
+                writer.close()
+
+
 # Substrings that identify a *schema* rejection of a structured submission, as
 # opposed to any other errored tool result. Measured against real worker
 # streams: the CLI emits "Output does not match required schema: …" for a
@@ -11995,6 +12434,16 @@ async def _invoke(cmd: list[str], cwd: str, timeout: int,
         if worker_env is None:
             worker_env = os.environ.copy()
         worker_env["CLAUDE_CODE_OAUTH_TOKEN"] = active_token
+    # Forced constrained decoding: point the worker's API traffic at this
+    # run's proxy so it can set `strict: true` on the injected
+    # StructuredOutput tool (DESIGN §7). Composes with the two blocks above —
+    # worker debug, token rotation and strict output are orthogonal.
+    # `main()` has already refused to start if the operator set this variable
+    # themselves, so there is nothing here to clobber.
+    if _STRICT_PROXY is not None:
+        if worker_env is None:
+            worker_env = os.environ.copy()
+        worker_env["ANTHROPIC_BASE_URL"] = f"http://127.0.0.1:{_STRICT_PROXY.port}"
 
     proc = await asyncio.create_subprocess_exec(
         *cmd,
@@ -19746,10 +20195,15 @@ async def phase_adherence_gate(plans: list[dict], task: str, st: State,
             [s for plan in cur_plans[0] for s in plan.get("subtasks", []) or []],
         )
         last_floor_issues[0] = floor_issues
+        # Same reasoning as fit_judge's score: the threshold comparison
+        # carries no range check, so an out-of-range value would silently
+        # clear the gate (DESIGN §7 *Forcing constrained decoding*).
         adherence = judge_result.get("instruction_adherence")
         low_adherence = (
             isinstance(adherence, (int, float))
-            and adherence < _ADHERENCE_GATE_THRESHOLD
+            and _bounded_or_conservative(adherence, 0.0, 10.0, 0.0,
+                                         "adherence_judge instruction_adherence")
+            < _ADHERENCE_GATE_THRESHOLD
         )
         issues = list(floor_issues)
         if low_adherence:
@@ -21231,6 +21685,34 @@ def _is_baked_ecosystem_command(command: list[str]) -> bool:
     return False
 
 
+_PROVISION_TIMEOUT_DEFAULT_S = 1800.0
+
+
+def _recipe_timeout_s(entry: dict, max_s: float | None = None) -> float:
+    """Effective per-step timeout for one provision recipe entry.
+
+    The schema declares `timeout_s` as `{"type": "integer", "minimum": 1}`, but
+    grammar compilation cannot express `minimum`, so
+    `--dangerously-force-strict-output` strips it (DESIGN §7). The bound
+    therefore moves into Python — the same treatment `fit_judge.score` and
+    `adherence_judge.instruction_adherence` get, and for the same reason: the
+    consumer has no range check of its own.
+
+    `0` was always handled by the `or` fallback below, but a **negative** is
+    truthy and would reach `wait_for(timeout=-5.0)`, which fires immediately —
+    turning a provisioning step into an instant, unexplained timeout. Upper
+    bound is the worker wall-clock cap: a single install step cannot usefully
+    outlive the worker running it.
+    """
+    ceiling = float(max_s or DEFAULT_CAPS["worker_timeout_sec"])
+    raw = entry.get("timeout_s")
+    if not raw:  # absent, 0, or None — the documented default
+        return _PROVISION_TIMEOUT_DEFAULT_S
+    return _bounded_or_conservative(
+        raw, 1.0, ceiling, _PROVISION_TIMEOUT_DEFAULT_S,
+        f"provision recipe timeout_s for {' '.join(entry.get('command') or ['?'])}")
+
+
 def _format_provision_recipe_section(recipe: list[dict],
                                       *, audience: str) -> str | None:
     """Render the persisted provision recipe as a prompt section, or
@@ -21303,8 +21785,8 @@ def _format_provision_recipe_section(recipe: list[dict],
     for i, e in enumerate(filtered_entries, 1):
         cmd_str = " ".join(e["command"])
         wd = e.get("working_dir", ".")
-        timeout = e.get("timeout_s") or 1800
-        lines.append(f"  {i}. {cmd_str}   (cwd: {wd}, timeout: {timeout}s)")
+        timeout = _recipe_timeout_s(e)
+        lines.append(f"  {i}. {cmd_str}   (cwd: {wd}, timeout: {timeout:g}s)")
     return "\n".join(lines)
 
 
@@ -22811,7 +23293,7 @@ async def _capture_conformance_baseline(
         try:
             await _run_streaming(
                 e["command"], cwd=str(wd),
-                timeout=float(e.get("timeout_s") or 1800),
+                timeout=_recipe_timeout_s(e, caps.get("worker_timeout_sec")),
                 log_path=log_path, label=f"baseline-install: {' '.join(e['command'])}",
                 verbosity=verbosity)
         except subprocess.TimeoutExpired:
@@ -24816,6 +25298,25 @@ async def _orchestrate(args, caps: dict, leerie_dir: Path, st: State,
     # Same lifecycle as the sampler — cancelled in the finally so it never
     # outlives the run.
     reaper_task = asyncio.create_task(_zombie_reaper())
+    # Forced constrained decoding (DESIGN §7 *Forcing constrained decoding*).
+    # Started before the first worker so `_STRICT_PROXY` is already listening
+    # when `claude_p` builds a worker env, and torn down in the same finally as
+    # the tasks above so a crash, SIGINT or SIGTERM cannot leave the port held.
+    global _STRICT_PROXY
+    if caps.get("force_strict_output"):
+        _STRICT_PROXY = _StrictOutputProxy(caps["max_parallel"], verbosity)
+        try:
+            port = await _STRICT_PROXY.start()
+        except OSError as e:
+            # Fail closed: continuing would hand the operator ordinary
+            # post-hoc validation while they believe generation is constrained.
+            _STRICT_PROXY = None
+            die(f"--dangerously-force-strict-output: could not start the "
+                f"local proxy on 127.0.0.1 ({e}). Re-run without the flag to "
+                f"use the CLI's ordinary post-hoc validation.")
+        log(f"strict output: rewriting worker API requests via "
+            f"127.0.0.1:{port} — `strict: true` forced on the "
+            f"StructuredOutput tool (--dangerously-force-strict-output)")
     try:
         await _run_phases(args, caps, leerie_dir, st, sot_pref, verbosity,
                           models, efforts)
@@ -24826,6 +25327,21 @@ async def _orchestrate(args, caps: dict, leerie_dir: Path, st: State,
             await sampler_task
         with contextlib.suppress(asyncio.CancelledError):
             await reaper_task
+        if _STRICT_PROXY is not None:
+            # The pass-through count is the only signal that the private tool
+            # interface changed under us: the run still succeeds, but silently
+            # without the guarantee it was asked for.
+            log(f"strict output: {_STRICT_PROXY.rewritten} request(s) "
+                f"rewritten, {_STRICT_PROXY.passed_through} passed through"
+                + (" — passed-through requests did NOT get constrained "
+                   "decoding; the injected tool may have changed upstream"
+                   if _STRICT_PROXY.passed_through else "")
+                + (f", {_STRICT_PROXY.upstream_errors} upstream error(s) — "
+                   f"the rewrite itself may be being rejected; re-run without "
+                   f"the flag to confirm"
+                   if _STRICT_PROXY.upstream_errors else ""))
+            await _STRICT_PROXY.stop()
+            _STRICT_PROXY = None
 
 
 async def _run_phases(args, caps: dict, leerie_dir: Path, st: State,
@@ -25527,6 +26043,38 @@ See README.md "Launcher verbs" for full details and sub-flags.""")
                          "to a loud warning and runs workers uncapped. Also "
                          f"{DANGEROUS_ALLOW_UNCAPPED_ENV} env var or "
                          "dangerously_allow_uncapped=true in leerie.toml.")
+    ap.add_argument("--dangerously-force-strict-output", action="store_true",
+                    help="DANGEROUS: route every worker's API traffic through "
+                         "a per-run loopback proxy that rewrites the outbound "
+                         "request to set `strict: true` on the "
+                         "StructuredOutput tool Claude Code injects, turning "
+                         "post-hoc schema validation into grammar-constrained "
+                         "decoding. Measured: unconstrained generation is the "
+                         "cause of 28.8%% of all worker submissions being "
+                         "malformed (2,861 of 9,924 across the run corpus). "
+                         "FOUR THINGS TO UNDERSTAND FIRST. (1) It reaches an "
+                         "API capability the CLI does not expose and that is "
+                         "not documented for subscription auth — verified "
+                         "working, but undefined against the Consumer terms; "
+                         "that judgement is yours. (2) It matches an internal "
+                         "tool name and shape carrying no compatibility "
+                         "guarantee, which may change in any Claude Code "
+                         "release; leerie then fails OPEN (forwards "
+                         "unmodified), so you lose the guarantee silently — "
+                         "watch for the 'passed through' count in the run "
+                         "summary. (3) Strict cannot express minLength/"
+                         "maxLength/minimum/maximum, so 21 such constraints "
+                         "are stripped from leerie's schemas; the 5 numeric "
+                         "bounds are re-checked in Python, the 16 string ones "
+                         "rely on existing emptiness guards. (4) It sets "
+                         "ANTHROPIC_BASE_URL for workers, which changes other "
+                         "CLI behaviour (MCP tool-search defaults and other "
+                         "first-party-gated paths), and is refused outright if "
+                         "you already set that variable yourself. Default is "
+                         "off — leerie uses the CLI's ordinary post-hoc "
+                         "validation and absorbs the retries. Also "
+                         f"{DANGEROUS_FORCE_STRICT_OUTPUT_ENV} env var or "
+                         "dangerously_force_strict_output=true in leerie.toml.")
     ap.add_argument("--max-workers", type=_positive_int, metavar="N",
                     help=f"total worker-invocation budget "
                          f"(default {DEFAULT_CAPS['max_total_workers']}); "
@@ -26010,6 +26558,45 @@ See README.md "Launcher verbs" for full details and sub-flags.""")
 
     args.dangerously_allow_uncapped = resolve_dangerously_allow_uncapped(
         repo_root, args.dangerously_allow_uncapped)
+
+    # Forced constrained decoding (DESIGN §7 *Forcing constrained decoding*).
+    caps["force_strict_output"] = resolve_dangerously_force_strict_output(
+        repo_root, args.dangerously_force_strict_output)
+    if caps["force_strict_output"] and os.environ.get("ANTHROPIC_BASE_URL"):
+        # The flag works by owning ANTHROPIC_BASE_URL. Overriding an operator's
+        # gateway silently would hijack their setup; honouring theirs and
+        # quietly skipping the rewrite would deny the guarantee they asked for.
+        # Both are wrong, so refuse and let them choose.
+        die("--dangerously-force-strict-output needs ANTHROPIC_BASE_URL for "
+            f"its own proxy, but it is already set to "
+            f"{os.environ['ANTHROPIC_BASE_URL']!r}. leerie will not override "
+            "your endpoint, and will not silently run without the constrained "
+            "decoding you asked for. Unset ANTHROPIC_BASE_URL, or drop the "
+            "flag.")
+    # Same contract, second collision: Bedrock. The proxy's upstream is
+    # hardcoded to api.anthropic.com and it owns ANTHROPIC_BASE_URL, which is
+    # the *first-party* endpoint override — Bedrock has its own
+    # (ANTHROPIC_BEDROCK_BASE_URL). So under Bedrock the flag either does
+    # nothing (the CLI never contacts the proxy, and the operator is silently
+    # given post-hoc validation — the exact silent loss the guard above exists
+    # to prevent) or misroutes every worker call to the wrong endpoint. Neither
+    # is distinguishable from a healthy run at the log level, so refuse. The
+    # truthy spellings match the launcher's own detect_bedrock_mode().
+    bedrock_via = (
+        "AWS_BEARER_TOKEN_BEDROCK" if os.environ.get("AWS_BEARER_TOKEN_BEDROCK")
+        else "CLAUDE_CODE_USE_BEDROCK"
+        if os.environ.get("CLAUDE_CODE_USE_BEDROCK", "").strip().lower()
+        in ("1", "true", "yes", "on")
+        else "")
+    if caps["force_strict_output"] and bedrock_via:
+        die(f"--dangerously-force-strict-output cannot be used with Bedrock "
+            f"({bedrock_via} is set). The flag works by pointing workers at a "
+            "local proxy via ANTHROPIC_BASE_URL, which is the first-party "
+            "endpoint override; Bedrock routes elsewhere, so the rewrite would "
+            "either be skipped silently or send every worker call to the wrong "
+            "endpoint. leerie will not silently run without the constrained "
+            "decoding you asked for. Drop the flag, or use subscription/API "
+            "auth for this run.")
 
     # Resolve --pr-template: free-form string (no enum). Re-attach to
     # args so phase_finalize sees the resolved value via

--- a/tests/test_strict_output_proxy.py
+++ b/tests/test_strict_output_proxy.py
@@ -1,0 +1,973 @@
+"""`--dangerously-force-strict-output` — the transform and the proxy.
+
+`claude -p --json-schema` is *validated*, not constrained. The CLI injects the
+schema as a synthetic `StructuredOutput` tool with **no `strict: true`** and no
+`output_config` — confirmed from a captured outbound request (2026-08-04), where
+`tools[18].name == "StructuredOutput"` and `strict` was absent. Measured across
+the run corpus, **2,861 of 9,924 submissions (28.8%)** are malformed as a direct
+result, in exactly the shapes the vendor documents as the cost of omitting
+strict mode.
+
+Setting `strict: true` compiles the schema into a sampling grammar, making those
+shapes unrepresentable. Two live experiments established that this works on
+subscription auth: injecting `strict` alone returned 400 with a *schema*
+complaint (not a permissions one), and adding `additionalProperties: false`
+returned 200 with valid output.
+
+The two properties this file exists to pin:
+
+**Fail-open on the transform.** The tool name and shape are a private,
+unversioned interface. Anything unexpected must forward the request
+byte-identical, so an upstream rename costs the guarantee rather than the run.
+
+**Fail-closed on the listener.** If the proxy cannot bind, the run must die
+rather than quietly proceeding unconstrained — an operator who asked for the
+guarantee must never be silently given the old behaviour.
+"""
+from __future__ import annotations
+
+import copy
+import json
+import re
+
+import pytest
+
+
+def _wrap(schema: dict, name: str = "StructuredOutput") -> bytes:
+    """A minimal Messages body carrying one injected tool."""
+    return json.dumps({
+        "model": "claude-sonnet-5",
+        "messages": [{"role": "user", "content": "x"}],
+        "tools": [{"name": name, "description": "d", "input_schema": schema}],
+    }).encode()
+
+
+def _tool(body: bytes) -> dict:
+    return json.loads(body)["tools"][0]
+
+
+# ----- the transform ---------------------------------------------------------
+
+def test_sets_strict_on_the_injected_tool(leerie):
+    out = leerie._strictify_request(_wrap({"type": "object", "properties": {}}))
+    assert out is not None
+    assert _tool(out[0])["strict"] is True
+
+
+def test_hardens_objects_nested_inside_array_items(leerie):
+    """leerie nests objects inside arrays (`collisions[]`, `subtasks[]`,
+    `wiring_defects[]`). A properties-only pass would leave those unhardened and
+    the API would reject the request naming that exact path."""
+    out = leerie._strictify_request(_wrap({
+        "type": "object",
+        "properties": {
+            "rows": {"type": "array",
+                     "items": {"type": "object",
+                               "properties": {"a": {"type": "string"}}}},
+        },
+    }))
+    schema = _tool(out[0])["input_schema"]
+    assert schema["additionalProperties"] is False
+    assert schema["properties"]["rows"]["items"]["additionalProperties"] is False
+
+
+def test_strips_keywords_grammar_compilation_cannot_express(leerie):
+    out = leerie._strictify_request(_wrap({
+        "type": "object",
+        "properties": {
+            "s": {"type": "string", "minLength": 1, "maxLength": 200},
+            "n": {"type": "number", "minimum": 0, "maximum": 1},
+        },
+    }))
+    props = _tool(out[0])["input_schema"]["properties"]
+    for gone in ("minLength", "maxLength"):
+        assert gone not in props["s"]
+    for gone in ("minimum", "maximum"):
+        assert gone not in props["n"]
+
+
+def test_minitems_survives_at_one_but_is_clamped_above(leerie):
+    """`minItems` is supported only at 0 or 1, so a larger value must be
+    clamped rather than dropped — dropping it would silently widen the
+    contract more than necessary."""
+    out = leerie._strictify_request(_wrap({
+        "type": "object",
+        "properties": {"a": {"type": "array", "minItems": 1},
+                       "b": {"type": "array", "minItems": 5}},
+    }))
+    props = _tool(out[0])["input_schema"]["properties"]
+    assert props["a"]["minItems"] == 1
+    assert props["b"]["minItems"] == 1
+
+
+def test_every_real_schema_survives_the_transform(leerie):
+    """The load-bearing test: all 23 shipped schemas must come out clean, or
+    the flag 400s on whichever worker runs first. `reconciler` (11 object
+    nodes) and `conformer` (10) are the stress cases."""
+    unsupported = leerie._STRICT_UNSUPPORTED_KEYWORDS
+
+    def residual(node, path="$"):
+        bad = []
+        if isinstance(node, dict):
+            for k, v in node.items():
+                if k in unsupported:
+                    bad.append(f"{path}.{k}")
+                if k == "minItems" and v not in (0, 1):
+                    bad.append(f"{path}.minItems={v}")
+                bad += residual(v, f"{path}.{k}")
+            if node.get("type") == "object" and node.get("additionalProperties") is not False:
+                bad.append(f"{path} missing additionalProperties:false")
+        elif isinstance(node, list):
+            for i, v in enumerate(node):
+                bad += residual(v, f"{path}[{i}]")
+        return bad
+
+    offenders = {}
+    for name, schema in leerie.SCHEMAS.items():
+        out = leerie._strictify_request(_wrap(copy.deepcopy(schema)))
+        assert out is not None, name
+        bad = residual(_tool(out[0])["input_schema"])
+        if bad:
+            offenders[name] = bad[:3]
+    assert not offenders, f"schemas still violating the strict subset: {offenders}"
+
+
+def test_the_real_schema_sweep_is_not_vacuous(leerie):
+    """Anti-vacuity: the sweep above only means something if the shipped
+    schemas genuinely need fixing. Measured: 21 unsupported keywords across 8
+    schemas, and almost every object node lacks additionalProperties."""
+    unsupported = leerie._STRICT_UNSUPPORTED_KEYWORDS
+    needed = 0
+    for schema in leerie.SCHEMAS.values():
+        blob = json.dumps(schema)
+        needed += sum(blob.count(f'"{k}"') for k in unsupported)
+    assert needed >= 15, f"expected the shipped schemas to need real fixing, found {needed}"
+
+
+# ----- fail-open -------------------------------------------------------------
+
+@pytest.mark.parametrize("label, payload", [
+    ("tool renamed", {"tools": [{"name": "Other", "input_schema": {"type": "object"}}]}),
+    ("tool absent", {"tools": []}),
+    ("tool duplicated", {"tools": [{"name": "StructuredOutput", "input_schema": {}},
+                                   {"name": "StructuredOutput", "input_schema": {}}]}),
+    ("no input_schema", {"tools": [{"name": "StructuredOutput"}]}),
+    ("input_schema not an object", {"tools": [{"name": "StructuredOutput",
+                                               "input_schema": "nope"}]}),
+    ("no tools key", {"messages": []}),
+    ("tools not a list", {"tools": "nope"}),
+])
+def test_unexpected_shapes_forward_unmodified(leerie, label, payload):
+    """An upstream rename must cost the guarantee, never the run."""
+    assert leerie._strictify_request(json.dumps(payload).encode()) is None, label
+
+
+def test_non_json_body_forwards_unmodified(leerie):
+    assert leerie._strictify_request(b"<html>not json</html>") is None
+
+
+def test_transform_does_not_touch_other_tools(leerie):
+    """The captured request carried 29 tools. Only ours may change."""
+    body = json.dumps({"tools": [
+        {"name": "Bash", "input_schema": {"type": "object",
+                                          "properties": {"command": {"type": "string",
+                                                                     "minLength": 1}}}},
+        {"name": "StructuredOutput", "input_schema": {"type": "object", "properties": {}}},
+    ]}).encode()
+    out = leerie._strictify_request(body)
+    assert out is not None
+    bash = json.loads(out[0])["tools"][0]
+    assert bash == json.loads(body)["tools"][0], "a non-target tool was modified"
+
+
+def test_strictify_schema_reports_what_it_changed(leerie):
+    """The counts feed the log line; a silent transform would make an upstream
+    change undiagnosable."""
+    schema = {"type": "object", "properties": {"s": {"type": "string", "minLength": 1}}}
+    hardened, stripped = leerie._strictify_schema(schema)
+    assert hardened == 1 and stripped == 1
+
+
+# ----- the proxy -------------------------------------------------------------
+#
+# Exercised against a mock upstream, so these never touch the network. The
+# hardening below is not defensive styling: a naive version of this proxy was
+# load-tested and failed two ways — 34 of 40 concurrent connections survived
+# (default executor saturation), and the port was not rebindable after
+# shutdown. Both are pinned here.
+
+import asyncio
+import socket
+import threading
+import http.server
+import socketserver
+
+
+class _MockUpstream(http.server.BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    def log_message(self, *a):
+        pass
+
+    def do_POST(self):
+        n = int(self.headers.get("content-length") or 0)
+        body = self.rfile.read(n)
+        # Echo back whether the request arrived with strict set, so the test
+        # can prove the transform survived the whole round trip.
+        strict = b'"strict": true' in body or b'"strict":true' in body
+        payload = json.dumps({"saw_strict": strict}).encode()
+        self.send_response(200)
+        self.send_header("content-type", "application/json")
+        self.send_header("content-length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+
+class _Pool(socketserver.ThreadingMixIn, http.server.HTTPServer):
+    daemon_threads = True
+    request_queue_size = 256
+
+
+@pytest.fixture()
+def mock_upstream():
+    srv = _Pool(("127.0.0.1", 0), _MockUpstream)
+    threading.Thread(target=srv.serve_forever, daemon=True).start()
+    yield f"http://127.0.0.1:{srv.server_address[1]}"
+    srv.shutdown()
+
+
+async def _post(port: int, body: bytes) -> bytes:
+    reader, writer = await asyncio.open_connection("127.0.0.1", port)
+    writer.write(b"POST /v1/messages HTTP/1.1\r\nhost: x\r\n"
+                 b"content-length: %d\r\n\r\n" % len(body) + body)
+    await writer.drain()
+    data = await reader.read(-1)
+    writer.close()
+    return data
+
+
+def test_proxy_binds_an_ephemeral_port_and_releases_it(leerie):
+    """Port 0 lets the OS pick, so concurrent leerie runs never collide. The
+    release half is the regression pin: the naive version left the port
+    unbindable, which breaks a second run in the same container."""
+    async def go():
+        p = leerie._StrictOutputProxy(max_parallel=5)
+        port = await p.start()
+        assert port > 0
+        await p.stop()
+        return port
+    port = asyncio.run(go())
+    s = socket.socket()
+    s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    try:
+        s.bind(("127.0.0.1", port))
+    finally:
+        s.close()
+
+
+def test_proxy_rewrites_the_request_end_to_end(leerie, mock_upstream, monkeypatch):
+    """The whole point: `strict` must actually reach the upstream."""
+    monkeypatch.setattr(leerie._StrictOutputProxy, "_UPSTREAM", mock_upstream)
+
+    async def go():
+        p = leerie._StrictOutputProxy(max_parallel=5)
+        port = await p.start()
+        try:
+            data = await _post(port, _wrap({"type": "object", "properties": {}}))
+        finally:
+            await p.stop()
+        return data, p
+    data, p = asyncio.run(go())
+    assert b'"saw_strict": true' in data
+    assert p.rewritten == 1 and p.passed_through == 0
+
+
+def test_proxy_forwards_unmodified_when_the_tool_is_renamed(leerie, mock_upstream,
+                                                            monkeypatch):
+    """Fail-open, end to end — the upstream must see no strict."""
+    monkeypatch.setattr(leerie._StrictOutputProxy, "_UPSTREAM", mock_upstream)
+
+    async def go():
+        p = leerie._StrictOutputProxy(max_parallel=5)
+        port = await p.start()
+        try:
+            data = await _post(port, _wrap({"type": "object"}, name="SomethingElse"))
+        finally:
+            await p.stop()
+        return data, p
+    data, p = asyncio.run(go())
+    assert b'"saw_strict": false' in data
+    assert p.rewritten == 0 and p.passed_through == 1
+
+
+@pytest.mark.parametrize("n", [5, 40])
+def test_proxy_survives_concurrent_workers(leerie, mock_upstream, monkeypatch, n):
+    """`max_parallel` defaults to 5 and is user-raisable, so the proxy sits in
+    the path of every concurrent worker. 40 is the width at which the naive
+    version lost 6 connections to executor saturation."""
+    monkeypatch.setattr(leerie._StrictOutputProxy, "_UPSTREAM", mock_upstream)
+
+    async def go():
+        p = leerie._StrictOutputProxy(max_parallel=n)
+        port = await p.start()
+        try:
+            body = _wrap({"type": "object", "properties": {}})
+            results = await asyncio.gather(
+                *[_post(port, body) for _ in range(n)], return_exceptions=True)
+        finally:
+            await p.stop()
+        return results
+    results = asyncio.run(go())
+    ok = [r for r in results if isinstance(r, bytes) and b'"saw_strict": true' in r]
+    assert len(ok) == n, f"only {len(ok)}/{n} concurrent connections completed"
+
+
+def test_one_aborted_connection_does_not_kill_the_listener(leerie, mock_upstream,
+                                                           monkeypatch):
+    """A worker being reaped mid-request must not take down the proxy every
+    other worker in the wave depends on."""
+    monkeypatch.setattr(leerie._StrictOutputProxy, "_UPSTREAM", mock_upstream)
+
+    async def go():
+        p = leerie._StrictOutputProxy(max_parallel=5)
+        port = await p.start()
+        try:
+            # Connect, send a partial request, then hang up.
+            r, w = await asyncio.open_connection("127.0.0.1", port)
+            w.write(b"POST /v1/messages HTTP/1.1\r\ncontent-length: 999\r\n\r\n{")
+            await w.drain()
+            w.close()
+            await asyncio.sleep(0.05)
+            # The listener must still serve a healthy request.
+            return await _post(port, _wrap({"type": "object", "properties": {}}))
+        finally:
+            await p.stop()
+    assert b'"saw_strict": true' in asyncio.run(go())
+
+
+# ----- flag resolution, collision guard, and the numeric bounds --------------
+
+def test_flag_defaults_off(leerie, tmp_path):
+    """Nothing about this feature may engage unless explicitly asked for."""
+    assert leerie.resolve_dangerously_force_strict_output(tmp_path, False) is False
+
+
+def test_flag_resolves_from_all_three_tiers(leerie, tmp_path, monkeypatch):
+    assert leerie.resolve_dangerously_force_strict_output(tmp_path, True) is True
+    monkeypatch.setenv(leerie.DANGEROUS_FORCE_STRICT_OUTPUT_ENV, "1")
+    assert leerie.resolve_dangerously_force_strict_output(tmp_path, False) is True
+    monkeypatch.delenv(leerie.DANGEROUS_FORCE_STRICT_OUTPUT_ENV)
+    (tmp_path / "leerie.toml").write_text("dangerously_force_strict_output = true\n")
+    assert leerie.resolve_dangerously_force_strict_output(tmp_path, False) is True
+
+
+def test_help_text_discloses_all_four_risks(leerie):
+    """The flag is where the risk is disclosed, so the disclosure is part of
+    the contract — not decoration that can be trimmed later."""
+    import inspect
+    src = inspect.getsource(leerie)
+    i = src.index('"--dangerously-force-strict-output"')
+    block = src[i:i + 2600]
+    # Rejoin adjacent string literals: the help text is written as many
+    # concatenated fragments, so phrases straddle source lines.
+    block = re.sub(r'"\s*\n\s*(f?)"', "", block)
+    for required in ("not documented for subscription auth",   # terms
+                     "no compatibility",                        # unversioned iface
+                     "fails OPEN",                              # silent loss
+                     "minLength",                               # stripped constraints
+                     "ANTHROPIC_BASE_URL",                      # side effects
+                     "Default is off"):
+        assert required in block, f"help text no longer discloses: {required}"
+
+
+def test_help_string_is_percent_escaped(leerie):
+    """argparse %-expands help strings, so a bare `%` raises 'badly formed
+    help string' and breaks `--help` for EVERY flag, not just this one. This
+    bit during development."""
+    import argparse
+    ap = argparse.ArgumentParser()
+    import inspect
+    src = inspect.getsource(leerie)
+    i = src.index('"--dangerously-force-strict-output"')
+    block = src[i:i + 2600]
+    assert "28.8%%" in block, "the percentage must be escaped as %% for argparse"
+
+
+def test_collision_with_operator_base_url_is_fatal(leerie):
+    """The flag owns ANTHROPIC_BASE_URL. Overriding a user's gateway silently
+    and silently skipping the requested guarantee are both wrong, so leerie
+    refuses and lets the operator choose."""
+    import inspect
+    src = inspect.getsource(leerie.main)
+    assert 'os.environ.get("ANTHROPIC_BASE_URL")' in src
+    assert "will not override" in src
+
+
+@pytest.mark.parametrize("value, expected", [
+    (0.8, 0.8),            # in range, untouched
+    (0.0, 0.0),
+    (1.0, 1.0),
+    (5.0, 0.0),            # impossible on a 0-1 axis -> conservative
+    (-2.0, 0.0),
+    (None, 0.0),
+    ("eight", 0.0),
+    (float("nan"), 0.0),
+    (float("inf"), 0.0),
+])
+def test_out_of_range_values_are_untrusted_not_clamped(leerie, value, expected):
+    """Clamping was tried and rejected: on a 0-1 axis it maps 5.0 to 1.0, which
+    still clears every threshold and preserves the permissive failure this
+    exists to prevent. The corpus shows the confusion is real — fit_judge
+    emitted `"fit": 8.5` on an axis declared 0-1."""
+    assert leerie._bounded_or_conservative(value, 0.0, 1.0, 0.0, "probe") == expected
+
+
+def test_a_bad_score_cannot_clear_the_fit_threshold(leerie):
+    """The property that matters, stated directly against the real cap."""
+    threshold = leerie.DEFAULT_CAPS["decompose_fit_threshold"]
+    bogus = leerie._bounded_or_conservative(8.5, 0.0, 1.0, 0.0, "probe")
+    assert bogus < threshold, "an uninterpretable score cleared the fit gate"
+
+
+def test_every_documented_range_guard_is_wired(leerie):
+    """Source-coupling: the helper is inert if a call site reads the raw value
+    again. There are exactly three numeric bounds in `SCHEMAS`, and the docs
+    name all three — this asserts all three, not a subset.
+
+    Regression: the earlier version of this test asserted two of the three, and
+    `provision.recipe[].timeout_s` was documented as guarded while being wired
+    nowhere. A test that covers a subset of a documented contract is how that
+    survived seven audit passes.
+    """
+    import inspect
+    for fn in (leerie._recursive_decompose,        # fit_judge.score
+               leerie.phase_adherence_gate,        # instruction_adherence
+               leerie._recipe_timeout_s):          # provision timeout_s
+        assert "_bounded_or_conservative(" in inspect.getsource(fn), (
+            f"{fn.__name__} does not use the guard")
+
+
+def test_the_three_guards_match_the_schemas_numeric_bounds(leerie):
+    """Anti-drift: if a new `minimum`/`maximum` is added to any schema, strict
+    mode will strip it and it needs a guard too. Fails when the count moves."""
+    found = []
+
+    def walk(node, path):
+        if isinstance(node, dict):
+            if "minimum" in node or "maximum" in node:
+                found.append(path)
+            for k, v in node.items():
+                walk(v, f"{path}/{k}")
+        elif isinstance(node, list):
+            for v in node:
+                walk(v, path)
+
+    for name, schema in leerie.SCHEMAS.items():
+        walk(schema, name)
+    assert len(found) == 3, (
+        f"schemas now carry {len(found)} range-bounded fields, not 3: {found}. "
+        "Strict mode strips these — each needs a _bounded_or_conservative guard "
+        "and a line in DESIGN §7 / IMPLEMENTATION.md.")
+
+
+def test_recipe_timeout_rejects_a_negative_but_keeps_a_sane_value(leerie):
+    """`minimum: 1` is stripped under the flag. `0` was already absorbed by the
+    old `or 1800` fallback, but a negative is *truthy* and would have reached
+    `wait_for(timeout=-5.0)`, firing instantly — a provisioning step failing for
+    no visible reason."""
+    default = leerie._PROVISION_TIMEOUT_DEFAULT_S
+    assert leerie._recipe_timeout_s({"timeout_s": 600, "command": ["x"]}) == 600
+    assert leerie._recipe_timeout_s({"timeout_s": -5, "command": ["x"]}) == default
+    assert leerie._recipe_timeout_s({"timeout_s": 0, "command": ["x"]}) == default
+    assert leerie._recipe_timeout_s({"command": ["x"]}) == default
+    # Above the worker wall-clock cap: a step cannot outlive the worker.
+    over = float(leerie.DEFAULT_CAPS["worker_timeout_sec"]) + 1
+    assert leerie._recipe_timeout_s({"timeout_s": over, "command": ["x"]}) == default
+    # An explicit ceiling is honoured over the default cap.
+    assert leerie._recipe_timeout_s({"timeout_s": 3000, "command": ["x"]}, 100) == default
+
+
+def test_both_recipe_timeout_consumers_go_through_the_guard(leerie):
+    """The guard is worthless if either consumer still reads the raw field."""
+    import inspect
+    for fn in (leerie._format_provision_recipe_section,
+               leerie._capture_conformance_baseline):
+        src = inspect.getsource(fn)
+        assert "_recipe_timeout_s(" in src, f"{fn.__name__} bypasses the guard"
+        assert 'get("timeout_s")' not in src, (
+            f"{fn.__name__} still reads timeout_s directly")
+
+
+def test_worker_env_gets_the_base_url_only_when_the_proxy_is_running(leerie):
+    """Default-off proof at the injection seam: no proxy, no variable."""
+    import inspect
+    src = inspect.getsource(leerie)
+    i = src.index('worker_env["ANTHROPIC_BASE_URL"]')
+    window = src[max(0, i - 400):i]
+    assert "_STRICT_PROXY is not None" in window
+
+
+# --------------------------------------------------------------------------
+# Transport: every verb and every body framing must survive the hop.
+#
+# Only POST bodies are ever rewritten, so everything below is about the proxy
+# not corrupting what it was never supposed to touch. Both defects these pin
+# were live in the first implementation.
+# --------------------------------------------------------------------------
+
+
+class _RecordingUpstream(http.server.BaseHTTPRequestHandler):
+    """Echoes back the method, path and body it actually received."""
+
+    protocol_version = "HTTP/1.1"
+    seen: list = []
+
+    def log_message(self, *a):
+        pass
+
+    def _reply(self):
+        n = int(self.headers.get("content-length") or 0)
+        body = self.rfile.read(n) if n else b""
+        type(self).seen.append({
+            "method": self.command, "path": self.path, "body": body,
+            # Lowercased names only: the point of recording these is to prove a
+            # header did not survive, and the survivor's casing is the variable.
+            "headers": {k.lower(): v for k, v in self.headers.items()},
+        })
+        payload = json.dumps({"method": self.command, "len": len(body)}).encode()
+        self.send_response(200)
+        self.send_header("content-type", "application/json")
+        self.send_header("content-length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+    do_GET = do_POST = do_DELETE = _reply
+
+
+@pytest.fixture()
+def recording_upstream():
+    _RecordingUpstream.seen = []
+    srv = _Pool(("127.0.0.1", 0), _RecordingUpstream)
+    threading.Thread(target=srv.serve_forever, daemon=True).start()
+    yield f"http://127.0.0.1:{srv.server_address[1]}", _RecordingUpstream.seen
+    srv.shutdown()
+
+
+async def _raw(port: int, wire: bytes) -> bytes:
+    """Send a hand-built request so the framing is under the test's control."""
+    reader, writer = await asyncio.open_connection("127.0.0.1", port)
+    writer.write(wire)
+    await writer.drain()
+    data = await reader.read(-1)
+    writer.close()
+    return data
+
+
+@pytest.mark.parametrize("method", ["GET", "DELETE"])
+def test_non_post_verbs_reach_upstream_as_themselves(leerie, recording_upstream,
+                                                     monkeypatch, method):
+    """Regression: `_upstream` hardcoded `method="POST"`, so any other verb the
+    CLI issues (model listing, token counting, telemetry) was replayed upstream
+    as a POST. The transform already branched on the method; the hop did not."""
+    url, seen = recording_upstream
+    monkeypatch.setattr(leerie._StrictOutputProxy, "_UPSTREAM", url)
+
+    async def go():
+        p = leerie._StrictOutputProxy(max_parallel=5)
+        port = await p.start()
+        try:
+            return await _raw(port, b"%s /v1/models HTTP/1.1\r\nhost: x\r\n\r\n"
+                              % method.encode())
+        finally:
+            await p.stop()
+    data = asyncio.run(go())
+    assert seen and seen[0]["method"] == method, (
+        f"upstream saw {seen[0]['method'] if seen else 'nothing'}, not {method}")
+    assert seen[0]["body"] == b"", "a bodyless verb acquired a body"
+    assert b'"method": "%s"' % method.encode() in data
+
+
+def test_post_still_reaches_upstream_as_post(leerie, recording_upstream,
+                                             monkeypatch):
+    """Anti-vacuity control for the parametrized test above: threading the
+    method through must not have broken the one verb that always worked."""
+    url, seen = recording_upstream
+    monkeypatch.setattr(leerie._StrictOutputProxy, "_UPSTREAM", url)
+
+    async def go():
+        p = leerie._StrictOutputProxy(max_parallel=5)
+        port = await p.start()
+        try:
+            return await _post(port, _wrap({"type": "object", "properties": {}}))
+        finally:
+            await p.stop()
+    asyncio.run(go())
+    assert seen[0]["method"] == "POST"
+    assert b'"strict"' in seen[0]["body"]
+
+
+def _chunked_wire(path: bytes, body: bytes, chunk: int) -> bytes:
+    """A request framed with `Transfer-Encoding: chunked` and no length."""
+    out = bytearray(b"POST " + path + b" HTTP/1.1\r\nhost: x\r\n"
+                    b"transfer-encoding: chunked\r\n\r\n")
+    for i in range(0, len(body), chunk):
+        piece = body[i:i + chunk]
+        out += b"%X\r\n" % len(piece) + piece + b"\r\n"
+    out += b"0\r\n\r\n"
+    return bytes(out)
+
+
+@pytest.mark.parametrize("chunk", [7, 4096])
+def test_chunked_request_body_arrives_whole(leerie, recording_upstream,
+                                            monkeypatch, chunk):
+    """Regression: body length came solely from `content-length`, so a chunked
+    request read as length 0 and forwarded whatever landed in the first packet —
+    a silently truncated request, which surfaces downstream as a model error
+    rather than a proxy bug. Today's CLI always sends `content-length`, but that
+    is an observation about one client version, not a guarantee.
+
+    Two chunk sizes: 7 forces many chunks and a mid-chunk read boundary; 4096
+    covers the single-chunk case.
+    """
+    url, seen = recording_upstream
+    monkeypatch.setattr(leerie._StrictOutputProxy, "_UPSTREAM", url)
+    body = json.dumps({"filler": "x" * 20_000}).encode()
+
+    async def go():
+        p = leerie._StrictOutputProxy(max_parallel=5)
+        port = await p.start()
+        try:
+            return await _raw(port, _chunked_wire(b"/v1/messages", body, chunk))
+        finally:
+            await p.stop()
+    asyncio.run(go())
+    assert seen, "the chunked request never reached upstream"
+    assert seen[0]["body"] == body, (
+        f"upstream saw {len(seen[0]['body'])} of {len(body)} bytes")
+
+
+def test_chunked_body_is_not_forwarded_with_its_framing(leerie, recording_upstream,
+                                                        monkeypatch):
+    """The de-chunk is load-bearing, not decorative: urllib recomputes
+    `content-length` for the upstream hop, so forwarding the raw framing would
+    describe a body that is not what it says it is."""
+    url, seen = recording_upstream
+    monkeypatch.setattr(leerie._StrictOutputProxy, "_UPSTREAM", url)
+    body = b'{"a": 1}'
+
+    async def go():
+        p = leerie._StrictOutputProxy(max_parallel=5)
+        port = await p.start()
+        try:
+            await _raw(port, _chunked_wire(b"/v1/messages", body, 3))
+        finally:
+            await p.stop()
+        return p
+    p = asyncio.run(go())
+    assert seen[0]["body"] == body
+    assert b"\r\n" not in seen[0]["body"], "chunk framing leaked into the body"
+    assert json.loads(seen[0]["body"]) == {"a": 1}
+    # Never rewritten: this path is untested against the real CLI, so the
+    # fail-open discipline applies to it too.
+    assert p.rewritten == 0 and p.passed_through == 1
+
+
+# --------------------------------------------------------------------------
+# Logging: the proxy shares the orchestrator's log stream.
+# --------------------------------------------------------------------------
+
+
+class _ErrorUpstream(http.server.BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    def log_message(self, *a):
+        pass
+
+    def do_POST(self):
+        n = int(self.headers.get("content-length") or 0)
+        self.rfile.read(n)
+        payload = json.dumps({"error": {
+            "message": "tools.18.custom.input_schema: additionalProperties "
+                       "must be false at #/properties/collisions"}}).encode()
+        self.send_response(400)
+        self.send_header("content-type", "application/json")
+        self.send_header("content-length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+
+@pytest.fixture()
+def error_upstream():
+    srv = _Pool(("127.0.0.1", 0), _ErrorUpstream)
+    threading.Thread(target=srv.serve_forever, daemon=True).start()
+    yield f"http://127.0.0.1:{srv.server_address[1]}"
+    srv.shutdown()
+
+
+def _run_against(leerie, port_url, monkeypatch, n: int, verbosity: str):
+    """Drive `n` requests through a proxy and return the captured log lines."""
+    monkeypatch.setattr(leerie._StrictOutputProxy, "_UPSTREAM", port_url)
+    lines: list[str] = []
+    monkeypatch.setattr(leerie, "log", lambda m: lines.append(m))
+
+    async def go():
+        p = leerie._StrictOutputProxy(max_parallel=5, verbosity=verbosity)
+        port = await p.start()
+        try:
+            body = _wrap({"type": "object", "properties": {}})
+            for _ in range(n):
+                await _post(port, body)
+        finally:
+            await p.stop()
+        return p
+    return asyncio.run(go()), lines
+
+
+@pytest.mark.parametrize("verbosity", ["quiet", "normal", "stream", "debug"])
+def test_upstream_errors_are_logged_at_every_verbosity(leerie, error_upstream,
+                                                       monkeypatch, verbosity):
+    """This proxy is the only thing in the path that rewrites a request, so a
+    4xx here is most likely leerie's own edit being rejected — and the response
+    names the offending schema path. Suppressing it at low verbosity would leave
+    the operator watching workers retry, which is exactly the misattribution the
+    flag's failure mode consists of."""
+    p, lines = _run_against(leerie, error_upstream, monkeypatch, 1, verbosity)
+    hits = [l for l in lines if "upstream 400" in l]
+    assert len(hits) == 1, f"no upstream-error line at verbosity={verbosity}"
+    assert "additionalProperties must be false" in hits[0], (
+        "the response body carries the offending schema path — it must survive")
+    assert p.upstream_errors == 1
+
+
+def test_upstream_error_echoes_are_budgeted(leerie, error_upstream, monkeypatch):
+    """A rejected rewrite is systematic: every worker call fails the same way.
+    The first few carry all the diagnostic value; echoing the rest would bury
+    the run log the proxy shares with every other leerie line."""
+    n = leerie._STRICT_PROXY_ERROR_LOG_MAX + 4
+    p, lines = _run_against(leerie, error_upstream, monkeypatch, n, "stream")
+    echoed = [l for l in lines if "upstream 400" in l]
+    assert len(echoed) == leerie._STRICT_PROXY_ERROR_LOG_MAX
+    assert any("counted, not echoed" in l for l in lines)
+    # Counted in full even when not echoed — the summary must not under-report.
+    assert p.upstream_errors == n
+
+
+def test_per_request_lines_are_debug_only(leerie, mock_upstream, monkeypatch):
+    """One line per worker API call is far too much for normal output, and the
+    end-of-run summary already covers the aggregate."""
+    _, debug = _run_against(leerie, mock_upstream, monkeypatch, 2, "debug")
+    _, stream = _run_against(leerie, mock_upstream, monkeypatch, 2, "stream")
+    assert len([l for l in debug if "-> 200" in l]) == 2
+    assert [l for l in stream if "-> 200" in l] == []
+    assert any("strict:true" in l for l in debug), (
+        "the debug line must say what the transform did, not just that it ran")
+
+
+def test_the_transform_description_is_not_discarded(leerie):
+    """`_strictify_request` builds a description of exactly what it changed and
+    the first implementation threw it away into `_desc`, contradicting its own
+    docstring. It must reach the log."""
+    import inspect
+    src = inspect.getsource(leerie._StrictOutputProxy._handle)
+    assert "body, desc = swap" in src
+    assert "_log_exchange" in src
+
+
+def test_claude_md_documents_the_flag_with_its_mirrors(leerie):
+    """CLAUDE.md's Quick start is where the user-facing flag surface is
+    enumerated, and it is loaded into context every session. Both sibling
+    dangerous flags are documented there."""
+    import pathlib
+    text = (pathlib.Path(__file__).resolve().parents[1] / "CLAUDE.md").read_text()
+    assert "--dangerously-force-strict-output" in text
+    assert leerie.DANGEROUS_FORCE_STRICT_OUTPUT_ENV in text
+    assert "dangerously_force_strict_output = true" in text
+    assert "DANGEROUS" in text.split("--dangerously-force-strict-output")[0][-1200:], (
+        "the Quick start entry must carry the risk, not just the flag name")
+
+
+# --------------------------------------------------------------------------
+# Bedrock: the second collision, same contract as ANTHROPIC_BASE_URL.
+# --------------------------------------------------------------------------
+
+
+def _main_guard_src(leerie) -> str:
+    import inspect
+    return inspect.getsource(leerie.main)
+
+
+def test_bedrock_collision_is_fatal(leerie):
+    """`ANTHROPIC_BASE_URL` is the *first-party* endpoint override and the
+    proxy's upstream is hardcoded to api.anthropic.com. Under Bedrock the flag
+    is either inert — the CLI never contacts the proxy and the operator is
+    silently handed the post-hoc validation they asked to replace — or it
+    misroutes every worker call. Neither is distinguishable from a healthy run
+    in the log, so it must die() rather than warn."""
+    src = _main_guard_src(leerie)
+    assert "AWS_BEARER_TOKEN_BEDROCK" in src
+    assert "CLAUDE_CODE_USE_BEDROCK" in src
+    # It must be a die(), not a log/warn: silently proceeding is the failure.
+    i = src.index("AWS_BEARER_TOKEN_BEDROCK")
+    assert "die(" in src[i:i + 1600], "the Bedrock collision does not die()"
+
+
+def test_bedrock_guard_accepts_the_launchers_truthy_spellings(leerie):
+    """`detect_bedrock_mode()` in the launcher accepts 1/true/yes/on. A guard
+    that only matched `"1"` would miss a settings.json-driven Bedrock run."""
+    src = _main_guard_src(leerie)
+    i = src.index("CLAUDE_CODE_USE_BEDROCK")
+    window = src[i:i + 400]
+    for spelling in ('"1"', '"true"', '"yes"', '"on"'):
+        assert spelling in window, f"truthy spelling {spelling} not accepted"
+    assert ".lower()" in window, "the match is case-sensitive"
+
+
+def test_bedrock_guard_is_gated_on_the_flag(leerie):
+    """Bedrock alone is a fully supported configuration (CLAUDE.md documents
+    both auth paths). Only the *combination* is refused."""
+    src = _main_guard_src(leerie)
+    i = src.index("bedrock_via")
+    assert 'caps["force_strict_output"] and bedrock_via' in src[i:], (
+        "the guard must fire only when the flag is also on")
+
+
+def test_both_collision_guards_name_the_same_contract(leerie):
+    """Both refusals exist for one reason — the operator asked for a guarantee
+    and must never be silently denied it. The wording carries that."""
+    src = _main_guard_src(leerie)
+    assert src.count("will not silently run without the constrained") == 2
+
+
+# --------------------------------------------------------------------------
+# Transport, continued: counters and header casing.
+# --------------------------------------------------------------------------
+
+
+def test_chunked_non_post_does_not_count_as_passed_through(leerie,
+                                                           recording_upstream,
+                                                           monkeypatch):
+    """`passed_through` drives the operator warning that constrained decoding
+    was lost. A GET was never a candidate for it, so counting one raises a false
+    alarm about the flag's single most important failure mode."""
+    url, seen = recording_upstream
+    monkeypatch.setattr(leerie._StrictOutputProxy, "_UPSTREAM", url)
+
+    async def go():
+        p = leerie._StrictOutputProxy(max_parallel=5)
+        port = await p.start()
+        try:
+            await _raw(port, _chunked_wire(b"/v1/models", b"", 8).replace(
+                b"POST ", b"GET ", 1))
+        finally:
+            await p.stop()
+        return p
+    p = asyncio.run(go())
+    assert seen and seen[0]["method"] == "GET"
+    assert p.passed_through == 0, "a chunked GET was counted as passed-through"
+    assert p.rewritten == 0
+
+
+def test_chunked_post_still_counts_as_passed_through(leerie, recording_upstream,
+                                                     monkeypatch):
+    """Anti-vacuity control: the POST case must still count, or the assertion
+    above would pass against a counter that never increments at all."""
+    url, _ = recording_upstream
+    monkeypatch.setattr(leerie._StrictOutputProxy, "_UPSTREAM", url)
+
+    async def go():
+        p = leerie._StrictOutputProxy(max_parallel=5)
+        port = await p.start()
+        try:
+            await _raw(port, _chunked_wire(b"/v1/messages", b'{"a":1}', 3))
+        finally:
+            await p.stop()
+        return p
+    assert asyncio.run(go()).passed_through == 1
+
+
+@pytest.mark.parametrize("casing", [
+    b"Transfer-Encoding", b"transfer-encoding", b"TRANSFER-ENCODING",
+    b"Transfer-encoding",
+])
+def test_transfer_encoding_is_stripped_case_insensitively(leerie,
+                                                          recording_upstream,
+                                                          monkeypatch, casing):
+    """Header names are case-insensitive on the wire. A casing that survived
+    would reach upstream beside urllib's computed content-length, and a request
+    carrying both framing headers is a smuggling shape servers reject.
+
+    The earlier fix popped two literal spellings, so `TRANSFER-ENCODING` got
+    through; the exclusion list two lines above was already case-insensitive.
+    """
+    url, seen = recording_upstream
+    monkeypatch.setattr(leerie._StrictOutputProxy, "_UPSTREAM", url)
+    body = b'{"a": 1}'
+    wire = _chunked_wire(b"/v1/messages", body, 3).replace(
+        b"transfer-encoding: chunked", casing + b": chunked", 1)
+    assert casing + b": chunked" in wire, "the casing rewrite did not apply"
+
+    async def go():
+        p = leerie._StrictOutputProxy(max_parallel=5)
+        port = await p.start()
+        try:
+            await _raw(port, wire)
+        finally:
+            await p.stop()
+    asyncio.run(go())
+    assert seen, f"the {casing.decode()} request never reached upstream"
+    assert seen[0]["body"] == body, "body truncated or framing leaked through"
+    # The load-bearing assertion. Checking only the body is vacuous: http.server
+    # honours content-length regardless, so the body arrives intact even when a
+    # stray transfer-encoding rides along. Verified by reintroducing the
+    # literal-spelling pops — the body assertion alone passes for all casings.
+    assert "transfer-encoding" not in seen[0]["headers"], (
+        f"{casing.decode()} survived to upstream beside content-length "
+        f"({seen[0]['headers'].get('transfer-encoding')!r}) — a request with "
+        "both framing headers is an RFC 7230 smuggling shape")
+
+
+def test_no_transfer_encoding_header_survives_to_upstream(leerie):
+    """Structural pin for the mechanism, not just the outcome: the exclusion
+    happens in the case-insensitive list rather than via literal pops."""
+    import inspect
+    src = inspect.getsource(leerie._StrictOutputProxy._handle)
+    assert '"transfer-encoding"' in src
+    assert 'headers.pop("Transfer-Encoding"' not in src, (
+        "literal-spelling pops are case-sensitive; use the lower()ed list")
+
+
+@pytest.mark.parametrize("env, expected", [
+    ({}, ""),
+    ({"AWS_BEARER_TOKEN_BEDROCK": "tok"}, "AWS_BEARER_TOKEN_BEDROCK"),
+    ({"CLAUDE_CODE_USE_BEDROCK": "1"}, "CLAUDE_CODE_USE_BEDROCK"),
+    ({"CLAUDE_CODE_USE_BEDROCK": "TRUE"}, "CLAUDE_CODE_USE_BEDROCK"),
+    ({"CLAUDE_CODE_USE_BEDROCK": " yes "}, "CLAUDE_CODE_USE_BEDROCK"),
+    ({"CLAUDE_CODE_USE_BEDROCK": "on"}, "CLAUDE_CODE_USE_BEDROCK"),
+    ({"CLAUDE_CODE_USE_BEDROCK": "0"}, ""),
+    ({"CLAUDE_CODE_USE_BEDROCK": "false"}, ""),
+    ({"CLAUDE_CODE_USE_BEDROCK": ""}, ""),
+    ({"AWS_BEARER_TOKEN_BEDROCK": "", "CLAUDE_CODE_USE_BEDROCK": "1"},
+     "CLAUDE_CODE_USE_BEDROCK"),
+])
+def test_bedrock_detection_behaviour(leerie, env, expected):
+    """Behavioural coverage of the classifier itself, not just its source text.
+
+    `main()` cannot be driven here (it parses argv, resolves a repo, and dies),
+    so the detection block is extracted verbatim and executed against a
+    controlled environment — the same technique
+    `tests/test_launcher_env_forwarding.py` uses for launcher fragments.
+
+    An empty `AWS_BEARER_TOKEN_BEDROCK` must not shadow a truthy
+    `CLAUDE_CODE_USE_BEDROCK`: the launcher exports the former unconditionally
+    on some paths, and a guard that reported the wrong variable would send the
+    operator to unset something that was never set.
+    """
+    import inspect
+    src = inspect.getsource(leerie.main)
+    start = src.index("    bedrock_via = (")
+    end = src.index('    if caps["force_strict_output"] and bedrock_via:')
+    block = src[start:end].strip()
+    assert "bedrock_via" in block and len(block) < 500, "extraction drifted"
+    ns = {"os": type("_O", (), {"environ": dict(env)})}
+    exec(block, ns)  # noqa: S102 - executing our own extracted source
+    assert ns["bedrock_via"] == expected


### PR DESCRIPTION
## Why

`claude -p --json-schema` **validates** worker output after generation and re-prompts on a miss — it does not constrain sampling. Confirmed from a captured outbound request (2026-08-04): the CLI injects the schema as a synthetic `StructuredOutput` tool with **`strict` absent** and no `output_config`.

Measured across the run corpus, **2,861 of 9,924 submissions (28.8%) are malformed** as a direct result, in exactly the shapes the vendor documents as the cost of omitting strict mode:

| shape | count |
|---|---|
| payload wrapped in a protocol-vocabulary container key (`{"input": …}`, `{"output": …}`) | 1,648 |
| required fields simply absent | 752 |
| bytes the CLI cannot parse at all | 261 |
| decoder flipping to legacy XML mid-value | 136 |

None of these is the model being unable to do the work — the answers are usually correct and merely unreachable, which is why the CLI's re-prompt loop recovers most of them at the cost of regenerating the payload.

## What

`--dangerously-force-strict-output` (**off by default**) starts a per-run loopback proxy, points workers at it via `ANTHROPIC_BASE_URL`, and sets `strict: true` on the injected tool — compiling the schema into a sampling grammar so those shapes become *unrepresentable* rather than merely rarer.

Two live experiments established this works on subscription auth: injecting `strict` alone returned 400 with a **schema** complaint (not a permissions one); adding `additionalProperties: false` returned 200 with valid output.

## Why it's `--dangerously-`

It edits requests leerie does not own. The injected tool is a private, unversioned interface, and schema keywords the grammar cannot express are stripped. Disclosed in `--help`, CLAUDE.md, DESIGN §7 and IMPLEMENTATION.md.

- **Fail-open on the transform** — tool renamed, absent, duplicated, or wrong shape → forwarded byte-identical. An upstream rename costs the guarantee, not the run.
- **Fail-closed on the listener** — cannot bind → `die()`, never a quiet downgrade to unconstrained.
- **Two fatal collisions**, because both would silently deny the guarantee the operator asked for: a pre-set `ANTHROPIC_BASE_URL` (the flag works by owning it), and **Bedrock** (`AWS_BEARER_TOKEN_BEDROCK` / `CLAUDE_CODE_USE_BEDROCK`), which routes through its own endpoint override — so the flag there would either be inert or misroute every worker call to `api.anthropic.com`.

## Proxy design

Each choice was forced by a measured failure, not taste:

| property | why |
|---|---|
| ephemeral port (bind `0`) | concurrent leerie runs on one host must not collide |
| dedicated executor, `max_parallel + 8` | the default pool saturates — 34 of 40 concurrent connections survived; 40/40 and 80/80 once bounded |
| `reuse_address` + writer drain on shutdown | the port was otherwise unbindable, breaking a second run in the same container |
| client hang-ups caught per connection | the CLI hangs up routinely once it has what it needs |
| upstream bridged through `urllib` | leerie has no async HTTP dependency (stdlib-preferred); hand-rolled HTTP/1.1 is where a proxy in the path of every worker call acquires subtle bugs |

## Logging

Proxy activity streams into the orchestrator's own log — same stream as every other leerie line, no separate file.

**Upstream errors are logged at every verbosity, with the response body.** This proxy is the only thing in the path that rewrites a request, so a 4xx is most likely leerie's own edit being rejected — and the body names the offending schema path. Suppressing it would leave the operator watching workers retry, which is precisely the misattribution this flag's failure mode consists of. Success lines are debug-only (`-vv`); error echoes cap at 3 while the count stays complete.

## Stripped bounds are re-imposed in Python

Of the 21 stripped keywords, 16 are string-length bounds whose consumers already test truthiness. The 5 numeric ones fail **permissively** — `if score >= threshold` reads an out-of-range score as well-fit — so `fit_judge.score`, `adherence_judge.instruction_adherence` and `provision.recipe[].timeout_s` go through `_bounded_or_conservative`, unconditionally (a value outside its declared range was always a worker bug).

Out-of-range returns the conservative end rather than clamping: on a 0–1 axis, clamping `5.0` to `1.0` still clears every threshold and preserves the exact permissive failure the guard exists to prevent. The corpus shows the confusion is real — `fit_judge` emitted `"fit": 8.5` on an axis declared 0–1.

## Testing

**77 new tests** in `tests/test_strict_output_proxy.py`; **210 passing** across the affected set.

Every guard is falsified live — the defect reintroduced, the failure observed, then reverted:

| guard | falsification |
|---|---|
| method passthrough | GET/DELETE replayed as POST → 2 failures |
| chunked body | length-only read → 3 failures, one showing 8,192 of 20,015 bytes arriving |
| Bedrock collision | guard removed → 4 failures; case-sensitive match → 4 failures |
| `timeout_s` range | wiring reverted → source-coupling failure |
| `passed_through` counter | non-POST counted → 1 failure |
| `Transfer-Encoding` casing | literal-spelling pops → fails on exactly the 2 casings they miss, passes on the 2 they catch |

Two of my own checks were broken and caught during this work: an F4 falsification patch silently no-opped on whitespace (fixed by asserting the patch applied), and the F4 test was **vacuous** — asserting only on the body, which arrives intact either way since `http.server` honours `content-length` regardless. Rewritten to assert on the headers that actually reached upstream.

Full suite not run (repo standing instruction: never run two copies concurrently on one host).

## Not yet verified

The proxy has **not** run against a real worker with a real leerie schema — only a 1-node schema live. The decisive check is re-running a real task with the flag against the 0.9.105 baseline (13.5% wasted retries, 12 failing submissions, 0 never-valid); success is anomalies → ~0. It must be run on subscription auth, not Bedrock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
