### PR TITLE
docs(prompt): drop the coverage judge's stale claim of gating authority

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1161,6 +1161,7 @@ gates (`PRESCRIBED_CMD_UNRUN`), a goal-only task and a fully-covered
 command never gate, and `check_planner_output` itself carries no separate
 adherence axis to demote to advisory, since the floor is wired only into
 `phase_adherence_gate`, not the planner check loop.
+
 The task-coverage gate is **advisory** (2026-08-04). Its deterministic
 floor, `check_required_items_coverage`, was deleted: it required one
 subtask's token set to be a SUPERSET of a required item's, and across every
@@ -1172,10 +1173,9 @@ input it returned a different finding set 85% of the time (n=20) and the
 intersection across repeated samples was empty. `tests/test_phase_planning_coverage_gate.py`
 pins the advisory contract and the floor's absence.
 
-
-`migration_targets`' own sibling gap —
-optional and silently no-op on omission — gets a narrower, same-worker
-mechanical cross-check: `performs_replacement: bool` on the subtask schema
+`migration_targets` carries a gap of the same shape — optional on the
+subtask schema, and silently no-op when a planner omits it — closed by a
+narrow, same-worker mechanical cross-check: `performs_replacement: bool` on the subtask schema
 (alongside, not nested inside, `migration_targets` — that object's
 `additionalProperties: False` forces this), and
 `_check_migration_targets_declared(subtasks)` flags `MIGRATION_TARGETS_MISSING`

--- a/prompts/task_coverage_judge.md
+++ b/prompts/task_coverage_judge.md
@@ -1,6 +1,6 @@
 # Plan-Task Coverage Judge
 
-You are the independent task-coverage gate for the leerie orchestrator
+You are the independent task-coverage reviewer for the leerie orchestrator
 (DESIGN §8 *Independent adversarial verification*). A planner has already
 produced a reconciled set of subtasks for the user's task. You did **not**
 write that plan — you are a separate reviewer, handed the task text plus
@@ -10,7 +10,7 @@ your job is to **attack** it: does the union of subtasks actually address
 what the user asked for, or does it leave required work out, or drift onto
 work the user never asked for?
 
-This gate exists because the planner self-grades its own `task_understanding`
+This review exists because the planner self-grades its own `task_understanding`
 confidence, and a self-review is anchored to the decomposition the planner
 already committed to — it cannot see a whole required piece of work that
 simply never became a subtask, because there is no subtask whose self-review
@@ -32,15 +32,15 @@ sized or not, actually cover the task?**
 > addresses (`missing_work`)? Or a subtask whose work does not serve the
 > task at all (`off_task_subtask`)?
 
-Only a gap backed by **concrete evidence in the task text** gates. "The plan
+Only report a gap backed by **concrete evidence in the task text**. "The plan
 could be more thorough" is not evidence; "the task says *ship the landing
 page with feature pillars, CTA, and hero*, but no subtask mentions the CTA
 or hero sections" is.
 
 ## Calibration
 
-| Case | Gate? | Why |
-|------|-------|-----|
+| Case | Report? | Why |
+|------|---------|-----|
 | Every piece of work the task requires is addressed by some subtask, and no subtask is off-task | **no** (empty `coverage_gaps`) | Correct coverage — do not manufacture a defect. |
 | The task asks for a feature plus a regression test, but no subtask covers testing | **yes** — `missing_work` | The explicitly-required test work has no subtask. |
 | The task asks to fix a bug in module A, but a subtask also refactors unrelated module B | **yes** — `off_task_subtask` | Scope creep the task never asked for. |
@@ -82,7 +82,7 @@ whether the run proceeds, so do not soften a real finding to avoid that.
   subtask's work does not serve the task); `description` names the gap;
   `concrete_evidence` cites the specific task text and subtask set that
   prove it — **must be non-empty and concrete**, or the entry is dropped and
-  does not gate. Empty array when coverage is correct.
+  never reaches the human. Empty array when coverage is correct.
 - `rationale`: 1–3 sentences on whether the subtask set covers the task's
   actual work.
 

--- a/tests/test_phase_plan_required_items_ctx.py
+++ b/tests/test_phase_plan_required_items_ctx.py
@@ -9,9 +9,12 @@ floor: without it the planner never sees the classifier's required_items
 checklist, so it cannot plan the work those items name — and the advisory
 `task_coverage_judge` downstream has a real gap to report rather than an
 avoidable one.
-This was caught by an independent re-verification pass after the floor
-itself landed — the floor and its test suite were both correct in
-isolation, but nothing fed the planner the data it needed to satisfy it.
+
+The injection was originally added by an independent re-verification pass
+after the floor landed: the floor and its test suite were both correct in
+isolation, but nothing fed the planner the checklist the floor measured it
+against. The floor is gone; the missing-input defect it exposed is not,
+which is why these tests outlived it.
 
 Verifies:
 - When st.data["required_items"] is non-empty, the ctx JSON blob carries


### PR DESCRIPTION
Sweep after the 0.10.1 release. Four small defects — two mine from #168, two older.

## The one that ships to workers

`prompts/task_coverage_judge.md` is **product surface**: sent verbatim to a worker on every run. It still told the judge it was a gate in three places, while lines 54-59 of the same file already said findings are advisory. The file contradicted itself, and the half a worker reads first was the wrong half.

The rename is **threshold-preserving**, which is why I deferred it last round and am doing it now:

| Before | After |
|---|---|
| "Only a gap backed by **concrete evidence in the task text** gates" | "Only **report** a gap backed by **concrete evidence in the task text**" |
| `\| Case \| Gate? \| Why \|` | `\| Case \| Report? \| Why \|` |
| "the entry is dropped and does not gate" | "the entry is dropped and never reaches the human" |

That first sentence **is** the reporting bar — the reason I left it alone before. The new wording keeps the bar byte-for-byte and removes only the false claim of authority. The entry-drop at L84 is real (the code filters entries missing `description`/`concrete_evidence`); only its stated consequence was wrong.

## Two I introduced in #168

Deleting the 19-line stale block left `CLAUDE.md` reading:

> `migration_targets`' **own** sibling gap — … gets a **narrower**, same-worker mechanical cross-check

Sibling of what? Narrower than what? Both referred to the `required_items` floor discussion the same commit deleted. Rewritten to stand alone, plus the double blank line left behind.

## One from #166

`CLAUDE.md` welded "…not the planner check loop." to "The task-coverage gate is **advisory**" with no blank line, joining two unrelated topics into one paragraph.

## And a test-docstring seam

My replacement paragraph ran straight into the original closing sentence, which still described the deleted floor as something to satisfy. History kept, referent made explicit.

## Verification

- Prose only; `ast.parse` clean, no code touched
- `tests/test_prompts_have_no_foreign_identifiers.py` — 59 passed (this edits a shipped prompt)
- The three tests that read this prompt (`test_task_file_coverage_freeze`, `test_task_file_extraction`, `test_task_coverage_judge_schema`) assert on sections untouched here — 49 passed
- 94 passed across the coverage-gate, call-sites, resume-regression, state-fields, version-flag and required-items files
- The scans that found the dangling reference and the double blank line both come back clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)