### PR TITLE
fix(resume): `resume <run-id>` resumed a DIFFERENT run

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2617,6 +2617,30 @@ behavioral file pins that narrowing the `except` did not make an advisory
 gate fatal. All were falsified live against each defect reintroduced
 individually.
 
+`leerie resume <run-id>` — the documented positional form — is pinned by
+`tests/test_resume_positional_run_id.py`. It silently ignored the run-id on
+every runtime until 2026-08-05: `main()` popped only `argv[0]` (the verb), so
+a run-id in `argv[1]` bound to argparse's `task` positional, `--run-id` stayed
+`None`, and `resolve_run_id` **auto-picked a different run** — measured live
+against a *running* one, where only the run-directory flock prevented a second
+orchestrator (an idle run would have been resumed silently). `resume` is the
+only verb exposed to this: `stop` / `kill` / `accept-blocked` / `finalize` /
+`status` all `exit` inside the launcher and never reach that argparse.
+`_extract_resume_run_id()` now takes the positional **before** `parse_args`
+(the ordering IS the contract — afterwards `task` has already swallowed it),
+scoped to `resume` because `list` has its own positionals
+(`list status paused`, `list chains`), with a `die()` when a positional and
+`--run-id` disagree. **No existing test could catch it** —
+`test_resolve_run_id*.py` call `resolve_run_id` directly *with* an id, so they
+passed against broken plumbing; nothing crossed the launcher→argparse
+boundary, the same shape as the coverage-gate bug above. Two traps recorded in
+that file: reverting only the *wiring* (helper defined but uncalled) must fail
+— a present-but-inert fix is the failure mode that let the coverage gate ship
+— and the safety proof that `args.task` is read only on the non-resume branch
+walks the AST of `_run_phases`, because the obvious
+`"args.task" not in getsource(main)` passes trivially (the reads are in
+`_run_phases`, not `main`) and proved nothing.
+
 No coverage
 target is set — the suite was introduced from scratch and a number
 now would be arbitrary.

--- a/docs/IMPLEMENTATION.md
+++ b/docs/IMPLEMENTATION.md
@@ -8233,6 +8233,24 @@ read it as a post-run harvest.
 
 ### Reporting — the `--report` verb
 
+**`resume` takes its run-id positionally OR as `--run-id`; both are
+equivalent.** `main()` pops the bare verb from `argv[0]`, then — for `resume`
+only — takes an optional leading non-flag positional via
+`_extract_resume_run_id()` **before** `ap.parse_args()`, and assigns it to
+`args.run_id`. The ordering is the contract: after `parse_args` the `task`
+positional has already swallowed the id. Passing both forms with *different*
+values `die()`s rather than silently preferring one. `list` is deliberately
+excluded — it has its own positionals (`list status paused`, `list chains`).
+
+This was broken from the introduction of the positional form until
+2026-08-05: only the verb was popped, so `leerie resume <run-id>` bound the id
+to `task`, left `--run-id` as `None`, and auto-picked a *different* run —
+measured live against a running one, where only the run-directory flock
+prevented a second orchestrator. `resume` is the sole verb exposed to this:
+`stop` / `kill` / `accept-blocked` / `finalize` / `status` all exit inside the
+launcher and never reach this argparse. Pinned by
+`tests/test_resume_positional_run_id.py`.
+
 `leerie --report [RUN_ID]` is a read-only telemetry report for a single run;
 like `list` it exits without running orchestrate. Run selection reuses
 `resolve_run_id` (exact-match a passed id, else auto-pick the most recent

--- a/leerie
+++ b/leerie
@@ -5433,9 +5433,18 @@ _rw_argi=0
 for arg in "$@"; do
   _rw_argi=$((_rw_argi + 1))
   # `resume` and `list` (and any positional run-id after `resume`) flow
-  # through untouched — orchestrator/leerie.py's argparse understands
-  # the bare verb form natively, exactly like the launcher's own
-  # `case "${1:-}"` dispatch one level up. No rewrite needed.
+  # through untouched — orchestrator/leerie.py pops the bare verb itself,
+  # exactly like the launcher's own `case "${1:-}"` dispatch one level up,
+  # and takes `resume`'s positional run-id via `_extract_resume_run_id`
+  # BEFORE argparse runs.
+  #
+  # That last part was NOT true until 2026-08-05, and this comment used to
+  # assert "No rewrite needed" without it. The orchestrator popped only the
+  # verb, so a positional run-id bound to argparse's `task` positional,
+  # `--run-id` stayed None, and `resolve_run_id` AUTO-PICKED A DIFFERENT RUN
+  # — measured live against a running one, where only the flock prevented a
+  # duplicate orchestrator. Do not restore the shorter claim: forwarding
+  # untouched is correct only because the orchestrator now handles it.
   if [ "$_prev_was_state_dir_rewrite" = "true" ]; then
     _prev_was_state_dir_rewrite=false
     continue

--- a/orchestrator/leerie.py
+++ b/orchestrator/leerie.py
@@ -3678,6 +3678,29 @@ def _run_recency_key(run: dict, leerie_root: Path) -> tuple[int, str]:
         return (0, "")
 
 
+def _extract_resume_run_id(argv: list[str]) -> tuple[str | None, list[str]]:
+    """Split `resume`'s optional positional run-id off the front of argv.
+
+    `leerie resume <run-id>` is the documented interface (CLAUDE.md Quick
+    start) and mirrors the `stop` / `kill` convention — but those verbs are
+    handled entirely inside the launcher, while `resume` is the one verb that
+    round-trips through this argparse. `main()` popped only `argv[0]` (the
+    verb), so a run-id in `argv[1]` bound to the `task` positional, `run_id`
+    stayed None, and `resolve_run_id` AUTO-PICKED A DIFFERENT RUN.
+
+    Measured 2026-08-05: `leerie resume 488c42e5…` announced "auto-picked the
+    most recent resumable run 7859ad30…" — a live run owned by another
+    orchestrator. Only the flock prevented a duplicate; an idle run would have
+    been resumed silently, spending hours on the wrong work.
+
+    Returns `(run_id, remaining_argv)`. A leading `-` means the caller passed
+    flags only, so there is no positional to take.
+    """
+    if argv and not argv[0].startswith("-"):
+        return argv[0], argv[1:]
+    return None, argv
+
+
 def resolve_run_id(leerie_root: Path, cli_run_id: str | None, *,
                    resumable_only: bool = False) -> str:
     """Pick the run_id to operate on.
@@ -26872,7 +26895,18 @@ See README.md "Launcher verbs" for full details and sub-flags.""")
     is_list = bool(argv) and argv[0] == "list"
     if is_resume or is_list:
         argv = argv[1:]
