### PR TITLE
chore(release): 0.10.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "leerie",
       "source": ".",
-      "version": "0.10.0",
+      "version": "0.10.1",
       "description": "Deterministic, headless task orchestrator for Claude Code. Classifies a task, decomposes it into dependency-ordered waves, and executes each subtask in an isolated git worktree under an evidence-gated implement/validate loop. Runs entirely on the Claude Code CLI/subscription via `claude -p` workers."
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "leerie",
   "displayName": "Leerie",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Deterministic, headless task orchestrator for Claude Code. Classifies a task, decomposes it into granular subtasks, schedules them into dependency-ordered waves, and executes each in an isolated git worktree under an evidence-gated implement/validate loop. Runs entirely on the Claude Code CLI/subscription via `claude -p` workers.",
   "author": { "name": "Andres Restrepo", "email": "andres@enricai.com", "url": "https://enricai.com" },
   "license": "MIT",


### PR DESCRIPTION
Patch release delivering the coverage-gate fix. **0.10.0 shipped a judge that never ran** — installs on 0.10.0 do not have it.

## What's in it

**#167 — the task-coverage judge never ran under 0.10.0.** `phase_planning_coverage_gate` called `claude_p` with two positionals plus a duplicate `system_prompt=`, and omitted the required `allowed_tools`/`max_turns`. It raised `TypeError` on every invocation and a broad `except Exception` logged it as a clean advisory degrade, so the log line read like a healthy path. Four defects fixed in that one call, plus:

- `st.bump_workers(caps)` was missing — the invocation was invisible to `max_total_workers` (IMPLEMENTATION.md §8 requires it; `integration_judge`, named in the same sentence, already did it). Placed outside the `try`, so budget exhaustion aborts instead of degrading.
- `except WorkerError` alone let an `OSError` from process spawn kill a run at a gate documented never to terminate one.
- `tests/test_claude_p_call_sites.py` — a static AST sweep over **all 27** `claude_p` call sites, because no stub-based test can catch this class: every test stubs `claude_p`, and a stub accepts any signature. The other 26 audit clean.

**#168 — retire the pre-demotion prose** left by #166 and #167: a self-contradicting CLAUDE.md paragraph, a `STATE_FIELDS` comment describing the gating gate, `check_replan_affordable` documented as called from a callback that no longer exists, and 19 lines documenting a deleted function and a deleted test file as live.

## Verification

- CI green on both PRs and on `main` for each merge commit
- Every defect falsified individually against reverted code
- 2600 passed, 45 skipped on the final sweep
- Both manifests valid JSON with matching versions; every referenced plugin path resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)