### PR TITLE
fix(worktree): stop losing a committed subtask to a worktree-setup failure

### DIFF
--- a/docs/IMPLEMENTATION.md
+++ b/docs/IMPLEMENTATION.md
@@ -5697,10 +5697,10 @@ at the producer eliminates the prose round-trip.
 
 The coupling test in `tests/test_retryable_failure.py` enforces that
 every retryable-path return from a producer (`_validate_result`,
-`check_branch_has_commits`, the inline dirty-worktree check) carries a
-`failure_kind` in `_RETRYABLE_FAILURE_KINDS`. When adding a new
-retryable failure mode, extend the enum and update the producer in the
-same change.
+`check_branch_has_commits`, the inline dirty-worktree check,
+`_run_implementer`'s `WorktreeSetupError`) carries a `failure_kind` in
+`_RETRYABLE_FAILURE_KINDS`. When adding a new retryable failure mode,
+extend the enum and update the producer in the same change.
 
 | Failure | Tier | `failure_kind` / source |
 |---------|------|-----------------|
@@ -5710,6 +5710,18 @@ same change.
 | cross-field invariant violation (other) | Terminal | `"broken"` from `_validate_result` |
 | diff touched a protected path | Terminal | `"broken"` from `check_diff_scope` |
 | worker-level error (timeout, schema-invalid twice) | Terminal | `"broken"` from `WorkerError` path |
+| `new-worktree.sh` could not create the worktree | Retryable | `"worktree_setup"` from `_run_implementer`'s `WorktreeSetupError`, caught by its own arm in `_settle_subtask` **before** the generic `except WorkerError` (it is a subclass, so a generic-first order swallows it). Infrastructure, not a broken worker: the raise happens before any worker runs, so `_retryable_failure`'s terminal rationale ("the worker is broken or dishonest, and re-running burns an invocation for no expected gain") does not apply — re-running is exactly what clears it. Was terminal until run `488c42e5` (2026-08-05) lost `bugfix-009-2` to it *after* the implementer had committed, killing the wave with 25 of 26 subtasks complete and leaving `resume` to hit the same wall on every attempt |
+
+**Retry in place vs. reset first.** `fail()` normally calls
+`_reset_subtask_worktree` before looping, which runs `git branch -D` on the
+subtask branch — correct for `no_commits` (the branch holds nothing worth
+keeping) and destructive when it does not. `_RETRY_IN_PLACE_KINDS`
+(currently `{"worktree_setup"}`) names the kinds whose retry must skip that
+reset: a worktree-setup failure fires before any worker runs, so there is no
+leftover from *this* attempt to clear, while an *earlier* attempt's commits
+may be sitting on the branch (`488c42e5`'s `bugfix-009-2` failed with
+`de0d3bf` already committed). `new-worktree.sh` reuses an existing branch by
+design, so retrying in place re-attaches to that work instead of deleting it.
 
 `_settle_subtask` routes every failure through `_retryable_failure` via the
 `fail(kind, reason)` helper. Retryable consumes the retry cap; terminal ends

--- a/docs/IMPLEMENTATION.md
+++ b/docs/IMPLEMENTATION.md
@@ -5710,18 +5710,46 @@ extend the enum and update the producer in the same change.
 | cross-field invariant violation (other) | Terminal | `"broken"` from `_validate_result` |
 | diff touched a protected path | Terminal | `"broken"` from `check_diff_scope` |
 | worker-level error (timeout, schema-invalid twice) | Terminal | `"broken"` from `WorkerError` path |
-| `new-worktree.sh` could not create the worktree | Retryable | `"worktree_setup"` from `_run_implementer`'s `WorktreeSetupError`, caught by its own arm in `_settle_subtask` **before** the generic `except WorkerError` (it is a subclass, so a generic-first order swallows it). Infrastructure, not a broken worker: the raise happens before any worker runs, so `_retryable_failure`'s terminal rationale ("the worker is broken or dishonest, and re-running burns an invocation for no expected gain") does not apply — re-running is exactly what clears it. Was terminal until run `488c42e5` (2026-08-05) lost `bugfix-009-2` to it *after* the implementer had committed, killing the wave with 25 of 26 subtasks complete and leaving `resume` to hit the same wall on every attempt |
+| `new-worktree.sh` could not create the worktree | Retryable (infrastructure) | `"worktree_setup"` from `_run_implementer`'s `WorktreeSetupError`, caught by its own arm in `_settle_subtask` **before** the generic `except WorkerError` (it is a subclass, so a generic-first order swallows it). Infrastructure, not a broken worker: the raise happens before any worker runs, so `_retryable_failure`'s terminal rationale ("the worker is broken or dishonest, and re-running burns an invocation for no expected gain") does not apply — re-running is exactly what clears it. Was terminal until run `488c42e5` (2026-08-05) lost `bugfix-009-2` to it *after* the implementer had committed, killing the wave with 25 of 26 subtasks complete and leaving `resume` to hit the same wall on every attempt |
+
+**Two categories, one source of truth.** `_INFRASTRUCTURE_FAILURE_KINDS` is
+the single place a kind is declared *not the worker's doing*; everything else
+derives from it, including `_RETRYABLE_FAILURE_KINDS`, which is **composed**
+(`_WORKER_RETRYABLE_KINDS | _INFRASTRUCTURE_FAILURE_KINDS`) rather than
+hand-maintained. A kind listed in only some of several lists is silently
+half-wrong — retried but branch-deleted, or preserved but terminal — and that
+is the bug class this area keeps producing. An infrastructure retry is also
+**logged**; it used to be silent, since `fail()` logs only on terminal or
+cap-reached.
+
+*Measured candidates deliberately not yet moved into the category:* auditing
+every `raise WorkerError` found `worker {sid} exhausted its PID`, `worker
+{sid} was OOM-killed`, `Claude API connection dropped mid-response`, 529
+overloaded, and auth/quota — all infrastructure on the same generic path.
+Reclassifying them is a behaviour change beyond the incident that motivated
+the category and could mask a real resource problem, so it needs its own
+evidence.
 
 **Retry in place vs. reset first.** `fail()` normally calls
 `_reset_subtask_worktree` before looping, which runs `git branch -D` on the
 subtask branch — correct for `no_commits` (the branch holds nothing worth
-keeping) and destructive when it does not. `_RETRY_IN_PLACE_KINDS`
-(currently `{"worktree_setup"}`) names the kinds whose retry must skip that
+keeping) and destructive when it does not. Infrastructure kinds skip that
 reset: a worktree-setup failure fires before any worker runs, so there is no
 leftover from *this* attempt to clear, while an *earlier* attempt's commits
 may be sitting on the branch (`488c42e5`'s `bugfix-009-2` failed with
 `de0d3bf` already committed). `new-worktree.sh` reuses an existing branch by
 design, so retrying in place re-attaches to that work instead of deleting it.
+
+The exemption covers the `continuation` flag and the corrective `note` too,
+not just the reset. An infrastructure failure carries no information about
+what the worker should do differently, so it must not overwrite the state
+that says what the worker should do differently: in `488c42e5` the worktree
+failed while the mechanical-check path had already set `continuation=True`
+and a `_format_check_feedback` note naming the unmet criterion — the pending
+feedback the retry existed to deliver. Overwriting it restarts the worker
+blind to the thing it was sent back to fix, so it misses the same check again
+and burns `implementer_confidence_retries`. Only a *worker* failure earns a
+corrective note, because only a worker failure produced one.
 
 `_settle_subtask` routes every failure through `_retryable_failure` via the
 `fail(kind, reason)` helper. Retryable consumes the retry cap; terminal ends

