### PR TITLE
chore(release): 0.10.3

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "leerie",
       "source": ".",
-      "version": "0.10.2",
+      "version": "0.10.3",
       "description": "Deterministic, headless task orchestrator for Claude Code. Classifies a task, decomposes it into dependency-ordered waves, and executes each subtask in an isolated git worktree under an evidence-gated implement/validate loop. Runs entirely on the Claude Code CLI/subscription via `claude -p` workers."
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "leerie",
   "displayName": "Leerie",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "description": "Deterministic, headless task orchestrator for Claude Code. Classifies a task, decomposes it into granular subtasks, schedules them into dependency-ordered waves, and executes each in an isolated git worktree under an evidence-gated implement/validate loop. Runs entirely on the Claude Code CLI/subscription via `claude -p` workers.",
   "author": { "name": "Andres Restrepo", "email": "andres@enricai.com", "url": "https://enricai.com" },
   "license": "MIT",


### PR DESCRIPTION
Ships #172 — the worktree fix that keeps a run from losing a subtask whose work is already committed.

Run `488c42e5` lost `bugfix-009-2` **after its implementer had committed** `de0d3bf`; wave 2 refused to close with 25 of 26 subtasks complete, and `resume` would have hit the same wall forever.

Two root causes:

- **`new-worktree.sh` trusted its pre-checks instead of its outcome.** Check-then-act against a repo a dozen sibling subtasks mutate concurrently. Now re-derives state on failure and retries once, across every empirically-enumerated failure mode (orphaned dir, stale registration, branch created by the failed attempt, branch held by a live sibling → surfaced, never forced).
- **A worktree-setup failure was classified `"broken"`** — the kind whose docstring reads *"the worker is broken or dishonest"*, when no worker had run. `_INFRASTRUCTURE_FAILURE_KINDS` is now the single source of truth, with `_RETRYABLE_FAILURE_KINDS` composed from it, so one membership drives retryability, no branch-deleting reset, and preservation of the pending corrective note.

An earlier diagnosis blaming `git worktree prune` ordering was **refuted by measurement** during review; the PR body records that rather than quietly dropping it.

## Verification

- Full CI green on #172 (`test`, `syntax`, `shellcheck`)
- Every failure mode falsified individually against reverted code
- Both manifests valid JSON with matching versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)