### PR TITLE
fix(strict-output): report what happened, not the worst it could mean

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -4935,11 +4935,23 @@ edits. Everything else in the request is forwarded untouched.
 
 Two properties make that safe to run in the path of every worker call.
 
-**It fails open.** If the tool is renamed, absent, duplicated, or shaped
-unexpectedly — all of which an upstream release may do without notice — the
-request is forwarded unmodified. The run continues exactly as it would without
-the flag; the guarantee is lost, not the run. That loss is logged, because the
+**It fails open.** If the tool is renamed, duplicated, or shaped unexpectedly —
+all of which an upstream release may do without notice — the request is
+forwarded unmodified. The run continues exactly as it would without the flag;
+the guarantee is lost, not the run. That loss is reported, because the
 dangerous failure here is a silent one.
+
+A request that simply carries no such tool is **not** one of those losses, and
+is deliberately not reported: the CLI injects the tool only on turns that ask
+for structured output, so a multi-turn worker always makes some requests
+without it — measured, roughly a quarter to a third of them. Treating those as
+suspected upstream changes made a healthy run describe itself as broken.
+
+The rename case needs its own mechanism, because per request it is
+indistinguishable from that ordinary traffic: both yield no matching tool.
+Across a run it is not — every worker is invoked with a schema, so if anything
+was proxied at all, something must have carried the tool. A run that rewrote
+*nothing* is therefore reported as a probable rename, once, at the end.
 
 **It fails closed at startup.** If the listener cannot bind, the run dies rather
 than proceeding unconstrained, so an operator who asked for the guarantee is

--- a/docs/IMPLEMENTATION.md
+++ b/docs/IMPLEMENTATION.md
@@ -3389,6 +3389,12 @@ because the CLI injects the tool only on turns that want structured output),
 (400s, the flag's own failure mode) and `transient_errors` (429/5xx, unrelated
 to the rewrite). Echo budgets are **per class**.
 
+A **renamed** tool is caught separately, at run level: it yields no matching
+tool per request, exactly like an ordinary turn that never asked for structured
+output, so it cannot be classified where the other shape problems are. If a run
+ends having rewritten nothing while requests were proxied, the summary reports
+a probable rename — once, so it cannot reintroduce per-request false positives.
+
 Recorded because the merged form shipped and misled on the first real run: 395
 rewrites, zero 400s and zero fallbacks reported themselves as *"the injected
 tool may have changed upstream … the rewrite itself may be being rejected;

--- a/docs/IMPLEMENTATION.md
+++ b/docs/IMPLEMENTATION.md
@@ -3377,9 +3377,26 @@ port mapping.
 | method | parsed from the request line and threaded to `_upstream` | only POST bodies are rewritten; every other verb the CLI issues must reach upstream as itself |
 | chunked request body | decoded by `_read_chunked`, never rewritten | a chunked body carries no `content-length`, so a length-driven read forwards only the first packet — a silently truncated request, which reads downstream as a model error rather than a proxy bug |
 
-**Logging.** The proxy runs in the orchestrator process, so `log()` from the
-handler interleaves with every other leerie line — there is no separate proxy
-log to go find. Three levels, emitted by `_log_exchange`:
+**Logging reports categories, never a merged total.** The proxy runs in the
+orchestrator process, so `log()` from the handler interleaves with every other
+leerie line — there is no separate proxy log to go find.
+
+Four counters, deliberately not merged: `passed_through` (no `StructuredOutput`
+tool in the request — ordinary multi-turn traffic, measured at ~25-30% of POSTs
+because the CLI injects the tool only on turns that want structured output),
+`unexpected_tool_shape` (the tool IS present but duplicated or missing its
+`input_schema` — the only pass-through worth warning about), `schema_errors`
+(400s, the flag's own failure mode) and `transient_errors` (429/5xx, unrelated
+to the rewrite). Echo budgets are **per class**.
+
+Recorded because the merged form shipped and misled on the first real run: 395
+rewrites, zero 400s and zero fallbacks reported themselves as *"the injected
+tool may have changed upstream … the rewrite itself may be being rejected;
+re-run without the flag to confirm"*. Three transient 529s had also consumed
+the whole shared echo budget, so a genuine 400 — carrying the API's own message
+naming the offending schema path — would have been counted rather than shown.
+A summary that cries wolf on a healthy run is worse than none: it sends the
+operator chasing nothing and devalues the warning for when it is real. Three levels, emitted by `_log_exchange`:
 
 | when | verbosity | line |
 |---|---|---|