--- a/orchestrator/leerie.py
+++ b/orchestrator/leerie.py
@@ -10570,6 +10570,16 @@ class WorkerError(RuntimeError):
     pass
 
 
+class WorktreeSetupError(WorkerError):
+    """`new-worktree.sh` could not produce the subtask's worktree.
+
+    A distinct type because the retry classifier dispatches on a kind tagged
+    at the PRODUCER, never on prose (see `_RETRYABLE_FAILURE_KINDS`). Raised
+    before any worker runs, so it is infrastructure, not a broken or
+    dishonest worker — the distinction `_retryable_failure` turns on.
+    """
+
+
 def _api_error_category(status: int | None) -> str | None:
     """Map a `claude -p` `api_error_status` to a coarse failure category.
 
@@ -22223,7 +22233,8 @@ async def _run_implementer(sid: str, leerie_dir: Path, caps: dict, st: State,
     sys_prompt = _load_prompt("implementer")
     proc = await _run_script("new-worktree.sh", sid, st.run_id)
     if proc.returncode != 0:
-        raise WorkerError(f"worktree creation failed for {sid}: {proc.stderr.strip()}")
+        raise WorktreeSetupError(
+            f"worktree creation failed for {sid}: {proc.stderr.strip()}")
     worktree = proc.stdout.strip().splitlines()[-1]
     # The fresh worktree has NO installed deps. The implementer runs
     # installs itself in its own worktree against the shared
@@ -22347,7 +22358,27 @@ async def _run_implementer(sid: str, leerie_dir: Path, caps: dict, st: State,
 # producer return the new kind. The coupling test in
 # tests/test_retryable_failure.py asserts every producer's retryable-path
 # return uses a kind in this set.
+# Retryable kinds whose retry must NOT call `_reset_subtask_worktree`.
+# That helper runs `git branch -D` on the subtask branch — correct when the
+# failure means the branch holds nothing worth keeping (`no_commits`), and
+# DESTRUCTIVE when it does. A worktree-setup failure fires before any worker
+# runs, so there is no leftover from this attempt to clear, while an EARLIER
+# attempt's commits may be sitting on that branch: run 488c42e5's
+# `bugfix-009-2` failed this way with `de0d3bf` already committed, and
+# resetting would have deleted it rather than re-attaching. `new-worktree.sh`
+# reuses an existing branch by design, so retrying in place is both safe and
+# the point.
+_RETRY_IN_PLACE_KINDS = frozenset({"worktree_setup"})
+
 _RETRYABLE_FAILURE_KINDS = frozenset({
+    "worktree_setup",  # WorktreeSetupError — `new-worktree.sh` could not
+                       # produce the worktree. Infrastructure, not a broken
+                       # worker: no worker ran, and re-running is exactly
+                       # what fixes it. Was terminal ("broken") until run
+                       # 488c42e5 (2026-08-05) lost `bugfix-009-2` to it
+                       # AFTER the implementer had already committed —
+                       # killing the wave with 25 of 26 subtasks complete
+                       # and leaving `resume` to hit the same wall forever.
     "no_commits",      # check_branch_has_commits — implementer claimed
                        # complete with nothing committed
     "dirty_worktree",  # inline status-porcelain check in _settle_subtask —
@@ -24106,7 +24137,8 @@ async def _settle_subtask(sid: str, leerie_dir: Path, caps: dict, st: State,
         if retries > caps["failed_retries"]:
             log(f"  {sid}: retry cap reached — terminating")
             return res
-        await _reset_subtask_worktree(sid, leerie_dir, st.run_id)
+        if kind not in _RETRY_IN_PLACE_KINDS:
+            await _reset_subtask_worktree(sid, leerie_dir, st.run_id)
         continuation = False
         note = f"Previous attempt failed: {reason}"
         return None
@@ -24116,6 +24148,17 @@ async def _settle_subtask(sid: str, leerie_dir: Path, caps: dict, st: State,
             res = await _run_implementer(sid, leerie_dir, caps, st, models,
                                         efforts, continuation=continuation,
                                         note=note)
+        except WorktreeSetupError as e:
+            # `new-worktree.sh` failed. Tagged as its own retryable kind
+            # rather than the generic "broken" below: no worker ran, so the
+            # worker is neither broken nor dishonest, and a fresh attempt is
+            # exactly what clears it. `_RETRY_IN_PLACE_KINDS` keeps the retry
+            # from deleting the branch, which may already carry an earlier
+            # attempt's commits (run 488c42e5, `bugfix-009-2`).
+            fail_res = await fail("worktree_setup", str(e))
+            if fail_res is not None:
+                return fail_res
+            continue
         except WorkerError as e:
             # Per-subtask infrastructure failure (e.g. `new-worktree.sh`
             # could not create the worktree). `_run_implementer`'s own

--- a/orchestrator/leerie.py
+++ b/orchestrator/leerie.py
@@ -22358,27 +22358,37 @@ async def _run_implementer(sid: str, leerie_dir: Path, caps: dict, st: State,
 # producer return the new kind. The coupling test in
 # tests/test_retryable_failure.py asserts every producer's retryable-path
 # return uses a kind in this set.
-# Retryable kinds whose retry must NOT call `_reset_subtask_worktree`.
-# That helper runs `git branch -D` on the subtask branch — correct when the
-# failure means the branch holds nothing worth keeping (`no_commits`), and
-# DESTRUCTIVE when it does. A worktree-setup failure fires before any worker
-# runs, so there is no leftover from this attempt to clear, while an EARLIER
-# attempt's commits may be sitting on that branch: run 488c42e5's
-# `bugfix-009-2` failed this way with `de0d3bf` already committed, and
-# resetting would have deleted it rather than re-attaching. `new-worktree.sh`
-# reuses an existing branch by design, so retrying in place is both safe and
-# the point.
-_RETRY_IN_PLACE_KINDS = frozenset({"worktree_setup"})
-
-_RETRYABLE_FAILURE_KINDS = frozenset({
+# A failure the WORKER did not cause: either no worker ran, or its own
+# behaviour is not implicated. Three consequences follow from that one fact,
+# so this set is the SINGLE place a kind is declared infrastructure and the
+# rest derive from it — a kind listed in only some of them is silently
+# half-wrong, which is the bug class this whole area keeps producing:
+#
+#   1. retryable by definition (re-running IS the remedy)  -> composed below
+#   2. no `_reset_subtask_worktree` — that runs `git branch -D`, and an
+#      earlier attempt's commits may be on that branch (488c42e5's
+#      `bugfix-009-2` failed with `de0d3bf` already committed; resetting
+#      would have deleted it instead of re-attaching)
+#   3. no corrective note — an infrastructure failure says nothing about what
+#      the worker should do differently, so it must not overwrite what the
+#      worker is being told to fix
+#
+# MEASURED CANDIDATES NOT YET MOVED HERE (deliberate): auditing every
+# `raise WorkerError` found `worker {sid} exhausted its PID`, `worker {sid}
+# was OOM-killed`, `Claude API connection dropped mid-response`, 529
+# overloaded, and auth/quota — all infrastructure on the same generic path.
+# Reclassifying them is a behaviour change well past this incident and could
+# mask a real resource problem, so it needs its own evidence. Bundling it
+# here is how the previous response to this incident became containment.
+_INFRASTRUCTURE_FAILURE_KINDS = frozenset({
     "worktree_setup",  # WorktreeSetupError — `new-worktree.sh` could not
-                       # produce the worktree. Infrastructure, not a broken
-                       # worker: no worker ran, and re-running is exactly
-                       # what fixes it. Was terminal ("broken") until run
-                       # 488c42e5 (2026-08-05) lost `bugfix-009-2` to it
-                       # AFTER the implementer had already committed —
-                       # killing the wave with 25 of 26 subtasks complete
-                       # and leaving `resume` to hit the same wall forever.
+                       # produce the worktree. Terminal ("broken") until run
+                       # 488c42e5 (2026-08-05), where it killed a wave with
+                       # 25 of 26 subtasks complete and left `resume` hitting
+                       # the same wall on every attempt.
+})
+
+_WORKER_RETRYABLE_KINDS = frozenset({
     "no_commits",      # check_branch_has_commits — implementer claimed
                        # complete with nothing committed
     "dirty_worktree",  # inline status-porcelain check in _settle_subtask —
@@ -22395,6 +22405,11 @@ _RETRYABLE_FAILURE_KINDS = frozenset({
                        # TimeoutExpired catches. Both are corrective-note
                        # cases — a fresh worker can plausibly do better.
 })
+
+
+# Composed, so ONE membership drives every consequence. A kind declared
+# infrastructure is retryable without anyone having to remember a second list.
+_RETRYABLE_FAILURE_KINDS = _WORKER_RETRYABLE_KINDS | _INFRASTRUCTURE_FAILURE_KINDS
 
 
 def _retryable_failure(kind: str) -> bool:
@@ -24137,10 +24152,21 @@ async def _settle_subtask(sid: str, leerie_dir: Path, caps: dict, st: State,
         if retries > caps["failed_retries"]:
             log(f"  {sid}: retry cap reached — terminating")
             return res
-        if kind not in _RETRY_IN_PLACE_KINDS:
+        if kind in _INFRASTRUCTURE_FAILURE_KINDS:
+            # Retry in place: no reset (it would `git branch -D` work an
+            # earlier attempt may have committed) and no corrective note (an
+            # infrastructure failure says nothing about what the worker should
+            # do differently, so it must not overwrite what the worker is
+            # being told to fix — in 488c42e5 the pending note named the unmet
+            # criterion the retry existed to deliver). Logged because it was
+            # previously silent: `fail()` logs only on terminal or cap-reached,
+            # so an operator saw a worker re-run with no line explaining why.
+            log(f"  {sid}: infrastructure failure ({kind}) — retrying "
+                f"{retries}/{caps['failed_retries']}: {reason}")
+        else:
             await _reset_subtask_worktree(sid, leerie_dir, st.run_id)
-        continuation = False
-        note = f"Previous attempt failed: {reason}"
+            continuation = False
+            note = f"Previous attempt failed: {reason}"
         return None
 
     while True:

--- a/scripts/new-worktree.sh
+++ b/scripts/new-worktree.sh
@@ -28,13 +28,32 @@ esac
 BRANCH="leerie/subtasks/${RUN_ID}/${ID}"
 PARENT_BRANCH="leerie/runs/${RUN_ID}"
 
+# Clear stale admin entries whose directory is gone, so the orphan check and
+# the `worktree add` fallbacks below all see post-prune truth.
+#
+# ORDER IS LOAD-BEARING: this MUST run before the orphan-directory check.
+# `git worktree prune` is itself an operation that CREATES the orphaned state
+# that check exists to repair — it drops the admin entry and leaves the
+# directory on disk. Running the check first and pruning after left a window
+# where the entry vanished with nothing left to notice: the reuse grep below
+# missed, and `worktree add` hit the directory prune had just orphaned.
+#
+# That is not hypothetical. Run 488c42e5 (2026-08-05) lost `bugfix-009-2`
+# this way *after* its implementer had already committed: a mechanical check
+# drove the continuation path, this script ran a second time, and it died on
+# "fatal: '<path>' already exists" — the wave then refused to close with 25 of
+# 26 subtasks complete. Under `--max-parallel` a *sibling's* concurrent prune
+# can drop a live registration the same way, which is the likelier trigger.
+git worktree prune
+
 # Drop an orphaned worktree directory that git no longer knows about.
 # `_cleanup_on_abnormal_exit` deregisters and removes worktrees, but a
-# partial cleanup (or an rmtree that lost a race with git's metadata write)
-# can leave the directory on disk with no registration. `worktree add` then
-# refuses with "fatal: '<path>' already exists", which crashes continuation
-# retries — the same class the `pwd -P` normalisation above addresses, but
-# reached from cleanup rather than from a relative path.
+# partial cleanup (or an rmtree that lost a race with git's metadata write),
+# or the prune immediately above, can leave the directory on disk with no
+# registration. `worktree add` then refuses with "fatal: '<path>' already
+# exists", which crashes continuation retries — the same class the `pwd -P`
+# normalisation above addresses, but reached from cleanup rather than from a
+# relative path.
 #
 # `git worktree prune` does NOT cover this: it only drops admin entries whose
 # directory is *gone*. `--force` does not either: it overrides
@@ -45,11 +64,6 @@ PARENT_BRANCH="leerie/runs/${RUN_ID}"
 if ! git worktree list --porcelain | grep -qxF "worktree $WT" && [ -d "$WT" ]; then
   rm -rf "$WT"
 fi
-# Clear stale admin entries whose directory is gone, so the reuse check below
-# and the `worktree add` fallbacks see post-cleanup truth. Safe under
-# `max_parallel`: prune only touches entries whose directory no longer exists,
-# never a live sibling's.
-git worktree prune
 
 if git worktree list --porcelain | grep -qxF "worktree $WT"; then
   : # already present — reuse it

--- a/scripts/new-worktree.sh
+++ b/scripts/new-worktree.sh
@@ -65,14 +65,92 @@ if ! git worktree list --porcelain | grep -qxF "worktree $WT" && [ -d "$WT" ]; t
   rm -rf "$WT"
 fi
 
+# Add with a repair-and-retry.
+#
+# Everything above is CHECK-THEN-ACT, and the checks run against a repo a
+# dozen sibling subtasks are mutating concurrently (`--max-parallel`). Any
+# window between a check and the `add` it selected can invalidate it, so the
+# add must verify its own outcome rather than trust the earlier check. That
+# assumption — not any one race — is the root cause of run 488c42e5 losing
+# `bugfix-009-2` after its implementer had committed: the surviving evidence
+# there is self-contradictory (the admin entry outlived the failure, yet the
+# reuse check missed), which is exactly the kind of detail a correct
+# implementation must not depend on.
+#
+# The repair re-DERIVES state; it never parses git's prose. Modes measured
+# against git 2.53:
+#   M1  path exists, branch free      -> "fatal: '<path>' already exists"
+#                                        repair: remove the orphaned directory
+#   M3  registered, directory gone    -> "use 'add -f' … or 'prune' …"
+#                                        repair: `git worktree prune`
+#   M2  branch checked out elsewhere  -> "already used by worktree at '<other>'"
+#                                        NO repair: forcing would steal a live
+#                                        sibling's branch. Surface it instead —
+#                                        `worktree_setup` is retryable, so the
+#                                        subtask retries rather than dying.
+# Decide the add form from CURRENT state every time this is called. The
+# retry below MUST re-derive it, not reuse the caller's earlier decision:
+# `git worktree add <path> -b <branch> <start>` CREATES THE BRANCH and can
+# still fail on the path, so a retry of the same `-b` form then dies with
+# "a branch named '<branch>' already exists". Measured, not theorised — the
+# race test caught exactly this.
+_create_worktree() {
+  if git show-ref --verify --quiet "refs/heads/${BRANCH}"; then
+    # branch exists (pre-existing, or created by a failed first attempt) —
+    # attach to it, preserving any commits already on it
+    git worktree add "$WT" "$BRANCH"
+  else
+    git worktree add "$WT" -b "$BRANCH" "$PARENT_BRANCH"
+  fi
+}
+
+# Create with a repair-and-retry.
+#
+# Everything above is CHECK-THEN-ACT, and the checks run against a repo a
+# dozen sibling subtasks are mutating concurrently (`--max-parallel`). Any
+# window between a check and the act it selected can invalidate it, so the
+# operation must verify its own outcome rather than trust the earlier check.
+# That assumption — not any one race — is the root cause of run 488c42e5
+# losing `bugfix-009-2` after its implementer had committed: the surviving
+# evidence there is self-contradictory (the admin entry outlived the failure,
+# yet the reuse check missed), which is exactly the kind of detail a correct
+# implementation must not depend on.
+#
+# The repair re-DERIVES state; it never parses git's prose. Modes measured
+# against git 2.53:
+#   M1  path exists, branch free      -> "fatal: '<path>' already exists"
+#                                        repair: remove the orphaned directory
+#   M3  registered, directory gone    -> "use 'add -f' … or 'prune' …"
+#                                        repair: `git worktree prune`
+#   M5  branch created by a failed
+#       first attempt                 -> "a branch named '<b>' already exists"
+#                                        repair: re-derive -> attach form
+#   M2  branch checked out elsewhere  -> "already used by worktree at '<other>'"
+#                                        NO repair: forcing would steal a live
+#                                        sibling's branch. Surface it instead —
+#                                        `worktree_setup` is retryable, so the
+#                                        subtask retries rather than dying.
+_add_with_repair() {
+  local err
+  if err="$(_create_worktree 2>&1)"; then
+    return 0
+  fi
+  if ! git worktree list --porcelain | grep -qxF "worktree $WT" \
+      && [ -d "$WT" ]; then
+    rm -rf "$WT"
+  fi
+  git worktree prune
+  if err="$(_create_worktree 2>&1)"; then
+    return 0
+  fi
+  printf '%s\n' "$err" >&2
+  return 1
+}
+
 if git worktree list --porcelain | grep -qxF "worktree $WT"; then
   : # already present — reuse it
-elif git show-ref --verify --quiet "refs/heads/${BRANCH}"; then
-  # branch exists but worktree was removed — re-attach
-  git worktree add "$WT" "$BRANCH" >/dev/null
 else
-  # fresh subtask — branch off the current run-branch tip
-  git worktree add "$WT" -b "$BRANCH" "$PARENT_BRANCH" >/dev/null
+  _add_with_repair >/dev/null
 fi
 
 (cd "$WT" && pwd)

--- a/tests/test_new_worktree_idempotency.py
+++ b/tests/test_new_worktree_idempotency.py
@@ -147,3 +147,92 @@ def test_reuse_worktree_when_state_dir_set(tmp_path: Path) -> None:
     assert r2.returncode == 0, f"second call failed (reuse path broken): {r2.stderr}"
     wt2 = r2.stdout.strip().splitlines()[-1]
     assert wt2 == wt1
+
+
+def test_prune_must_not_orphan_the_dir_it_then_fails_on(tmp_path: Path) -> None:
+    """ORDER PIN: `git worktree prune` must run BEFORE the orphan-dir check.
+
+    Prune is not a passive cleanup — it is itself an operation that CREATES
+    the orphaned state (registration dropped, directory left on disk) that
+    the orphan check exists to repair. With the check first and prune second
+    there was a window nothing covered: prune dropped the entry, the reuse
+    grep then missed, and `worktree add` died on the directory prune had
+    just orphaned.
+
+    Run 488c42e5 (2026-08-05) lost `bugfix-009-2` exactly this way, AFTER its
+    implementer had committed: a mechanical check drove the continuation
+    path, this script ran a second time, and the wave refused to close with
+    25 of 26 subtasks complete.
+
+    This test reproduces the state prune leaves behind — a registration git
+    considers stale plus a directory still on disk — and asserts the script
+    recovers instead of dying. It fails if the two blocks are swapped back.
+    """
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git("init", "-q", "-b", "main", cwd=repo)
+    _git("config", "user.email", "test@leerie.local", cwd=repo)
+    _git("config", "user.name", "leerie-test", cwd=repo)
+    _git("config", "commit.gpgsign", "false", cwd=repo)
+    (repo / "file.txt").write_text("initial\n")
+    _git("add", "file.txt", cwd=repo)
+    _git("commit", "-q", "-m", "initial", cwd=repo)
+    _git("branch", "leerie/runs/run-42", "main", cwd=repo)
+
+    r1 = _run_new_worktree(repo, "sub-001", "run-42")
+    assert r1.returncode == 0, f"first call failed: {r1.stderr}"
+    wt = Path(r1.stdout.strip().splitlines()[-1])
+
+    # The implementer commits work — this is what must survive.
+    (wt / "work.txt").write_text("implementer output\n")
+    _git("add", "work.txt", cwd=wt)
+    _git("commit", "-q", "-m", "subtask work", cwd=wt)
+    sha = _git("rev-parse", "HEAD", cwd=wt).stdout.strip()
+
+    # Make the entry PRUNABLE while leaving the directory on disk, so the
+    # orphan is created by prune itself rather than pre-existing. Removing
+    # the worktree's `.git` link file is what git checks: the admin entry's
+    # gitdir target vanishes, so `git worktree prune` drops the entry — and
+    # the populated directory stays.
+    #
+    # This distinction is the whole point. An orphan that ALREADY exists when
+    # the script starts is handled by either ordering (the pre-existing
+    # `test_orphaned_dir_without_registration_is_reclaimed` covers it). Only
+    # an orphan that prune CREATES mid-script escapes a guard that ran first.
+    admin = repo / ".git" / "worktrees" / "sub-001"
+    assert admin.is_dir(), "expected a registration"
+    (wt / ".git").unlink()
+    assert wt.is_dir(), "the directory must remain — that is the orphan state"
+    still_registered = subprocess.run(
+        ["git", "worktree", "list", "--porcelain"], cwd=repo,
+        capture_output=True, text=True).stdout
+    assert str(wt) in still_registered, (
+        "precondition: git must still consider it registered, so an "
+        "orphan-check-first ordering skips the removal")
+
+    r2 = _run_new_worktree(repo, "sub-001", "run-42")
+    assert r2.returncode == 0, (
+        "script died on the state prune itself produces: "
+        f"{r2.stderr.strip()}")
+
+    # THE LOAD-BEARING ASSERTION: the committed work is re-attached, not lost.
+    wt2 = Path(r2.stdout.strip().splitlines()[-1])
+    assert _git("rev-parse", "HEAD", cwd=wt2).stdout.strip() == sha, (
+        "the retry did not re-attach to the branch — committed work lost")
+    assert (wt2 / "work.txt").exists()
+
+
+def test_prune_precedes_the_orphan_guard_in_source(tmp_path: Path) -> None:
+    """Source-order guard. The behavioural test above can pass for the wrong
+    reason if a future edit adds a second cleanup; this pins the ordering the
+    fix actually depends on, ignoring comments (which discuss both)."""
+    src = (Path(__file__).resolve().parent.parent
+           / "scripts" / "new-worktree.sh").read_text()
+    code = "\n".join(l for l in src.splitlines()
+                     if not l.strip().startswith("#"))
+    assert code.index("git worktree prune") < code.index('rm -rf "$WT"'), (
+        "`git worktree prune` must precede the orphan-directory removal — "
+        "prune is what creates the orphan the removal repairs")
+    assert code.index('rm -rf "$WT"') < code.index("git worktree add"), (
+        "the orphan removal must precede `worktree add`")
+

--- a/tests/test_new_worktree_idempotency.py
+++ b/tests/test_new_worktree_idempotency.py
@@ -236,3 +236,150 @@ def test_prune_precedes_the_orphan_guard_in_source(tmp_path: Path) -> None:
     assert code.index('rm -rf "$WT"') < code.index("git worktree add"), (
         "the orphan removal must precede `worktree add`")
 
+
+# --- repair-and-retry: one test per measured `worktree add` failure mode --- #
+#
+# The pre-checks are CHECK-THEN-ACT against a repo a dozen sibling subtasks
+# mutate concurrently, so the add must verify its own outcome. These drive the
+# REAL script against a REAL repo, one per mode enumerated against git 2.53.
+
+def _repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git("init", "-q", "-b", "main", cwd=repo)
+    _git("config", "user.email", "test@leerie.local", cwd=repo)
+    _git("config", "user.name", "leerie-test", cwd=repo)
+    _git("config", "commit.gpgsign", "false", cwd=repo)
+    (repo / "file.txt").write_text("initial\n")
+    _git("add", "file.txt", cwd=repo)
+    _git("commit", "-q", "-m", "initial", cwd=repo)
+    _git("branch", "leerie/runs/run-42", "main", cwd=repo)
+    return repo
+
+
+def test_mode_M1_path_exists_unregistered_is_repaired(tmp_path: Path) -> None:
+    """M1: `fatal: '<path>' already exists` — the incident's own error.
+
+    Repair is removing the orphaned directory. The branch is untouched, so the
+    retry re-attaches to work an earlier attempt committed."""
+    repo = _repo(tmp_path)
+    r1 = _run_new_worktree(repo, "sub-001", "run-42")
+    wt = Path(r1.stdout.strip().splitlines()[-1])
+    (wt / "work.txt").write_text("committed work\n")
+    _git("add", "work.txt", cwd=wt)
+    _git("commit", "-q", "-m", "work", cwd=wt)
+    sha = _git("rev-parse", "HEAD", cwd=wt).stdout.strip()
+
+    # Deregister but leave the populated directory: the M1 state, however it
+    # arises (prune, partial cleanup, or a race the evidence cannot name).
+    shutil.rmtree(repo / ".git" / "worktrees" / "sub-001")
+    assert wt.is_dir()
+
+    r2 = _run_new_worktree(repo, "sub-001", "run-42")
+    assert r2.returncode == 0, f"M1 not repaired: {r2.stderr.strip()}"
+    wt2 = Path(r2.stdout.strip().splitlines()[-1])
+    assert _git("rev-parse", "HEAD", cwd=wt2).stdout.strip() == sha, (
+        "committed work lost — the repair must re-attach, not restart")
+
+
+def test_mode_M3_registered_but_directory_gone_is_repaired(
+        tmp_path: Path) -> None:
+    """M3: `use 'add -f' to override, or 'prune' or 'remove' to clear`.
+    Repair is `git worktree prune`."""
+    repo = _repo(tmp_path)
+    r1 = _run_new_worktree(repo, "sub-001", "run-42")
+    wt = Path(r1.stdout.strip().splitlines()[-1])
+    shutil.rmtree(wt)          # directory gone, admin entry left behind
+    assert (repo / ".git" / "worktrees" / "sub-001").is_dir()
+
+    r2 = _run_new_worktree(repo, "sub-001", "run-42")
+    assert r2.returncode == 0, f"M3 not repaired: {r2.stderr.strip()}"
+    assert Path(r2.stdout.strip().splitlines()[-1]).is_dir()
+
+
+def test_mode_M2_branch_held_elsewhere_is_surfaced_not_forced(
+        tmp_path: Path) -> None:
+    """M2: the branch is checked out at ANOTHER path.
+
+    Forcing would steal a live sibling's branch, so the script must fail
+    loudly instead. Safe to fail: `worktree_setup` is retryable, so the
+    subtask retries rather than dying."""
+    repo = _repo(tmp_path)
+    branch = "leerie/subtasks/run-42/sub-001"
+    _git("branch", branch, "leerie/runs/run-42", cwd=repo)
+    other = repo / "held-elsewhere"
+    _git("worktree", "add", "-q", str(other), branch, cwd=repo)
+
+    r = _run_new_worktree(repo, "sub-001", "run-42")
+
+    assert r.returncode != 0, "must not silently steal a live branch"
+    assert other.is_dir(), "the sibling's worktree must be untouched"
+    assert _git("rev-parse", "--abbrev-ref", "HEAD",
+                cwd=other).stdout.strip() == branch
+
+
+def test_mode_M4_healthy_worktree_is_reused_with_no_add(
+        tmp_path: Path) -> None:
+    """ANTI-VACUITY: the repair path must not fire on the healthy case.
+    A script that always removed and re-added would pass M1/M3 while
+    destroying uncommitted work on every ordinary call."""
+    repo = _repo(tmp_path)
+    r1 = _run_new_worktree(repo, "sub-001", "run-42")
+    wt = Path(r1.stdout.strip().splitlines()[-1])
+    (wt / "uncommitted.txt").write_text("in progress\n")
+
+    r2 = _run_new_worktree(repo, "sub-001", "run-42")
+
+    assert r2.returncode == 0
+    assert (wt / "uncommitted.txt").exists(), (
+        "the healthy reuse path removed the worktree — uncommitted work lost")
+
+
+def test_race_between_check_and_add_is_repaired(tmp_path: Path) -> None:
+    """THE TEST FOR THE REPAIR ITSELF.
+
+    M1/M3 above are handled by the PRE-CHECKS (the orphan guard and the
+    prune), so they pass even with the repair removed — verified by mutation.
+    The repair only earns its place when the state changes BETWEEN the check
+    and the `add` it selected, which is precisely the window a dozen sibling
+    subtasks create and precisely what a sequential test cannot produce
+    naturally.
+
+    So inject it: a `git` shim that creates the destination directory on the
+    FIRST `worktree add` (a sibling landing in the window) and then gets out
+    of the way. Without repair the script dies on `already exists`; with it,
+    the failure is re-derived, the orphan removed, and the retry succeeds.
+    """
+    repo = _repo(tmp_path)
+    real_git = subprocess.run(["bash", "-lc", "command -v git"],
+                              capture_output=True, text=True).stdout.strip()
+    assert real_git, "need a real git on PATH"
+
+    shim_dir = tmp_path / "shim"
+    shim_dir.mkdir()
+    sentinel = tmp_path / "raced"
+    (shim_dir / "git").write_text(
+        "#!/bin/sh\n"
+        'if [ "$1" = "worktree" ] && [ "$2" = "add" ] && '
+        f'[ ! -e "{sentinel}" ]; then\n'
+        f'  : > "{sentinel}"\n'
+        # $3 is the destination path for `worktree add <path> …`
+        '  mkdir -p "$3" 2>/dev/null || true\n'
+        '  : > "$3/.racer" 2>/dev/null || true\n'
+        "fi\n"
+        f'exec {real_git} "$@"\n')
+    (shim_dir / "git").chmod(0o755)
+
+    env = dict(os.environ, PATH=f"{shim_dir}:{os.environ['PATH']}")
+    r = subprocess.run(
+        ["bash", str(Path(__file__).resolve().parent.parent
+                     / "scripts" / "new-worktree.sh"), "sub-001", "run-42"],
+        cwd=repo, capture_output=True, text=True, env=env)
+
+    assert sentinel.exists(), (
+        "the shim never fired — the race was not injected and this test "
+        "would pass vacuously")
+    assert r.returncode == 0, (
+        f"the check-then-act race was not repaired: {r.stderr.strip()}")
+    assert Path(r.stdout.strip().splitlines()[-1]).is_dir()
+

--- a/tests/test_retryable_failure.py
+++ b/tests/test_retryable_failure.py
@@ -77,18 +77,18 @@ def test_worktree_setup_retries_in_place_and_keeps_the_branch(leerie):
     failed with `de0d3bf` committed). Resetting would turn an infrastructure
     hiccup into silent loss of paid-for work.
 
-    So the kind must ALSO be in `_RETRY_IN_PLACE_KINDS`, and `_settle_subtask`
+    So the kind must ALSO be in `_INFRASTRUCTURE_FAILURE_KINDS`, and `_settle_subtask`
     must gate the reset on it. `new-worktree.sh` reuses an existing branch by
     design, so retrying in place re-attaches to the work."""
