### PR TITLE
chore(release): 0.10.4

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "leerie",
       "source": ".",
-      "version": "0.10.3",
+      "version": "0.10.4",
       "description": "Deterministic, headless task orchestrator for Claude Code. Classifies a task, decomposes it into dependency-ordered waves, and executes each subtask in an isolated git worktree under an evidence-gated implement/validate loop. Runs entirely on the Claude Code CLI/subscription via `claude -p` workers."
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "leerie",
   "displayName": "Leerie",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "description": "Deterministic, headless task orchestrator for Claude Code. Classifies a task, decomposes it into granular subtasks, schedules them into dependency-ordered waves, and executes each in an isolated git worktree under an evidence-gated implement/validate loop. Runs entirely on the Claude Code CLI/subscription via `claude -p` workers.",
   "author": { "name": "Andres Restrepo", "email": "andres@enricai.com", "url": "https://enricai.com" },
   "license": "MIT",


### PR DESCRIPTION
Ships #174 — `leerie resume <run-id>` resuming a **different run** than the one named.

The documented positional form was silently ignored on every runtime: `main()` popped only the verb, so the run-id bound to argparse's `task`, `--run-id` stayed `None`, and `resolve_run_id` auto-picked. Measured live, it selected a **running** run owned by another orchestrator — only the run-directory flock prevented a second orchestrator attaching to it. An idle run would have been resumed silently.

`_extract_resume_run_id()` now takes the positional **before** `parse_args` (the ordering is the contract), scoped to `resume` since `list` has its own positionals, with a `die()` when a positional and `--run-id` disagree.

Fixed in the orchestrator rather than the launcher so the documented form becomes real at the single point of parsing — local, fly, ec2 and direct `leerie.py` invocation all at once.

## Verification

- Full CI green on the PR head and on `main` (`test`, `syntax`, `release`) across 3.10/3.11/3.12
- Five falsifications, each confirmed failing on revert — including that removing only the *wiring* fails 5 tests, so a present-but-inert fix cannot pass
- 2830 passed / 28 skipped locally across the 179-file `run_id`/`resume`/`argparse` superset
- Both manifests valid JSON with matching versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)