--- a/orchestrator/leerie.py
+++ b/orchestrator/leerie.py
@@ -25566,6 +25566,20 @@ async def _orchestrate(args, caps: dict, leerie_dir: Path, st: State,
                      f"{_p.passed_through} without a StructuredOutput tool "
                      f"(normal — the CLI injects it only on turns that ask "
                      f"for structured output)"]
+            # A RENAMED tool is invisible per-request — it yields zero hits,
+            # exactly like an ordinary turn that never asked for structured
+            # output — so it cannot be caught where the other shape problems
+            # are. Across a whole run it is visible: leerie passes
+            # `--json-schema` to every worker, so if anything was proxied at
+            # all, something must have carried the tool. Nothing rewritten
+            # means the tool is renamed or gone, and the flag has been silently
+            # doing nothing. Fires once per run, so it cannot reintroduce the
+            # per-request false positives this summary exists to remove.
+            if _p.rewritten == 0 and _p.passed_through:
+                parts.append(
+                    "NOTHING was rewritten — the injected tool appears to have "
+                    f"been renamed or removed (expected `{_STRICT_OUTPUT_TOOL_NAME}`). "
+                    "No worker got constrained decoding this run")
             if _p.unexpected_tool_shape:
                 parts.append(
                     f"{_p.unexpected_tool_shape} request(s) carried a "

--- a/orchestrator/leerie.py
+++ b/orchestrator/leerie.py
@@ -11295,7 +11295,6 @@ class _StrictOutputProxy:
         self.port = 0
         self.rewritten = 0
         self.passed_through = 0
-        self.upstream_errors = 0
         self.fell_back = 0
         # Split deliberately. Merging these is what made a clean run describe
         # itself as suspect: `unexpected_tool_shape` is the only pass-through
@@ -11403,7 +11402,6 @@ class _StrictOutputProxy:
         (`-vv`): one per worker API call is far too much for normal output.
         """
         if status >= 400:
-            self.upstream_errors += 1
             # Budget PER CLASS. A shared budget is not a milder version of this
             # — it is a different, broken thing: measured live, three transient
             # 529s in the first minutes consumed the whole allowance, so a
@@ -11536,11 +11534,6 @@ class _StrictOutputProxy:
             # keeps the run, which is the same trade the request-side fail-open
             # already makes. Only 400 is retried: 401/403/429 are not schema
             # problems and the original would fail identically.
-            if status == 400:
-                self.schema_errors += 1
-            elif status >= 400:
-                self.transient_errors += 1
-
             if original is not None and status == 400:
                 self._unhardenable.add(fingerprint or "")
                 self.fell_back += 1
@@ -11554,6 +11547,19 @@ class _StrictOutputProxy:
                     self._pool, self._upstream, method.upper(), path,
                     original, headers)
                 desc = "fell back: schema will not compile"
+
+            # Classified on the FINAL status, deliberately — after any
+            # fallback, not before. A 400 the fallback absorbs ends at 200 and
+            # is counted nowhere here, because `fell_back` already reports it
+            # once and correctly; counting it again as an unhandled rejection
+            # would send the operator to "re-run without the flag to confirm" a
+            # problem the proxy just resolved itself. A 400 that survives the
+            # fallback, or one on a request we never rewrote, is genuinely
+            # unhandled and is ours to raise.
+            if status == 400:
+                self.schema_errors += 1
+            elif status >= 400:
+                self.transient_errors += 1
             self._log_exchange(method.upper(), path, status, desc, payload)
 
             out = [f"HTTP/1.1 {status} X".encode("latin-1")]

--- a/orchestrator/leerie.py
+++ b/orchestrator/leerie.py
@@ -11196,6 +11196,38 @@ def _api_error_head(payload: bytes, limit: int = 160) -> str:
     return " ".join(str(text).split())[:limit]
 
 
+def _unexpected_structured_output_shape(body: bytes) -> bool:
+    """True only when a `StructuredOutput` tool is PRESENT but unusable.
+
+    `_strictify_request` declines for several reasons, and they are not equally
+    interesting. The overwhelmingly common one is that the request simply
+    carries no `StructuredOutput` tool — measured against a real 4-turn worker,
+    one of its four `/v1/messages` POSTs arrives with *no tools array at all*,
+    because the CLI injects the tool only on the turns where it wants
+    structured output. That is ordinary traffic and says nothing about anything.
+
+    The interesting case is a tool that IS there and is shaped wrong —
+    duplicated, or missing its `input_schema`. That is the "the private
+    interface changed upstream" signal, and it is what the operator warning
+    exists for. Merging the two made a healthy run report 173 pass-throughs as
+    a suspected upstream change.
+    """
+    try:
+        payload = json.loads(body)
+    except Exception:
+        return False
+    if not isinstance(payload, dict):
+        return False
+    tools = payload.get("tools")
+    if not isinstance(tools, list):
+        return False
+    hits = [t for t in tools
+            if isinstance(t, dict) and t.get("name") == _STRICT_OUTPUT_TOOL_NAME]
+    if not hits:
+        return False          # no tool at all — normal
+    return len(hits) > 1 or not isinstance(hits[0].get("input_schema"), dict)
+
+
 def _structured_output_fingerprint(body: bytes) -> str | None:
     """Stable id for the schema a request carries, or None if it carries none.
 
@@ -11265,6 +11297,13 @@ class _StrictOutputProxy:
         self.passed_through = 0
         self.upstream_errors = 0
         self.fell_back = 0
+        # Split deliberately. Merging these is what made a clean run describe
+        # itself as suspect: `unexpected_tool_shape` is the only pass-through
+        # worth warning about, and `schema_errors` the only upstream error the
+        # flag can be responsible for.
+        self.unexpected_tool_shape = 0
+        self.schema_errors = 0
+        self.transient_errors = 0
         # Schemas the API refuses to compile into a grammar. Measured: 2 of
         # leerie's 23 (`planner`, `reconciler`) — both carry 12 optional
         # properties inside array items, and strict mode must accept every
@@ -11365,15 +11404,34 @@ class _StrictOutputProxy:
         """
         if status >= 400:
             self.upstream_errors += 1
-            if self.upstream_errors <= _STRICT_PROXY_ERROR_LOG_MAX:
-                snippet = " ".join(
-                    payload[:_STRICT_PROXY_ERROR_BODY_MAX]
-                    .decode("utf-8", "replace").split())
-                log(f"  strict-output proxy: upstream {status} on {method} "
-                    f"{path} ({desc or 'not rewritten'}) — {snippet}")
-                if self.upstream_errors == _STRICT_PROXY_ERROR_LOG_MAX:
-                    log("  strict-output proxy: further upstream errors will "
-                        "be counted, not echoed (see the end-of-run summary)")
+            # Budget PER CLASS. A shared budget is not a milder version of this
+            # — it is a different, broken thing: measured live, three transient
+            # 529s in the first minutes consumed the whole allowance, so a
+            # later genuine 400 (carrying the API's own message naming the
+            # offending schema path) would have been silently counted instead
+            # of shown. Overload noise must not starve the one channel that can
+            # diagnose this flag.
+            schema_shaped = status == 400
+            seen = self.schema_errors if schema_shaped else self.transient_errors
+            if seen <= _STRICT_PROXY_ERROR_LOG_MAX:
+                if schema_shaped:
+                    # The body names the offending path; it is the whole
+                    # diagnostic, so it is echoed rather than summarised.
+                    snippet = " ".join(
+                        payload[:_STRICT_PROXY_ERROR_BODY_MAX]
+                        .decode("utf-8", "replace").split())
+                    log(f"  strict-output proxy: upstream 400 on {method} "
+                        f"{path} ({desc or 'not rewritten'}) — {snippet}")
+                else:
+                    # Capacity or throttling — nothing to do with the rewrite.
+                    # Say so, so it is not mistaken for one.
+                    log(f"  strict-output proxy: upstream {status} on {method} "
+                        f"{path} — transient (not a schema rejection); "
+                        "retried upstream")
+                if seen == _STRICT_PROXY_ERROR_LOG_MAX:
+                    kind = "schema" if schema_shaped else "transient"
+                    log(f"  strict-output proxy: further {kind} errors will be "
+                        "counted, not echoed (see the end-of-run summary)")
         elif self._verbosity == "debug":
             log(f"  strict-output proxy: {method} {path} -> {status} "
                 f"({desc or 'forwarded unmodified'})")
@@ -11428,9 +11486,9 @@ class _StrictOutputProxy:
             # rewrite a body that arrived on this untested path.
             if chunked:
                 body = await self._read_chunked(reader, rest)
-                # Counted only for POST, matching the branch below: the counter
-                # drives an operator warning that the constrained-decoding
-                # guarantee was lost, and a GET was never a candidate for it.
+                # Counted only for POST, matching the branch below: a GET was
+                # never a candidate for constrained decoding, so counting one
+                # would inflate the pass-through total for no reason.
                 if method.upper() == "POST":
                     self.passed_through += 1
             else:
@@ -11454,6 +11512,11 @@ class _StrictOutputProxy:
                             self.rewritten += 1
                         else:
                             self.passed_through += 1
+                            # Only a PRESENT-but-unusable tool is worth an
+                            # operator warning; a request with no tool at all
+                            # is ordinary multi-turn traffic.
+                            if _unexpected_structured_output_shape(body):
+                                self.unexpected_tool_shape += 1
 
             loop = asyncio.get_running_loop()
             status, up_headers, payload = await loop.run_in_executor(
@@ -11473,6 +11536,11 @@ class _StrictOutputProxy:
             # keeps the run, which is the same trade the request-side fail-open
             # already makes. Only 400 is retried: 401/403/429 are not schema
             # problems and the original would fail identically.
+            if status == 400:
+                self.schema_errors += 1
+            elif status >= 400:
+                self.transient_errors += 1
+
             if original is not None and status == 400:
                 self._unhardenable.add(fingerprint or "")
                 self.fell_back += 1
@@ -25480,18 +25548,38 @@ async def _orchestrate(args, caps: dict, leerie_dir: Path, st: State,
             # The pass-through count is the only signal that the private tool
             # interface changed under us: the run still succeeds, but silently
             # without the guarantee it was asked for.
-            log(f"strict output: {_STRICT_PROXY.rewritten} request(s) "
-                f"rewritten, {_STRICT_PROXY.passed_through} passed through"
-                + (" — passed-through requests did NOT get constrained "
-                   "decoding; the injected tool may have changed upstream"
-                   if _STRICT_PROXY.passed_through else "")
-                + (f", {_STRICT_PROXY.fell_back} schema(s) fell back to "
-                   f"post-hoc validation (would not compile into a grammar)"
-                   if _STRICT_PROXY.fell_back else "")
-                + (f", {_STRICT_PROXY.upstream_errors} upstream error(s) — "
-                   f"the rewrite itself may be being rejected; re-run without "
-                   f"the flag to confirm"
-                   if _STRICT_PROXY.upstream_errors else ""))
+            # Report each category as itself. The previous single-sentence
+            # form described every pass-through as a possible upstream change
+            # and every upstream error as a possible rewrite rejection — so a
+            # run with 395 successful rewrites, zero 400s and zero fallbacks
+            # announced itself as suspect and pointed at a re-run to "confirm"
+            # a problem that did not exist. A summary that cries wolf on a
+            # healthy run is worse than no summary.
+            _p = _STRICT_PROXY
+            parts = [f"strict output: {_p.rewritten} request(s) rewritten, "
+                     f"{_p.passed_through} without a StructuredOutput tool "
+                     f"(normal — the CLI injects it only on turns that ask "
+                     f"for structured output)"]
+            if _p.unexpected_tool_shape:
+                parts.append(
+                    f"{_p.unexpected_tool_shape} request(s) carried a "
+                    "StructuredOutput tool leerie could not use (duplicated, "
+                    "or no input_schema) — those did NOT get constrained "
+                    "decoding, and the injected tool may have changed upstream")
+            if _p.fell_back:
+                parts.append(
+                    f"{_p.fell_back} schema(s) fell back to post-hoc "
+                    "validation (would not compile into a grammar)")
+            if _p.schema_errors:
+                parts.append(
+                    f"{_p.schema_errors} schema rejection(s) — the rewrite "
+                    "itself is being rejected; re-run without the flag to "
+                    "confirm")
+            if _p.transient_errors:
+                parts.append(
+                    f"{_p.transient_errors} transient upstream error(s) "
+                    "(rate-limit/overload, unrelated to the rewrite)")
+            log("; ".join(parts))
             await _STRICT_PROXY.stop()
             _STRICT_PROXY = None
 

--- a/tests/test_strict_output_proxy.py
+++ b/tests/test_strict_output_proxy.py
@@ -818,7 +818,7 @@ def _run_against(leerie, port_url, monkeypatch, n: int, verbosity: str):
 
 
 @pytest.mark.parametrize("verbosity", ["quiet", "normal", "stream", "debug"])
-def test_upstream_errors_are_logged_at_every_verbosity(leerie, error_upstream,
+def test_schema_errors_are_logged_at_every_verbosity(leerie, error_upstream,
                                                        monkeypatch, verbosity):
     """This proxy is the only thing in the path that rewrites a request, so a
     4xx here is most likely leerie's own edit being rejected — and the response
@@ -1835,3 +1835,64 @@ def test_no_write_only_error_counter_survives(leerie):
         "the merged total is back — nothing reads it once the classes split")
     p = leerie._StrictOutputProxy(max_parallel=1)
     assert not hasattr(p, "upstream_errors")