-    assert "worktree_setup" in leerie._RETRY_IN_PLACE_KINDS
+    assert "worktree_setup" in leerie._INFRASTRUCTURE_FAILURE_KINDS
     assert "git branch -D" in inspect.getsource(
         leerie._reset_subtask_worktree) or "branch" in inspect.getsource(
         leerie._reset_subtask_worktree), "reset no longer touches the branch"
     src = inspect.getsource(leerie._settle_subtask)
-    assert "_RETRY_IN_PLACE_KINDS" in src, (
+    assert "_INFRASTRUCTURE_FAILURE_KINDS" in src, (
         "the reset is no longer gated — a worktree_setup retry would "
         "delete a branch that may hold committed work")
-    i = src.index("_RETRY_IN_PLACE_KINDS")
+    i = src.index("_INFRASTRUCTURE_FAILURE_KINDS")
     j = src.index("await _reset_subtask_worktree")
     assert i < j, "the guard must precede the reset call"
 
@@ -98,7 +98,7 @@ def test_no_commits_still_resets(leerie):
     the kind that genuinely needs it. `no_commits` means the branch holds
     nothing, and without the reset the retry hits
     `fatal: a branch ... already exists`."""
-    assert "no_commits" not in leerie._RETRY_IN_PLACE_KINDS
+    assert "no_commits" not in leerie._INFRASTRUCTURE_FAILURE_KINDS
 
 
 # --- coupling test: producer returns must match consumer's accepted set ---
@@ -248,4 +248,62 @@ def test_producer_raises_the_tagged_exception_type(leerie):
     src = inspect.getsource(leerie._run_implementer)
     assert "raise WorktreeSetupError(" in src
     assert issubclass(leerie.WorktreeSetupError, leerie.WorkerError)
+
+
+class TestCategoryIsTheSingleSourceOfTruth:
+    """One membership must drive every consequence.
+
+    The previous shape needed a kind listed in TWO sets (`_RETRYABLE_*` and
+    `_RETRY_IN_PLACE_*`); a kind in only one is silently half-wrong — retried
+    but branch-deleted, or preserved but terminal — and nothing catches it.
+    That hazard is not hypothetical: auditing `raise WorkerError` found 5-6
+    more infrastructure failures (PID exhaustion, OOM-kill, dropped API
+    connection, 529, auth/quota) on the same generic path, so this set will
+    gain members."""
+
+    def test_infrastructure_kinds_are_retryable_by_composition(self, leerie):
+        assert leerie._INFRASTRUCTURE_FAILURE_KINDS <= \
+            leerie._RETRYABLE_FAILURE_KINDS
+        assert leerie._RETRYABLE_FAILURE_KINDS == (
+            leerie._WORKER_RETRYABLE_KINDS
+            | leerie._INFRASTRUCTURE_FAILURE_KINDS), (
+            "the retryable set must be COMPOSED from the two categories, not "
+            "maintained separately — a hand-maintained copy is how a kind "
+            "ends up in one list and not the other")
+
+    def test_the_two_categories_are_disjoint(self, leerie):
+        """A kind is either the worker's doing or it is not."""
+        assert not (leerie._WORKER_RETRYABLE_KINDS
+                    & leerie._INFRASTRUCTURE_FAILURE_KINDS)
+
+    def test_composition_is_not_hand_maintained(self, leerie):
+        """Source guard: `_RETRYABLE_FAILURE_KINDS` must be derived. A literal
+        frozenset here would pass the equality test above today and silently
+        drift the moment a category gains a member."""
+        src = inspect.getsource(leerie)
+        m = re.search(r"^_RETRYABLE_FAILURE_KINDS\s*=\s*(.+)$", src,
+                      re.MULTILINE)
+        assert m, "constant not found"
+        assert "frozenset({" not in m.group(1), (
+            "must be composed from the category sets, not a literal")
+        assert "_INFRASTRUCTURE_FAILURE_KINDS" in m.group(1)
+
+    def test_infrastructure_retry_is_logged(self, leerie):
+        """It used to be silent: `fail()` logs only on terminal or
+        cap-reached, so an operator saw a worker re-run with no explanation.
+        Part of why 488c42e5 was hard to diagnose."""
+        src = inspect.getsource(leerie._settle_subtask)
+        # Strip comments first. The explanatory comment above the call also
+        # contains "infrastructure failure", so a naive substring check is
+        # satisfied by prose even when the log() call is gone — the same trap
+        # CLAUDE.md records for the zombie reaper's docstring. Verified by
+        # mutation: replacing the call with `pass` passed the naive check.
+        code = "\n".join(l for l in src.splitlines()
+                         if not l.strip().startswith("#"))
+        assert 'log(f"  {sid}: infrastructure failure' in code, (
+            "the infrastructure retry is silent again — an operator sees a "
+            "worker re-run with no line explaining why")
+        assert (code.index("_INFRASTRUCTURE_FAILURE_KINDS")
+                < code.index("infrastructure failure")), (
+            "the log must sit inside the category branch")
 

--- a/tests/test_retryable_failure.py
+++ b/tests/test_retryable_failure.py
@@ -43,13 +43,62 @@ def test_terminal_kinds_return_false(leerie, kind):
 
 
 def test_retryable_kinds_constant_matches_documented_set(leerie):
-    """The retryable enum must be exactly the three documented kinds.
+    """The retryable enum must be exactly the four documented kinds.
     Adding a kind requires updating IMPLEMENTATION.md's "The two-tier
     retry policy" section (under §5 "Deterministic enforcement points")
     in the same change."""
     assert leerie._RETRYABLE_FAILURE_KINDS == frozenset(
-        {"no_commits", "dirty_worktree", "empty_handoff"}
+        {"no_commits", "dirty_worktree", "empty_handoff", "worktree_setup"}
     )
+
+
+def test_worktree_setup_is_retryable(leerie):
+    """A worktree-setup failure is INFRASTRUCTURE, not a broken worker.
+
+    It is raised before any worker runs, so `_retryable_failure`'s stated
+    rationale for terminal ("the worker is broken or dishonest, and
+    re-running it burns a worker invocation for no expected gain") does not
+    hold: re-running is exactly what clears it.
+
+    Regression pin for run 488c42e5 (2026-08-05), which lost `bugfix-009-2`
+    to this after its implementer had already committed — killing the wave
+    with 25 of 26 subtasks complete and leaving `resume` to hit the same
+    wall on every attempt."""
+    assert leerie._retryable_failure("worktree_setup") is True
+
+
+def test_worktree_setup_retries_in_place_and_keeps_the_branch(leerie):
+    """THE DESTRUCTIVE-FIX GUARD.
+
+    Marking the kind retryable is only half correct. The retry path calls
+    `_reset_subtask_worktree`, which runs `git branch -D` on the subtask
+    branch — right for `no_commits` (nothing worth keeping), catastrophic
+    here: the branch can already carry an earlier attempt's commits (488c42e5
+    failed with `de0d3bf` committed). Resetting would turn an infrastructure
+    hiccup into silent loss of paid-for work.
+
+    So the kind must ALSO be in `_RETRY_IN_PLACE_KINDS`, and `_settle_subtask`
+    must gate the reset on it. `new-worktree.sh` reuses an existing branch by
+    design, so retrying in place re-attaches to the work."""
+    assert "worktree_setup" in leerie._RETRY_IN_PLACE_KINDS
+    assert "git branch -D" in inspect.getsource(
+        leerie._reset_subtask_worktree) or "branch" in inspect.getsource(
+        leerie._reset_subtask_worktree), "reset no longer touches the branch"
+    src = inspect.getsource(leerie._settle_subtask)
+    assert "_RETRY_IN_PLACE_KINDS" in src, (
+        "the reset is no longer gated — a worktree_setup retry would "
+        "delete a branch that may hold committed work")
+    i = src.index("_RETRY_IN_PLACE_KINDS")
+    j = src.index("await _reset_subtask_worktree")
+    assert i < j, "the guard must precede the reset call"
+
+
+def test_no_commits_still_resets(leerie):
+    """ANTI-VACUITY: the in-place exemption must not disable the reset for
+    the kind that genuinely needs it. `no_commits` means the branch holds
+    nothing, and without the reset the retry hits
+    `fatal: a branch ... already exists`."""
+    assert "no_commits" not in leerie._RETRY_IN_PLACE_KINDS
 
 
 # --- coupling test: producer returns must match consumer's accepted set ---
@@ -65,6 +114,8 @@ _PRODUCER_RETRYABLE_KINDS = {
     "dirty_worktree",
     # _validate_result's incomplete-handoff missing-checkpoint arm → "empty_handoff"
     "empty_handoff",
+    # _settle_subtask's `except WorktreeSetupError` arm → "worktree_setup"
+    "worktree_setup",
 }
 
 
@@ -173,3 +224,28 @@ def test_settle_subtask_fail_calls_use_two_arg_signature():
         f"Every fail() invocation must pair a structured "
         f"`failure_kind` with a human-readable `reason`."
     )
+
+
+def test_settle_subtask_tags_worktree_setup(leerie):
+    """`_settle_subtask` must catch `WorktreeSetupError` SEPARATELY from the
+    generic `except WorkerError`, which tags everything "broken" (terminal).
+
+    Ordering is load-bearing: `WorktreeSetupError` subclasses `WorkerError`,
+    so a generic handler placed first would swallow it and the kind would
+    never be produced."""
+    src = inspect.getsource(leerie._settle_subtask)
+    assert "except WorktreeSetupError" in src
+    assert '"worktree_setup"' in src
+    assert (src.index("except WorktreeSetupError")
+            < src.index("except WorkerError as e:")), (
+        "WorktreeSetupError must be caught BEFORE the generic WorkerError "
+        "arm — it is a subclass, so a generic-first order swallows it")
+
+
+def test_producer_raises_the_tagged_exception_type(leerie):
+    """The kind is tagged at the producer, never inferred from prose
+    (the discipline `_RETRYABLE_FAILURE_KINDS`' own comment states)."""
+    src = inspect.getsource(leerie._run_implementer)
+    assert "raise WorktreeSetupError(" in src
+    assert issubclass(leerie.WorktreeSetupError, leerie.WorkerError)
+

--- a/tests/test_worktree_failure_not_fatal.py
+++ b/tests/test_worktree_failure_not_fatal.py
@@ -1,6 +1,7 @@
 """A worktree-creation failure must fail ONE subtask, not the whole run.
 
-`_run_implementer` raises `WorkerError` when `new-worktree.sh` returns
+`_run_implementer` raises `WorktreeSetupError` (a `WorkerError` subclass)
+when `new-worktree.sh` returns
 nonzero (e.g. an orphaned worktree dir makes `git worktree add` refuse).
 Its own `except WorkerError` guard wraps only `claude_p`, so a `_run_script`
 failure escapes it. Left uncaught in `_settle_subtask` it reaches
@@ -23,25 +24,42 @@ needs.
 from __future__ import annotations
 
 import asyncio
+import inspect
 
 from tests.test_oom_naming import env  # noqa: F401  (pytest fixture)
 
 
 def _stub_raising_run_implementer(leerie_mod, monkeypatch, calls):
-    """Patch _run_implementer to raise the exact WorkerError that
-    `_run_script("new-worktree.sh", ...)` produces on a nonzero rc."""
+    """Patch _run_implementer to raise the exact exception that
+    `_run_script("new-worktree.sh", ...)` produces on a nonzero rc.
+
+    MUST be `WorktreeSetupError`, not the base `WorkerError`. Production
+    stopped raising the base type on 2026-08-05; a stub that still raises it
+    lands on the generic `except WorkerError` arm — the terminal "broken"
+    path production no longer takes for this failure — so every assertion
+    below would pass while exercising a path that cannot occur."""
     async def _stub(sid_, leerie_dir, caps, st, models, efforts,
                     continuation=False, note=""):
-        calls.append(sid_)
-        raise leerie_mod.WorkerError(
+        calls.append((sid_, continuation, note))
+        raise leerie_mod.WorktreeSetupError(
             f"worktree creation failed for {sid_}: "
             f"fatal: '/leerie-state/runs/r/worktrees/{sid_}' already exists")
     monkeypatch.setattr(leerie_mod, "_run_implementer", _stub)
 
 
-def _settle(leerie_mod, env):
+def _settle(leerie_mod, env, *, failed_retries=None):
+    """Run `_settle_subtask`. `failed_retries` overrides the cap.
+
+    The shared `env` fixture pins `failed_retries = 0`, which is right for the
+    tests it was written for and wrong for any test asserting a RETRY: with a
+    zero budget the retry can never happen and the assertion passes or fails
+    for a reason that has nothing to do with the code under test. A test must
+    set the variable it asserts on."""
+    caps = dict(env["caps"])
+    if failed_retries is not None:
+        caps["failed_retries"] = failed_retries
     return asyncio.run(leerie_mod._settle_subtask(
-        env["sid"], env["run_dir"], env["caps"], env["st"],
+        env["sid"], env["run_dir"], caps, env["st"],
         env["models"], env["efforts"]))
 
 
@@ -72,16 +90,92 @@ def test_worktree_failure_is_recorded_in_state(env, monkeypatch):  # noqa: F811
     assert env["st"].data["subtask_status"][env["sid"]] == "failed"
 
 
-def test_worktree_failure_does_not_retry_forever(env, monkeypatch):  # noqa: F811
-    """`broken` is non-retryable: a stale worktree is not fixed by re-running
-    the same worker, so the subtask terminates on the first attempt rather
-    than burning the retry budget on a deterministic failure."""
+def test_worktree_failure_retries_but_is_bounded(env, monkeypatch):  # noqa: F811
+    """It MUST retry, and the retry must be bounded.
+
+    This test previously asserted the opposite — exactly one attempt — on the
+    premise that "a stale worktree is not fixed by re-running the same
+    worker". Run 488c42e5 (2026-08-05) falsified that premise: re-running is
+    precisely what fixes it, because `new-worktree.sh` clears the orphaned
+    directory and re-attaches to the existing branch. Treating it as terminal
+    killed a wave with 25 of 26 subtasks complete and left `resume` hitting
+    the same wall forever.
+
+    Bounded, not unbounded: a stub that fails every time must still stop at
+    `failed_retries + 1` attempts rather than spinning."""
     leerie_mod = env["leerie"]
-    calls: list[str] = []
+    calls: list = []
     _stub_raising_run_implementer(leerie_mod, monkeypatch, calls)
 
-    _settle(leerie_mod, env)
+    _settle(leerie_mod, env, failed_retries=2)
 
-    assert len(calls) == 1, (
-        f"expected exactly one attempt for a non-retryable failure, "
-        f"got {len(calls)}")
+    assert len(calls) == 3, (
+        f"expected 3 attempts (1 + failed_retries=2), got {len(calls)} — a "
+        "worktree-setup failure is retryable infrastructure, not a broken "
+        "worker")
+
+
+def test_worktree_failure_respects_a_zero_retry_budget(env, monkeypatch):  # noqa: F811
+    """ANTI-VACUITY for the test above: retryable does not mean unconditional.
+    With no budget the subtask still terminates after one attempt, so the
+    3-attempt assertion is measuring the cap, not an unbounded loop."""
+    leerie_mod = env["leerie"]
+    calls: list = []
+    _stub_raising_run_implementer(leerie_mod, monkeypatch, calls)
+
+    res = _settle(leerie_mod, env, failed_retries=0)
+
+    assert len(calls) == 1
+    assert res["status"] == "failed"
+
+
+def test_infra_retry_preserves_the_pending_corrective_note(env, monkeypatch):  # noqa: F811
+    """THE DESTRUCTIVE-FIX GUARD for the retry's payload.
+
+    In run 488c42e5 the worktree failed while the mechanical-check path had
+    already set `continuation=True` and a `_format_check_feedback` note naming
+    the unmet criterion — the pending feedback the retry existed to deliver.
+    `fail()` used to overwrite both unconditionally, so the retried worker
+    restarted blind to the very thing it was sent back to fix, missed the same
+    check again, and burned `implementer_confidence_retries`.
+
+    An infrastructure failure carries no information about what the worker
+    should do differently, so it must not overwrite the state that says what
+    the worker should do differently."""
+    leerie_mod = env["leerie"]
+    calls: list = []
+
+    pending_note = "UNMET_CRITERION: 'pnpm test roles/page.test.tsx passes'"
+    first = {"done": False}
+
+    async def _stub(sid_, leerie_dir, caps, st, models, efforts,
+                    continuation=False, note=""):
+        calls.append((sid_, continuation, note))
+        raise leerie_mod.WorktreeSetupError(
+            f"worktree creation failed for {sid_}: fatal: already exists")
+
+    monkeypatch.setattr(leerie_mod, "_run_implementer", _stub)
+    _settle(leerie_mod, env, failed_retries=2)
+    del first, pending_note
+
+    assert len(calls) > 1, "precondition: a retry must have happened"
+    _, cont_retry, note_retry = calls[1]
+    assert "worktree creation failed" not in note_retry, (
+        "the infrastructure error leaked into the worker's corrective note; "
+        "an infra failure must not overwrite what the worker is told to fix")
+    assert note_retry == calls[0][2], (
+        f"the note changed across an infrastructure retry: "
+        f"{calls[0][2]!r} -> {note_retry!r}")
+    assert cont_retry == calls[0][1], (
+        "the continuation flag changed across an infrastructure retry")
+
+
+def test_worker_failure_still_gets_a_corrective_note(env, monkeypatch):  # noqa: F811
+    """ANTI-VACUITY: the exemption must not leak to WORKER failures, where
+    the note is the entire mechanism by which the retry does better."""
+    leerie_mod = env["leerie"]
+    assert "no_commits" not in leerie_mod._INFRASTRUCTURE_FAILURE_KINDS
+    src = inspect.getsource(leerie_mod._settle_subtask)
+    i = src.index("_INFRASTRUCTURE_FAILURE_KINDS")
+    j = src.index('note = f"Previous attempt failed:')
+    assert i < j, "the note assignment must sit inside the worker-failure arm"


### PR DESCRIPTION
Run `488c42e5` lost `bugfix-009-2` **after its implementer had already committed** `de0d3bf`. Wave 2 refused to close with 25 of 26 subtasks complete, and `resume` would hit the same wall forever.

## This already happened, and the last fix was containment

`tests/test_worktree_failure_not_fatal.py`'s own docstring describes it verbatim:

> Observed in the wild: one subtask tripped a mechanical check, re-entered the continuation path, hit `fatal: '<path>' already exists`, and killed a run that had two subtasks' worth of correct committed work.

That response stopped the failure from killing the *whole run*. It never touched the cause — so it recurred, now killing the subtask and the wave instead.

## RC1 — `new-worktree.sh` pruned after it checked

```
 orphan guard   # repairs "registration gone, dir on disk"
 git worktree prune   # ← CREATES exactly that state
 reuse grep     # misses
 worktree add   # "already exists"
```

`git worktree prune` is *the operation that creates* the orphaned state the guard repairs. The comment directly below it already said prune must precede the reuse check and the add fallbacks — the guard just never moved with them. Under `--max-parallel`, a sibling's concurrent prune does the same to a live registration, which is the likelier trigger.

**Fix:** prune → orphan guard → reuse/add. A reorder, not a new guard.

## RC2 — an infrastructure failure wore a semantic label

`_run_implementer` raised a bare `WorkerError`; `_settle_subtask` tagged it `"broken"` — the terminal kind whose own docstring says it means *"the worker is broken or dishonest, and re-running it burns a worker invocation against the budget for no expected gain."*

**No worker ran.** Re-running is exactly what clears it. Same defect class as the coverage gate in #167: infrastructure wearing a semantic label, so the system takes the wrong action and the log hides the cause.

Now `WorktreeSetupError`, tagged at the producer (the discipline `_RETRYABLE_FAILURE_KINDS`' own comment states) and caught **before** the generic arm — it is a subclass, so a generic-first order swallows it.

### The part that would have made it worse

Marking the kind retryable *alone* is a data-loss bug. The retry path calls `_reset_subtask_worktree`, which runs `git branch -D` — on a branch that in this incident already held `de0d3bf`. Hence `_RETRY_IN_PLACE_KINDS`, gating the reset, with `test_worktree_setup_retries_in_place_and_keeps_the_branch` failing if the guard is removed and `test_no_commits_still_resets` as the anti-vacuity control.

**Either fix alone would have saved this run.** They are independent.

## Two of my own guards were vacuous first

Recorded so nobody trusts them blindly:

- The behavioural prune test **passed with the fix reverted** — it reproduced a *pre-existing* orphan, which either ordering handles. Rewritten to unlink the worktree's `.git` so **prune itself** creates the orphan; it now fails on the reverted order.
- The arm-deletion falsifier spliced the wrong region and proved nothing. Redone; it now fails. A third mutation (reordering the arms) produced a syntax error and is **inconclusive**, not a pass.

## Verification

- Each fix falsified individually against reverted code
- `tests/test_retryable_failure.py`'s coupling test forced the IMPLEMENTATION.md retry-policy update in the same change — working as designed
- **1172 passed** across every test touching worktree / retryable / failure_kind / `_settle_subtask` / `WorkerError` / new-worktree

🤖 Generated with [Claude Code](https://claude.com/claude-code)