### PR TITLE
fix(reconcile): stop an empty normalized tag key acting as a wildcard

### DIFF
--- a/orchestrator/leerie.py
+++ b/orchestrator/leerie.py
@@ -16916,9 +16916,18 @@ def _demote_unresolvable_with_external_twin(
         e["tag"]: e for e in external_preconditions if e.get("tag")
     }
     # Exact wins, so normalization can never perturb existing behavior.
+    # An EMPTY normalized key is skipped on both sides: `_REQUIRES_ITEM`'s
+    # `tag` carries no `minLength`, so `"---"` and `"___"` are both
+    # schema-valid and both normalize to frozenset() — which would make the
+    # empty key a wildcard pairing any two degenerate tags. Exact matching
+    # still handles them correctly; only the normalized pass needs the
+    # guard. Same class of hole as the empty-`tag_or_dep` guard in
+    # `_repair_missing_requires` (DESIGN §5).
     normalized: dict[frozenset[str], dict] = {}
     for tag in sorted(exact):
-        normalized.setdefault(_tag_key(tag), exact[tag])
+        key = _tag_key(tag)
+        if key:
+            normalized.setdefault(key, exact[tag])
 
     demoted: list[dict] = []
     for entry in unresolvable_entries:
@@ -16928,7 +16937,8 @@ def _demote_unresolvable_with_external_twin(
         twin = exact.get(tag)
         match = "exact"
         if twin is None:
-            twin = normalized.get(_tag_key(tag))
+            key = _tag_key(tag)
+            twin = normalized.get(key) if key else None
             match = "singularized"
         if twin is None:
             continue

--- a/tests/test_demote_unresolvable_twin.py
+++ b/tests/test_demote_unresolvable_twin.py
@@ -159,6 +159,50 @@ class TestNormalizerIsDiscriminating:
         assert out == []
 
 
+class TestDegenerateTagsAreNotAWildcard:
+    """`_REQUIRES_ITEM`'s `tag` carries no `minLength`, so `"---"` and `"___"`
+    are both schema-valid and both normalize to `frozenset()`. Without a guard
+    the empty key is a WILDCARD pairing any two degenerate tags — demoting a
+    real graph edge to a deploy note, the one failure this rule must not have.
+
+    Same class of hole as the empty-`tag_or_dep` guard in
+    `_repair_missing_requires`, which CLAUDE.md records for the same reason.
+    """
+
+    def test_empty_normalized_key_does_not_pair_two_degenerate_tags(self, leerie):
+        assert leerie._tag_key("---") == leerie._tag_key("___") == frozenset()
+        plans = _plans_with("test-1", "___")
+        out = leerie._demote_unresolvable_with_external_twin(
+            plans, [{"sid": "test-1", "tag": "___"}],
+            [_external("---", "feat-001", "degenerate")])
+        assert out == [], "empty normalized key must not act as a wildcard"
+        assert plans[0]["subtasks"][0]["requires"][0]["extent"] == "in_plan"
+
+    def test_a_degenerate_tag_never_pairs_a_real_one(self, leerie):
+        plans = _plans_with("test-1", "---")
+        out = leerie._demote_unresolvable_with_external_twin(
+            plans, [{"sid": "test-1", "tag": "---"}], INCIDENT_EXTERNALS)
+        assert out == []
+
+    def test_exact_match_on_a_degenerate_tag_still_works(self, leerie):
+        """The guard is scoped to the NORMALIZED pass. An exact string match
+        on the same tag is unambiguous and must still demote."""
+        plans = _plans_with("test-1", "---")
+        out = leerie._demote_unresolvable_with_external_twin(
+            plans, [{"sid": "test-1", "tag": "---"}],
+            [_external("---", "feat-001", "degenerate but exact")])
+        assert len(out) == 1 and out[0]["match"] == "exact"
+
+    def test_real_tags_still_pair_after_the_guard(self, leerie):
+        """Anti-vacuity: the guard must not disable normalized matching."""
+        plans = _plans_with("test-013", "webhook-event-types-schema-settled")
+        out = leerie._demote_unresolvable_with_external_twin(
+            plans, [{"sid": "test-013",
+                     "tag": "webhook-event-types-schema-settled"}],
+            INCIDENT_EXTERNALS)
+        assert len(out) == 1 and out[0]["match"] == "singularized"
+
+
 class TestExactWinsOverNormalized:
     def test_exact_match_is_preferred(self, leerie):
         """Normalization must never perturb a case exact matching handles."""


### PR DESCRIPTION
Follow-up hardening on #160, found while auditing the merged result.

## The hole

`_REQUIRES_ITEM`'s `tag` is declared as bare `{"type": "string"}` — **no `minLength`**. So `"---"` and `"___"` are both schema-valid capability tags, and both normalize to `frozenset()` under `_tag_key`:

```python
>>> _tag_key("---") == _tag_key("___") == frozenset()
True
```

The singularized pass looked that key up unconditionally, so the empty key acted as a **wildcard pairing any two degenerate tags** — demoting a real `in_plan` edge to a mere deploy note. That false pairing is precisely the failure mode `_demote_unresolvable_with_external_twin` is documented as not having, and the reason its matcher was deliberately narrowed to set-equality rather than partial token overlap in the first place.

## The fix

Skip the empty key on both sides — when building the normalized index and when looking a tag up.

Exact matching is untouched and still handles degenerate tags correctly, since `"---" == "---"` is unambiguous. Only the normalized pass needed the guard.

## Prior art

This is the same class of hole as the empty-`tag_or_dep` guard in `_repair_missing_requires`, which exists for exactly this reason — CLAUDE.md records it as *"the schema carries no `minLength`, and a subtask declaring `provides: [""]` would otherwise make the tag channel synthesize a meaningless empty-tag edge."* The repo has been bitten by this once already.

## Verification

- **Falsified live**: reverting the guard fails `test_empty_normalized_key_does_not_pair_two_degenerate_tags`. A guard whose test can't fail is not a guard.
- **Anti-vacuity**: `test_real_tags_still_pair_after_the_guard` proves the guard did not simply disable normalized matching — `webhook-event-types-schema-settled` still pairs with `webhook-event-type-schema-settled`.
- **Scope control**: `test_exact_match_on_a_degenerate_tag_still_works` proves the guard does not over-reach into the exact pass.
- **No behavioural change in the real world**: the replay harness against every recorded run still rescues exactly 2 of 6 fatal entries. This closes a latent hole; it does not move the measured outcome.
- 283 targeted tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)