+
+
+def _summary_for(leerie, **counters) -> str:
+    """Render the end-of-run summary for a given set of counters."""
+    import inspect
+    src = inspect.getsource(leerie._orchestrate)
+    start = src.index("_p = _STRICT_PROXY")
+    end = src.index('log("; ".join(parts))') + len('log("; ".join(parts))')
+    block = "\n".join(l[12:] if l.startswith(" " * 12) else l
+                      for l in src[start:end].splitlines())
+    base = {"rewritten": 0, "passed_through": 0, "unexpected_tool_shape": 0,
+            "fell_back": 0, "schema_errors": 0, "transient_errors": 0}
+    base.update(counters)
+    out: list[str] = []
+    exec(block, {"_STRICT_PROXY": type("F", (), base), "log": out.append,
+                 "_STRICT_OUTPUT_TOOL_NAME": leerie._STRICT_OUTPUT_TOOL_NAME})
+    return out[0]
+
+
+def test_a_renamed_tool_is_indistinguishable_per_request(leerie):
+    """Pinned deliberately, so the two mechanisms are not confused later.
+
+    A renamed tool yields no matching hit — exactly like an ordinary turn that
+    never asked for structured output. There is no per-request signal to
+    separate them, which is why the rename check lives at run level instead.
+    """
+    renamed = json.dumps({"model": "m", "messages": [], "tools": [
+        {"name": "StructuredOutputV2", "description": "d",
+         "input_schema": {"type": "object", "properties": {}}}]}).encode()
+    ordinary = json.dumps({"model": "m", "messages": [], "tools": [
+        {"name": "Bash", "input_schema": {}}]}).encode()
+    assert leerie._unexpected_structured_output_shape(renamed) is False
+    assert leerie._unexpected_structured_output_shape(ordinary) is False
+
+
+def test_a_run_that_rewrote_nothing_reports_a_probable_rename(leerie):
+    """DESIGN §7 requires a renamed tool to be reported — "the dangerous
+    failure here is a silent one". Suppressing the per-request false positives
+    removed that signal, so it is restored at run level: leerie passes a schema
+    to every worker, so if anything was proxied, something must have carried
+    the tool. Nothing rewritten means the flag silently did nothing all run."""
+    summary = _summary_for(leerie, rewritten=0, passed_through=50)
+    assert "NOTHING was rewritten" in summary
+    assert "renamed or removed" in summary
+    assert leerie._STRICT_OUTPUT_TOOL_NAME in summary
+
+
+def test_a_healthy_run_never_reports_a_rename(leerie):
+    """Anti-vacuity: the whole point of the change was to stop warning on
+    ordinary pass-throughs, so a run that rewrote anything must stay quiet no
+    matter how many tool-free requests it saw."""
+    summary = _summary_for(leerie, rewritten=395, passed_through=173,
+                           transient_errors=14)
+    assert "NOTHING was rewritten" not in summary
+    assert "renamed or removed" not in summary
+
+
+def test_no_proxied_requests_at_all_is_not_a_rename(leerie):
+    """A run where the proxy saw nothing proves nothing about the tool — the
+    warning must key on `passed_through`, not fire on an empty run."""
+    assert "NOTHING was rewritten" not in _summary_for(leerie)