+    # `resume <run-id>` — the documented form. Taken BEFORE parse_args, or
+    # argparse binds it to `task` and the run-id is silently discarded.
+    # Only for `resume`: `list` has its own positionals (`list status paused`,
+    # `list chains`) that must reach argparse untouched.
+    positional_run_id, argv = (
+        _extract_resume_run_id(argv) if is_resume else (None, argv))
     args = ap.parse_args(argv)
+    if positional_run_id:
+        if args.run_id and args.run_id != positional_run_id:
+            die(f"conflicting run ids: positional '{positional_run_id}' and "
+                f"--run-id '{args.run_id}'. Pass exactly one.")
+        args.run_id = positional_run_id
     args.resume = is_resume
     args.list_runs = is_list
 

--- a/tests/test_resume_positional_run_id.py
+++ b/tests/test_resume_positional_run_id.py
@@ -1,0 +1,172 @@
+"""`leerie resume <run-id>` must resume THAT run, not auto-pick another.
+
+The documented interface (CLAUDE.md Quick start: `./leerie resume <run-id>`)
+silently ignored the run-id on every runtime. `main()` popped only `argv[0]`
+(the verb), so the run-id in `argv[1]` bound to argparse's `task` positional,
+`args.run_id` stayed `None`, and `resolve_run_id` auto-picked the newest
+resumable run instead.
+
+Measured 2026-08-05: `leerie resume 488c42e5…` announced
+
+    auto-picked the most recent resumable run 7859ad30… (in-progress)
+
+— a **live** run owned by another orchestrator. Only the flock stopped a
+duplicate (exit 75). An *idle* auto-picked run would have been resumed
+silently, spending hours on the wrong work.
+
+`resume` is the only verb affected: `stop` / `kill` / `accept-blocked` /
+`finalize` / `status` all `exit` inside the launcher and never reach this
+argparse.
+
+**Why nothing caught it:** `test_resolve_run_id.py` and
+`test_resolve_run_id_autopick.py` call `resolve_run_id(...)` directly *with* a
+run-id, so they pass against the broken plumbing. Nothing crossed the
+launcher→argparse boundary — the same shape as the 0.10.0 coverage-gate bug,
+where every test stubbed `claude_p` and so no test could see a broken call.
+"""
+from __future__ import annotations
+
+import ast
+import inspect
+
+
+class TestExtractsThePositional:
+    def test_run_id_is_taken_off_the_front(self, leerie):
+        run_id, rest = leerie._extract_resume_run_id(
+            ["488c42e5", "--max-workers", "1200"])
+        assert run_id == "488c42e5"
+        assert rest == ["--max-workers", "1200"], (
+            "the run-id must be REMOVED, or argparse still binds it to `task`")
+
+    def test_bare_resume_is_untouched(self, leerie):
+        """Auto-pick is correct when no id is given — that behaviour stays."""
+        assert leerie._extract_resume_run_id([]) == (None, [])
+        assert leerie._extract_resume_run_id(["--report"]) == (
+            None, ["--report"])
+
+    def test_flag_form_is_left_for_argparse(self, leerie):
+        """`resume --run-id X` already worked; it must keep working through
+        argparse rather than being intercepted here."""
+        run_id, rest = leerie._extract_resume_run_id(["--run-id", "X"])
+        assert run_id is None
+        assert rest == ["--run-id", "X"]
+
+    def test_a_flag_value_is_never_mistaken_for_the_run_id(self, leerie):
+        """Only argv[0] is considered, and only when it is not a flag."""
+        assert leerie._extract_resume_run_id(
+            ["--max-workers", "1200", "abc"])[0] is None
+
+
+class TestWiring:
+    """The helper is inert unless it is called in the right place. These pin
+    the seam the behavioural tests cannot see."""
+
+    def test_main_extracts_before_parse_args(self, leerie):
+        """ORDER IS THE WHOLE BUG. After `parse_args` the run-id has already
+        been swallowed by `task` and the damage is done."""
+        src = inspect.getsource(leerie.main)
+        assert "_extract_resume_run_id(" in src, "helper never called"
+        assert (src.index("_extract_resume_run_id(")
+                < src.index("args = ap.parse_args(argv)")), (
+            "extraction must happen BEFORE parse_args")
+
+    def test_main_assigns_it_to_run_id(self, leerie):
+        """Extracting without assigning would leave `run_id` None and still
+        auto-pick — a silent no-op fix."""
+        src = inspect.getsource(leerie.main)
+        assert "args.run_id = positional_run_id" in src
+
+    def test_extraction_is_scoped_to_resume(self, leerie):
+        """ANTI-VACUITY: `list` has its own positionals (`list status paused`,
+        `list chains`). Taking argv[0] there would break them."""
+        src = inspect.getsource(leerie.main)
+        i = src.index("_extract_resume_run_id(")
+        window = src[max(0, i - 200):i + 120]
+        assert "is_resume" in window, (
+            "extraction must be guarded on is_resume, not applied to `list`")
+
+    def test_resolve_run_id_consumes_args_run_id(self, leerie):
+        """Closes the loop: the value we assign is the one actually used."""
+        src = inspect.getsource(leerie.main)
+        assert "resolve_run_id(leerie_root, args.run_id" in src
+
+
+class TestConflictingIds:
+    """Positional AND --run-id together is ambiguous. Silently preferring one
+    is how a user ends up resuming a run they did not name."""
+
+    def test_conflicting_ids_are_rejected(self, leerie):
+        src = inspect.getsource(leerie.main)
+        i = src.index("args.run_id = positional_run_id")
+        window = src[max(0, i - 400):i]
+        assert "die(" in window and "conflict" in window.lower(), (
+            "a positional that disagrees with --run-id must die(), not be "
+            "silently overridden")
+
+    def test_matching_ids_are_not_an_error(self, leerie):
+        """Passing the same id both ways is redundant, not wrong."""
+        src = inspect.getsource(leerie.main)
+        assert "args.run_id != positional_run_id" in src, (
+            "the guard must compare values, not merely detect presence")
+
+
+class TestTheHazardThatMadeThisSevere:
+    def test_task_is_only_read_on_the_NON_resume_branch(self, leerie):
+        """Why binding the positional to `run_id` is safe — proved
+        structurally, not by a substring.
+
+        `_run_phases` branches on `if args.resume:`; every `args.task` read
+        must live in that statement's `else`. If one appeared on the resume
+        side, taking the positional away from `task` would starve it, and
+        `resume` would start failing with "a task description is required".
+
+        An earlier version of this test asserted `"args.task" not in
+        getsource(main)` — which passes trivially, because the reads are in
+        `_run_phases`, not `main`. It proved nothing about the claim in its
+        own docstring. This walks the AST instead."""
+        tree = ast.parse(inspect.getsource(leerie._run_phases))
+        resume_ifs = [
+            n for n in ast.walk(tree)
+            if isinstance(n, ast.If)
+            and isinstance(n.test, ast.Attribute)
+            and n.test.attr == "resume"]
+        assert resume_ifs, "`if args.resume:` not found — structure changed"
+
+        def _task_reads(nodes):
+            return [n for node in nodes for n in ast.walk(node)
+                    if isinstance(n, ast.Attribute) and n.attr == "task"
+                    and isinstance(n.value, ast.Name) and n.value.id == "args"]
+
+        on_resume = [n for br in resume_ifs for n in _task_reads(br.body)]
+        on_fresh = [n for br in resume_ifs for n in _task_reads(br.orelse)]
+        assert not on_resume, (
+            "args.task is read on the RESUME branch — taking the positional "
+            "run-id away from `task` would starve it")
+        assert on_fresh, (
+            "no args.task read on the fresh-run branch: the structure moved, "
+            "so this test is no longer proving anything")
+
+    def test_resume_is_the_only_verb_through_argparse(self, leerie):
+        """`stop`/`kill`/`accept-blocked` handle their positional inside the
+        launcher and exit; only `resume` and `list` round-trip here."""
+        src = inspect.getsource(leerie.main)
+        assert 'argv[0] == "resume"' in src
+        assert 'argv[0] == "list"' in src
+        for verb in ("stop", "kill", "accept-blocked"):
+            assert f'argv[0] == "{verb}"' not in src
+
+
+def test_launcher_comment_no_longer_claims_no_rewrite_needed():
+    """The launcher forwarded the positional under a comment asserting the
+    orchestrator 'understands the bare verb form natively — No rewrite
+    needed.' That was false and is what stopped anyone looking further.
+
+    It is true NOW (the orchestrator handles it), but the sentence that
+    misled must not survive unqualified."""
+    import pathlib
+    launcher = (pathlib.Path(__file__).resolve().parent.parent
+                / "leerie").read_text()
+    assert "No rewrite needed." not in launcher or (
+        "_extract_resume_run_id" in launcher), (
+        "the launcher still asserts no rewrite is needed without pointing at "
+        "the orchestrator-side handling that makes it true")


