### PR TITLE
chore(release): 0.10.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "leerie",
       "source": ".",
-      "version": "0.10.1",
+      "version": "0.10.2",
       "description": "Deterministic, headless task orchestrator for Claude Code. Classifies a task, decomposes it into dependency-ordered waves, and executes each subtask in an isolated git worktree under an evidence-gated implement/validate loop. Runs entirely on the Claude Code CLI/subscription via `claude -p` workers."
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "leerie",
   "displayName": "Leerie",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "Deterministic, headless task orchestrator for Claude Code. Classifies a task, decomposes it into granular subtasks, schedules them into dependency-ordered waves, and executes each in an isolated git worktree under an evidence-gated implement/validate loop. Runs entirely on the Claude Code CLI/subscription via `claude -p` workers.",
   "author": { "name": "Andres Restrepo", "email": "andres@enricai.com", "url": "https://enricai.com" },
   "license": "MIT",


### PR DESCRIPTION
Patch release so #170's prompt fix reaches installs.

`prompts/task_coverage_judge.md` is **product surface** — sent verbatim to a worker on every run — and it only ships through a release. #170 removed its stale claim of gating authority: three places used "gate" as a verb for something that has not gated since #166, while lines 54-59 of the same file already said findings are advisory. A worker reads the contradiction top-down and hits the wrong half first.

The rename is threshold-preserving: "Only a gap backed by **concrete evidence in the task text** gates" → "Only **report** a gap backed by **concrete evidence in the task text**". Same bar, byte-for-byte; only the authority claim is gone.

Also in this release: CLAUDE.md prose repairs (a dangling reference and double blank line left by #168's block deletion, plus a paragraph run-on from #166) and a test-docstring seam. Those are contributor-facing, not runtime.

## Verification

- `tests/test_prompts_have_no_foreign_identifiers.py` — 59 passed
- The three tests that read this prompt assert on untouched sections — 49 passed
- Both manifests valid JSON with matching versions; every referenced plugin path resolves
- Prose only; `ast.parse` clean, no code touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)