--- a/tests/test_strict_output_proxy.py
+++ b/tests/test_strict_output_proxy.py
@@ -1618,3 +1618,142 @@ def test_recommendation_marker_survives_the_vocabulary_change(leerie):
     assert any(leerie._matches_recommendation(o, rec) for o in options), (
         "no rendered option matched the recommendation — _format_must_include "
         "and _matches_recommendation have drifted apart")
+
+
+# --------------------------------------------------------------------------
+# Self-reporting: say what happened, not the worst thing it could mean.
+#
+# The first real run rewrote 395 requests with zero 400s and zero fallbacks,
+# and reported itself as: "173 passed through — ... the injected tool may have
+# changed upstream, 14 upstream error(s) — the rewrite itself may be being
+# rejected; re-run without the flag to confirm."
+#
+# Every clause was false. One root cause, three symptoms: counters merged
+# distinct categories and the summary then described the merged total using
+# the alarming interpretation. A summary that cries wolf on a healthy run is
+# worse than no summary — it sends the operator chasing a problem that is not
+# there, and it devalues the warning for when it is real.
+# --------------------------------------------------------------------------
+
+
+def test_a_request_with_no_tool_is_not_alarming(leerie):
+    """Measured against a real 4-turn worker: one of its four /v1/messages
+    POSTs arrives with NO tools array at all, because the CLI injects
+    StructuredOutput only on turns that want structured output. 173 of these
+    in the real run. Ordinary traffic."""
+    body = json.dumps({"model": "m", "messages": [],
+                       "tools": [{"name": "Bash", "input_schema": {}}]}).encode()
+    assert leerie._unexpected_structured_output_shape(body) is False
+    assert leerie._unexpected_structured_output_shape(b'{"model":"m"}') is False
+    assert leerie._unexpected_structured_output_shape(b"not json") is False
+
+
+@pytest.mark.parametrize("tools, why", [
+    ([{"name": "StructuredOutput", "input_schema": {}},
+      {"name": "StructuredOutput", "input_schema": {}}], "duplicated"),
+    ([{"name": "StructuredOutput"}], "no input_schema"),
+    ([{"name": "StructuredOutput", "input_schema": "not-a-dict"}],
+     "input_schema is not an object"),
+])
+def test_a_present_but_unusable_tool_is_alarming(leerie, tools, why):
+    """THIS is what the warning was written for — the private, unversioned
+    interface changing shape under us."""
+    body = json.dumps({"model": "m", "messages": [], "tools": tools}).encode()
+    assert leerie._unexpected_structured_output_shape(body) is True, why
+
+
+def test_transient_errors_do_not_starve_the_schema_echo_budget(leerie,
+                                                               monkeypatch):
+    """The regression the real run demonstrated: three 529s consumed the whole
+    allowance, so a later genuine 400 — carrying the API's own message naming
+    the offending schema path — would have been counted, not shown."""
+    lines: list[str] = []
+    monkeypatch.setattr(leerie, "log", lambda m: lines.append(m))
+    p = leerie._StrictOutputProxy(max_parallel=2)
+
+    over = json.dumps({"error": {"message": "Overloaded"}}).encode()
+    for _ in range(leerie._STRICT_PROXY_ERROR_LOG_MAX + 2):
+        p.transient_errors += 1
+        p._log_exchange("POST", "/v1/messages", 529, "", over)
+
+    lines.clear()
+    body = json.dumps({"error": {"message":
+                                 "tools.0.custom: additionalProperties "
+                                 "must be false at #/properties/x"}}).encode()
+    p.schema_errors += 1
+    p._log_exchange("POST", "/v1/messages", 400, "strict:true", body)
+
+    hits = [l for l in lines if "upstream 400" in l]
+    assert len(hits) == 1, "the 400 was swallowed by the transient budget"
+    assert "additionalProperties must be false at #/properties/x" in hits[0], (
+        "the API's own diagnostic must survive — it names the offending path")
+
+
+def test_a_transient_error_is_not_described_as_a_rejection(leerie, monkeypatch):
+    """A 529 has nothing to do with the rewrite; saying it might be sends the
+    operator to re-run without the flag to 'confirm' an unrelated outage."""
+    lines: list[str] = []
+    monkeypatch.setattr(leerie, "log", lambda m: lines.append(m))
+    p = leerie._StrictOutputProxy(max_parallel=2)
+    p.transient_errors += 1
+    p._log_exchange("POST", "/v1/messages", 529, "",
+                    json.dumps({"error": {"message": "Overloaded"}}).encode())
+    assert any("transient (not a schema rejection)" in l for l in lines)
+    assert not any("rejected" in l and "not a schema rejection" not in l
+                   for l in lines)
+
+
+def test_the_healthy_run_summary_makes_no_accusation(leerie):
+    """Replays the real run's exact shape — 395 rewrites, 173 tool-free
+    requests, 14 transient errors, 0 schema errors, 0 fallbacks — and asserts
+    the summary reads as the clean run it was."""
+    import inspect
+    src = inspect.getsource(leerie._orchestrate)
+    start = src.index("_p = _STRICT_PROXY")
+    end = src.index('log("; ".join(parts))') + len('log("; ".join(parts))')
+    block = "\n".join(l[12:] if l.startswith(" " * 12) else l
+                      for l in src[start:end].splitlines())
+
+    class Fake:
+        rewritten, passed_through = 395, 173
+        unexpected_tool_shape = fell_back = schema_errors = 0
+        transient_errors = 14
+    out: list[str] = []
+    exec(block, {"_STRICT_PROXY": Fake, "log": out.append})
+    summary = out[0]
+
+    assert "395 request(s) rewritten" in summary
+    assert "may have changed upstream" not in summary, (
+        "accused the upstream interface of changing on a healthy run")
+    assert "may be being rejected" not in summary, (
+        "accused the rewrite of being rejected with zero schema errors")
+    assert "re-run without the flag" not in summary, (
+        "sent the operator to re-run to confirm a problem that did not exist")
+    assert "transient" in summary and "unrelated to the rewrite" in summary
+
+
+def test_the_unhealthy_run_summary_still_accuses(leerie):
+    """Anti-vacuity: the warnings must still fire when they are true, or the
+    fix is just deletion."""
+    import inspect
+    src = inspect.getsource(leerie._orchestrate)
+    start = src.index("_p = _STRICT_PROXY")
+    end = src.index('log("; ".join(parts))') + len('log("; ".join(parts))')
+    block = "\n".join(l[12:] if l.startswith(" " * 12) else l
+                      for l in src[start:end].splitlines())
+
+    class Fake:
+        rewritten, passed_through = 10, 3
+        unexpected_tool_shape, fell_back = 4, 1
+        schema_errors, transient_errors = 2, 0
+    out: list[str] = []
+    exec(block, {"_STRICT_PROXY": Fake, "log": out.append})
+    summary = out[0]
+
+    assert "may have changed upstream" in summary
+    # Deliberately definite, not hedged: with schema_errors > 0 the rewrite IS
+    # being rejected. The hedge belongs on the upstream-shape claim (inferred
+    # from a private interface), not on a count of observed 400s.
+    assert "the rewrite itself is being rejected" in summary
+    assert "re-run without the flag" in summary
+    assert "fell back to post-hoc validation" in summary