### PR DESCRIPTION
`leerie resume <run-id>` — the documented interface (CLAUDE.md Quick start) — **silently ignored the run-id on every runtime** and auto-picked instead.

Measured 2026-08-05, resuming `488c42e5…`:

```
auto-picked the most recent resumable run 7859ad30… (in-progress)
```

That is a **live run owned by another orchestrator**. Only the run-directory flock prevented a second orchestrator attaching to it (exit 75). Had the auto-picked run been *idle*, it would have been resumed silently — hours spent on work the user never asked for.

## Root cause

```python
argv = sys.argv[1:]              # ["resume", "488c…", "--max-workers", …]
is_resume = argv[0] == "resume"
argv = argv[1:]                  # ← pops ONLY the verb
args = ap.parse_args(argv)       # task="488c…"   run_id=None
resolve_run_id(root, args.run_id, resumable_only=True)   # → auto-pick
```

The orchestrator's own comment shows the *verb* case was handled and a **second** positional never considered. The launcher forwarded it untouched under a comment asserting the opposite of the truth:

> orchestrator/leerie.py's argparse understands the bare verb form natively … **No rewrite needed.**

`resume` is the only verb exposed — `stop` / `kill` / `accept-blocked` / `finalize` / `status` all `exit` inside the launcher and never reach this argparse (measured).