--- a/tests/test_strict_output_proxy.py
+++ b/tests/test_strict_output_proxy.py
@@ -830,7 +830,7 @@ def test_upstream_errors_are_logged_at_every_verbosity(leerie, error_upstream,
     assert len(hits) == 1, f"no upstream-error line at verbosity={verbosity}"
     assert "additionalProperties must be false" in hits[0], (
         "the response body carries the offending schema path — it must survive")
-    assert p.upstream_errors == 1
+    assert p.schema_errors == 1
 
 
 def test_upstream_error_echoes_are_budgeted(leerie, error_upstream, monkeypatch):
@@ -843,7 +843,10 @@ def test_upstream_error_echoes_are_budgeted(leerie, error_upstream, monkeypatch)
     assert len(echoed) == leerie._STRICT_PROXY_ERROR_LOG_MAX
     assert any("counted, not echoed" in l for l in lines)
     # Counted in full even when not echoed — the summary must not under-report.
-    assert p.upstream_errors == n
+    # `schema_errors`, not a merged total: these are 400s on requests that were
+    # never rewritten (the fixture's tool is unnamed), so the fallback does not
+    # absorb them and they are genuinely ours to raise.
+    assert p.schema_errors == n
 
 
 def test_per_request_lines_are_debug_only(leerie, mock_upstream, monkeypatch):
@@ -1757,3 +1760,78 @@ def test_the_unhealthy_run_summary_still_accuses(leerie):
     assert "the rewrite itself is being rejected" in summary
     assert "re-run without the flag" in summary
     assert "fell back to post-hoc validation" in summary
+
+
+def test_an_absorbed_fallback_is_not_also_an_unhandled_rejection(leerie,
+                                                                 rejecting_upstream,
+                                                                 monkeypatch):
+    """A 400 the fallback resolves is reported ONCE, as `fell_back`.
+
+    Counting it again as a schema rejection produces:
+
+        1 schema(s) fell back to post-hoc validation …;
+        1 schema rejection(s) — the rewrite itself is being rejected;
+        re-run without the flag to confirm
+
+    Both clauses describe the same event, and the second sends the operator to
+    chase a problem the proxy already resolved. That is the exact failure this
+    whole change set exists to remove, reintroduced one layer down — the
+    classification therefore keys on the FINAL status, after any fallback.
+    """
+    url, _ = rejecting_upstream
+    monkeypatch.setattr(leerie._StrictOutputProxy, "_UPSTREAM", url)
+
+    async def go():
+        p = leerie._StrictOutputProxy(max_parallel=5)
+        port = await p.start()
+        try:
+            await _post(port, _wrap({"type": "object", "properties": {}}))
+        finally:
+            await p.stop()
+        return p
+    p = asyncio.run(go())
+    assert p.fell_back == 1, "the fallback did not fire"
+    assert p.schema_errors == 0, (
+        "an absorbed 400 was also counted as an unhandled schema rejection")
+
+
+def test_a_fallback_that_does_not_help_is_still_raised(leerie, monkeypatch):
+    """Anti-vacuity for the test above: if the retried original ALSO fails, the
+    fallback did not save the run and the operator must still hear about it."""
+    calls = []
+
+    def always_400(self, method, path, body, headers):
+        calls.append(body)
+        return 400, [], json.dumps(
+            {"error": {"message": "Schema is too complex."}}).encode()
+
+    monkeypatch.setattr(leerie._StrictOutputProxy, "_upstream", always_400)
+
+    async def go():
+        p = leerie._StrictOutputProxy(max_parallel=5)
+        port = await p.start()
+        try:
+            await _post(port, _wrap({"type": "object", "properties": {}}))
+        finally:
+            await p.stop()
+        return p
+    p = asyncio.run(go())
+    assert len(calls) == 2, "expected the hardened attempt plus the retry"
+    assert p.fell_back == 1
+    assert p.schema_errors == 1, (
+        "a 400 that survived the fallback must still be raised")
+
+
+def test_no_write_only_error_counter_survives(leerie):
+    """`upstream_errors` was a merged total nothing read once the classes were
+    split — state kept alive only by the tests asserting on it. The file's
+    stated goal is that the control flow reads top-to-bottom in one sitting."""
+    import inspect
+    import pathlib
+    # `inspect.getsource` on the class fails when leerie is imported from a
+    # path the linecache cannot resolve; read the module file directly.
+    src = pathlib.Path(inspect.getfile(leerie)).read_text()
+    assert "upstream_errors" not in src, (
+        "the merged total is back — nothing reads it once the classes split")
+    p = leerie._StrictOutputProxy(max_parallel=1)
+    assert not hasattr(p, "upstream_errors")


### PR DESCRIPTION
## What the first real run said about itself

`--dangerously-force-strict-output` rewrote **395 requests, 0 schema 400s, 0 fallbacks**, and produced **0 of 161 malformed submissions** (`parsed_ok=False`) against a measured baseline of **274/7,604 (3.6%)** across 100 prior runs. Then it reported:

```
173 passed through — passed-through requests did NOT get constrained decoding;
  the injected tool may have changed upstream, 14 upstream error(s) —
  the rewrite itself may be being rejected; re-run without the flag to confirm
```

Every clause was false. One root cause, three symptoms: **counters merged distinct categories, and the summary described the merged total using the alarming interpretation.**

## F1 — `passed_through` merged ordinary with alarming

Settled by instrumenting the classifier against a real 4-turn worker:

```
   3  rewritten (tool present + usable)
   1  normal: no StructuredOutput among 0 tools
ALARMING pass-throughs: 0
```

The CLI injects `StructuredOutput` **only on turns that want structured output**, so a multi-turn worker always makes some POSTs without it. 1-of-4 POSTs there; 173-of-568 in the real run — same structural cause, **zero** alarming cases.

`_unexpected_structured_output_shape` now separates them. Only a tool that is *present but unusable* (duplicated, or missing `input_schema`) warns — that being the actual "private interface changed upstream" signal.

## F2 — `upstream_errors` merged transient with schema rejection

A `529 Overloaded` has nothing to do with the rewrite, and "re-run without the flag to confirm" diagnoses an unrelated outage. Split into `schema_errors` (400) and `transient_errors` (429/5xx).

## F3 — the echo budget was shared, and starved the channel that matters

Observed live: **three transient 529s consumed the entire allowance** in the first minutes, so any later genuine 400 — carrying the API's own message naming the offending schema path — would have been counted rather than shown.

There's an irony worth recording: F3 is *why* F2 was hard to verify. The budget bug hid the evidence needed to characterise the errors.

Budgets are now per class.

## Same run, reported honestly

```
strict output: 395 request(s) rewritten, 173 without a StructuredOutput tool
(normal — the CLI injects it only on turns that ask for structured output);
14 transient upstream error(s) (rate-limit/overload, unrelated to the rewrite)
```

## Tests

Six, **each falsified by reverting its own fix**. Two carry the weight:

- `test_transient_errors_do_not_starve_the_schema_echo_budget` — the regression the run demonstrated: a 400 arriving after a burst of 529s is still echoed *with its body*
- `test_the_unhealthy_run_summary_still_accuses` — anti-vacuity. The warnings must still fire when true, or this is just deletion.

125 tests in the affected set, 185 reconciler tests.

## Scope

**Not a behaviour change to the rewrite.** No request is treated differently — only described differently. Worth fixing anyway: a summary that cries wolf on a healthy run sends the operator chasing nothing, and devalues the warning for when it is real.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