## Fix

`_extract_resume_run_id()` takes the positional **before** `parse_args` — the ordering *is* the contract, since afterwards `task` has already swallowed it — scoped to `resume` because `list` has its own positionals (`list status paused`, `list chains`). A positional that disagrees with an explicit `--run-id` `die()`s rather than silently preferring one.

Fixed in the **orchestrator**, not the launcher, so the documented form becomes real at the single point of parsing: local, fly, ec2 and direct `leerie.py` invocation all fixed at once instead of a third place to keep in sync. Safe because `args.task` is read only on the non-resume branch of `_run_phases` — proved structurally, not by substring.

## Why no test caught it

`test_resolve_run_id.py` and `test_resolve_run_id_autopick.py` call `resolve_run_id` directly **with** an id, so they pass against broken plumbing. Nothing crossed the launcher→argparse boundary — the same shape as the 0.10.0 coverage-gate bug, where every test stubbed `claude_p`.

## Two defects in my own work, caught by mutation during review

Recorded in the test file so nobody trusts these guards blindly:

- an unused `pytest` import;
- a test asserting `"args.task" not in getsource(main)` — which passes **trivially**, because both reads live in `_run_phases`. It proved nothing about the claim in its own docstring. It now walks the AST of `_run_phases` and asserts every `args.task` read sits in the `else` of `if args.resume:`, with an anti-vacuity check that one exists on the fresh-run branch.

## Verification

Five falsifications, each confirmed failing on revert:

| Revert | Result |
|---|---|
| wiring removed (helper defined, uncalled) | **5 tests fail** — a present-but-inert fix must not pass |
| extraction moved after `parse_args` | fails — that ordering *is* the bug |
| `is_resume` guard dropped | fails — would break `list status paused` |
| conflict `die()` → silent override | fails |
| launcher comment restored | fails |

**2830 passed, 28 skipped** across the 179-file `run_id`/`resume`/`argparse` superset (skips are pre-existing Darwin/bash-3.2 gates).

🤖 Generated with [Claude Code](https://claude.com/claude-code)