### PR TITLE
fix(integration-judge): don't gate a merge on a dropped duplicate

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -5583,6 +5583,32 @@ verify "the plan misses work X" without reading prose.
   through the same way a planner can add a subtask, so this gate is
   **detect-and-die, single pass**, mirroring `wiring_judge` /
   `provision_judge`.
+
+  **Location is not coverage.** A merge that drops a *duplicate* is textually
+  indistinguishable from one that drops the only copy — both remove content
+  present in a parent — so reasoning from the parent diffs alone cannot tell
+  them apart. Measured: this gate killed a run at wave 3 with 28 subtasks
+  complete and two waves integrated, over a dropped `describe` block whose
+  assertions were a strict *subset* of a separate test file written 4h45m
+  earlier. The textual claim was true and the behavioral claim was false.
+  `dropped_change` is 10 of the 14 findings this gate has ever emitted, and it
+  has no bypass flag, so this is the failure mode with the most exposure.
+
+  A `dropped_change` is therefore only behavioral if the behavior is absent
+  from the **merged tree**, not merely from the side the merge chose. The judge
+  already holds inspection tools, so it is asked to search the merged tree for
+  equivalent coverage and cite it concretely (file + assertion). A defect
+  carrying a specific citation is advisory; one without still gates. This is
+  the same correction applied to the on-HEAD satisfied-probe — judge by
+  *coverage*, not by *location*.
+
+  The citation is **asked for and never required**. Requiring a field on a
+  judge's schema has three times in this codebase produced a worker that emits
+  no schema-valid output at all, and a gate that never runs catches nothing
+  (§8 *Findings carry a severity* — the default is gating). Absence therefore
+  gates: the exception narrows this gate only when the judge does the extra
+  work and shows it, which keeps the failure direction conservative on the one
+  gate that has no operator bypass.
 - **`plan_overlap_judge`'s own `judgment` self-score is dropped, with no new
   independent verifier.** This worker is already the independent adversarial
   check for cross-planner surface collisions — layering a second judge on

--- a/docs/IMPLEMENTATION.md
+++ b/docs/IMPLEMENTATION.md
@@ -5646,7 +5646,23 @@ and no stub-based test could see it. Persists to
 (boolean), `defects` (array of `{kind: enum[dropped_change,
 reintroduced_conflict, call_site_mismatch, semantic_regression,
 incomplete_resolution], concrete_scenario (string), location (string),
-why_broken (string)}` — non-empty ⇒ gate), `rationale` (string). Given the
+why_broken (string)}` — non-empty ⇒ gate), `rationale` (string). Each
+`defects` item also carries an **optional** `coverage_elsewhere`
+(`{searched (boolean), file (string), assertion (string)}`) — asked for by
+the prompt, deliberately **not** in the item's `required` list (DESIGN §8
+*Location is not coverage*; requiring a judge field has three times produced
+a worker emitting no schema-valid output at all, and a gate that never runs
+catches nothing). A
+`dropped_change` whose `coverage_elsewhere` names a file that **exists in
+the merged tree** plus a non-blank `assertion` is downgraded to advisory —
+logged, not gating. Absence, a blank field, or a named file absent from
+the tree all gate exactly as before; absence is the conservative
+direction. Blankness and file existence are checked in
+`_coverage_citation_clears`, not by the schema: neither string carries a
+`minLength`, because a `minLength` on an *optional* property breaks the
+`--dangerously-force-strict-output` invariant that forcing a field must
+never make a trivial value illegal. A hallucinated path therefore cannot
+buy a downgrade, and the strict-output grammar stays satisfiable. Given the
 merged result plus both parent diffs and the conflicting subtasks' intents,
 it attacks the merge for behavioral breakage the mechanical conflict-marker
 scan and `check_merge_committed` cannot see — a syntactically clean merge

--- a/orchestrator/leerie.py
+++ b/orchestrator/leerie.py
@@ -2372,6 +2372,42 @@ SCHEMAS: dict[str, dict] = {
                         "concrete_scenario": {"type": "string"},
                         "location": {"type": "string"},
                         "why_broken": {"type": "string"},
+                        # DESIGN §8 "Location is not coverage": a merge that
+                        # drops a DUPLICATE is textually identical to one that
+                        # drops the only copy, so the parent diffs alone cannot
+                        # tell them apart. The judge is asked to search the
+                        # merged tree and cite equivalent coverage; a
+                        # `dropped_change` that cites a real file plus a
+                        # non-blank assertion is downgraded to advisory.
+                        #
+                        # Deliberately ABSENT from `required` above. Requiring a
+                        # judge field has three times produced a worker emitting
+                        # no schema-valid output at all (`confidence` on 10
+                        # schemas, `artifact_paths` -> 40.9% validity,
+                        # `severity` -> 9/66 wiring_judge runs invalid), and a
+                        # gate that never runs catches nothing. Absence gates --
+                        # the conservative direction, matching `wiring_defects`'
+                        # unlabelled-severity rule.
+                        #
+                        # No `minLength` on these two: an OPTIONAL field
+                        # carrying one is a trap, because
+                        # `--dangerously-force-strict-output` forces every
+                        # property into `required` -- the grammar could then
+                        # emit "" and the CLI's own validator would reject it,
+                        # trading a compile error for a validation error (see
+                        # tests/test_strict_output_proxy.py's
+                        # forcing-a-field-never-makes-a-trivial-value-illegal
+                        # invariant). Blankness is rejected in
+                        # `_coverage_citation_clears` instead, which is the
+                        # right layer anyway: code enforces, schemas describe.
+                        "coverage_elsewhere": {
+                            "type": "object",
+                            "properties": {
+                                "searched": {"type": "boolean"},
+                                "file": {"type": "string"},
+                                "assertion": {"type": "string"},
+                            },
+                        },
                     },
                 },
             },
@@ -6995,6 +7031,91 @@ def _normalize_artifact_path(path: str) -> str:
     while normalized.startswith("./"):
         normalized = normalized[2:]
     return normalized.lstrip("/")
+
+
+def _coverage_citation_clears(defect: dict, repo_root: Path) -> str | None:
+    """DESIGN §8 *Location is not coverage*. Returns the accepted citation as
+    `"<file>: <assertion>"` when a `dropped_change` defect proves the dropped
+    behavior still lives in the merged tree, or `None` when the defect gates.
+
+    A merge that drops a *duplicate* is textually identical to one that drops
+    the only copy — both remove content present in a parent — so the parent
+    diffs cannot distinguish them. Measured: this gate killed a run at wave 3
+    with 28 subtasks complete over a dropped `describe` block whose assertions
+    were a strict subset of a separate file written 4h45m earlier.
+
+    Only `dropped_change` is eligible: the other four kinds
+    (`reintroduced_conflict`, `call_site_mismatch`, `semantic_regression`,
+    `incomplete_resolution`) describe breakage *introduced* by the merge, which
+    coverage living elsewhere cannot excuse.
+
+    The file-existence test is mechanical and deliberate — the citation is the
+    only thing standing between a real lossy merge and a silent downgrade on
+    the one gate with no operator bypass, so a hallucinated path must not buy
+    one. `searched` is not consulted: a judge that sets it without supplying a
+    usable file/assertion has shown nothing."""
+    if defect.get("kind") != "dropped_change":
+        return None
+    cite = defect.get("coverage_elsewhere")
+    if not isinstance(cite, dict):
+        return None
+    rel = _normalize_artifact_path(str(cite.get("file") or ""))
+    assertion = str(cite.get("assertion") or "").strip()
+    if not rel or not assertion:
+        return None
+    try:
+        resolved = (repo_root / rel).resolve()
+        # A `..` segment survives _normalize_artifact_path (it only strips
+        # leading `./` and `/`), so confine the citation to the merged tree.
+        resolved.relative_to(repo_root.resolve())
+    except (ValueError, OSError):
+        return None
+    if not resolved.is_file():
+        return None
+    return f"{rel}: {assertion}"
+
+
+def _partition_integration_defects(
+        judge_result: dict, repo_root: Path) -> tuple[list[str], list[str]]:
+    """Split an `integration_judge` result's defects into
+    `(gating_issues, advisory_notes)`.
+
+    **Pure, and it must stay pure.** Its adapter inside `integrate_wave`
+    (`_check_integration`) is invoked TWICE per judge result: once by
+    `_run_checked_loop` as its `check=`, and again after the loop to decide the
+    `die()`. Any side effect on this path therefore fires at least twice per
+    defect, and up to `judgment_check_rounds` + 1 times when a `WorkerError`
+    retry re-invokes the judge. So the advisory text is *returned*, and the
+    caller logs it exactly once.
+
+    Both filters live here so neither is duplicated across the two call sites:
+    the pre-existing anti-gaming rule (a defect gates only with a concrete
+    scenario and a location named) and the DESIGN §8 *Location is not coverage*
+    citation downgrade."""
+    gating: list[str] = []
+    advisory: list[str] = []
+    for d in judge_result.get("defects") or []:
+        if not isinstance(d, dict):
+            continue
+        scenario = (d.get("concrete_scenario") or "").strip()
+        location = (d.get("location") or "").strip()
+        # Anti-gaming: a defect gates only with concrete scenario and location
+        # named.
+        if not scenario or not location:
+            continue
+        # DESIGN §8 "Location is not coverage": a dropped DUPLICATE is not
+        # behavioral breakage. Downgrade to advisory only on a citation naming
+        # a file that really exists in the merged tree; absence gates.
+        cleared = _coverage_citation_clears(d, repo_root)
+        if cleared:
+            advisory.append(
+                f"({d.get('kind')}) {location}: {scenario} — "
+                f"equivalent coverage cited at {cleared}")
+            continue
+        gating.append(
+            f"INTEGRATION_DEFECT ({d.get('kind', 'behavioral_defect')}) "
+            f"{location}: {scenario} — {d.get('why_broken', '')}")
+    return gating, advisory
 
 
 def check_overlap_judge_output(
@@ -20865,6 +20986,26 @@ async def phase_adherence_gate(plans: list[dict], task: str, st: State,
             "subtask (as that subtask's runs_commands), not substituted "
             "with hand-authored work."
         )
+        # No `domains=` here, deliberately -- this is NOT an oversight, and it
+        # is not the same situation as `phase_overlap_judge`, which does pass
+        # `domains=_replan_domain_closure(plans, implicated)`. That judge's
+        # findings are PAIRWISE BETWEEN SUBTASKS, so each carries sids a
+        # closure can expand. This gate's findings are plan-global: the
+        # deterministic floor emits `PRESCRIBED_CMD_UNRUN: ...` naming a
+        # COMMAND, and `SCHEMAS["adherence_judge"]["properties"]["violations"]`
+        # is an array of plain STRINGS -- there is no field that could carry a
+        # sid. Nothing here identifies a subtask, so there is nothing to seed a
+        # closure with.
+        #
+        # Scoping this by inventing an attribution the findings do not have
+        # (e.g. bolting a `suggested_domain` onto the judge and guessing when
+        # it is absent) was considered and rejected. When a prescribed command
+        # genuinely cannot be attached to any subtask, the whole plan really is
+        # implicated and re-planning every domain is correct, not wasteful.
+        # This path is rare regardless: repair-before-re-drive means it fired
+        # in 1 run of 130.
+        #
+        # If a future adherence finding DOES carry a sid, use the closure.
         cur_plans[0] = await phase_plan(
             replan_task, st, caps, models, efforts,
             replan_round=replan_round[0])
@@ -25021,20 +25162,12 @@ async def integrate_wave(wave: list[str], results: dict[str, dict],
                 )
 
             def _check_integration(judge_result: dict) -> list[str]:
-                issues: list[str] = []
-                for d in judge_result.get("defects") or []:
-                    if not isinstance(d, dict):
-                        continue
-                    scenario = (d.get("concrete_scenario") or "").strip()
-                    location = (d.get("location") or "").strip()
-                    # Anti-gaming: a defect gates only with concrete scenario
-                    # and location named.
-                    if not scenario or not location:
-                        continue
-                    issues.append(
-                        f"INTEGRATION_DEFECT ({d.get('kind', 'behavioral_defect')}) "
-                        f"{location}: {scenario} — {d.get('why_broken', '')}")
-                return issues
+                # Thin adapter for `_run_checked_loop`'s `check=` contract.
+                # Deliberately side-effect free: this runs once per round
+                # inside the loop AND again after it, so logging here would
+                # emit each advisory 2-4 times. The post-loop call site logs
+                # the advisory list once.
+                return _partition_integration_defects(judge_result, repo_root)[0]
 
             # No make_feedback_prompt: detect-and-die, single pass. The
             # integrator cannot mechanically fix a semantic finding without
@@ -25055,7 +25188,13 @@ async def integrate_wave(wave: list[str], results: dict[str, dict],
                 log(f"  ⚠  integration-judge for {sid} crashed every round; "
                     "degrading (merge preserved, check_merge_committed already ran)")
             else:
-                remaining_defects = _check_integration(judge_result)
+                # The single place advisories are logged — see
+                # `_partition_integration_defects`' docstring for why this is
+                # not done inside `_check_integration`.
+                remaining_defects, advisories = _partition_integration_defects(
+                    judge_result, repo_root)
+                for a in advisories:
+                    log(f"  ⚠  integration-judge-{sid}: advisory {a}")
                 if remaining_defects:
                     # Found behavioral breakage. Unlike the wiring gate (pre-merge),
                     # we already have a committed merge, so the abort instruction

--- a/prompts/integration_judge.md
+++ b/prompts/integration_judge.md
@@ -41,6 +41,34 @@ accomplish (their subtask intents/diffs, given in your input). Concretely:
   invariant) still reflecting only one side, when both should have been
   reconciled together.
 
+## Before you emit a `dropped_change`: look for the behavior elsewhere
+
+A merge that drops a **duplicate** looks exactly like a merge that drops the
+only copy — in both, content present in a parent is absent from the result.
+The parent diffs alone cannot tell those apart, so you have to check the
+merged tree itself.
+
+Before emitting any `dropped_change`, use your inspection tools to search the
+merged tree for the behavior you believe was lost — the same assertion, the
+same validation, the same field — under a different path, a different test
+file, or a different helper. Repos routinely carry the same coverage in a
+conventionally-named sibling written by an earlier subtask, so the content
+being gone *from the side the merge chose* does not mean it is gone.
+
+Then fill `coverage_elsewhere` on that defect:
+
+- **Found it** — set `file` to the path that still provides the behavior and
+  `assertion` to the specific test name, function, or assertion you actually
+  read there. The defect is recorded as advisory and does not gate.
+- **Searched and found nothing** — set `searched` to `true` and leave `file`
+  and `assertion` off. The defect gates, which is the right outcome for a
+  genuinely lossy merge.
+
+Cite only what you actually opened. The cited path is checked mechanically
+against the merged tree: one that does not exist there is ignored and the
+defect gates regardless. A citation is not a way to soften a finding you are
+unsure about — when in doubt, gate.
+
 ## What NOT to flag
 
 - A resolution that correctly picks one side over the other because the
@@ -50,6 +78,10 @@ accomplish (their subtask intents/diffs, given in your input). Concretely:
   would have worked."
 - Pre-existing bugs unrelated to this merge — you attack the merge's OWN
   resolution, not the codebase's general quality.
+- Content absent from the side the merge chose but still present **elsewhere
+  in the merged tree** — a duplicated block, or a test whose assertions a
+  sibling file already covers. No behavior was lost. Record it with
+  `coverage_elsewhere` filled in rather than gating the run on it.
 - Cosmetic/style differences between how the two sides wrote equivalent
   logic — attack behavior, not style.
 - A hypothetical "this could theoretically break under X" with no
@@ -65,6 +97,8 @@ accomplish (their subtask intents/diffs, given in your input). Concretely:
 | Merge resolves a conflicting edit to the same function by silently reverting to the pre-conflict version, losing both sides' work | **yes** — `dropped_change` |
 | Two sides added unrelated fields to the same config object; merge keeps both | **no** — correct resolution |
 | Merge picks side A's fix for a shared bug over side B's alternate fix; both would have worked | **no** — legitimate choice, not a defect |
+| Merge drops a test block whose assertions are all already covered by a separate, earlier test file still present in the merged tree | **no** — record it with `coverage_elsewhere` naming that file |
+| Merge drops a test block and you searched the merged tree and found nothing equivalent | **yes** — `dropped_change`, `searched` true, no file cited |
 
 Attack the merged result. Return an empty `defects` array only when you
 genuinely tried to find a behavioral break and could not — the correct,
@@ -82,9 +116,20 @@ on work that was already correct.
       "concrete_scenario": "feat-003 renamed validate_login(form) to validate_login(form, strict=False); the merge kept feat-003's rename but left feat-005's new call site in auth_handlers.py calling validate_login(form) with the old one-argument signature.",
       "location": "auth_handlers.py:142",
       "why_broken": "This call now raises TypeError at runtime — validate_login requires the strict argument after the rename, and this call site was added by the other branch after the rename landed, so it was never updated."
+    },
+    {
+      "kind": "dropped_change",
+      "concrete_scenario": "feat-005 added a describe block asserting the export endpoint's header row and its 401 rejection; the merge took feat-003's version of that file wholesale, so the block is absent from the result.",
+      "location": "tests/export_route_test.py",
+      "why_broken": "Those two assertions no longer run from this file.",
+      "coverage_elsewhere": {
+        "searched": true,
+        "file": "tests/export_route_shape_test.py",
+        "assertion": "test_export_header_row_and_rejects_unauthenticated"
+      }
     }
   ],
-  "rationale": "One call site was not updated to match a signature change from the other branch; otherwise the merge correctly combines both sides' work."
+  "rationale": "One call site was not updated to match a signature change from the other branch. A second block was dropped, but an earlier test file still covers both of its assertions, so that one is advisory."
 }
 ```
 
@@ -100,6 +145,13 @@ on work that was already correct.
   the defect lives at (**must be non-empty**); `why_broken` explains the
   concrete runtime/behavioral consequence. An entry missing a concrete
   field is dropped and does not gate.
+- `coverage_elsewhere`: optional, and meaningful only on `dropped_change`.
+  Where the behavior still lives in the merged tree after the merge.
+  `searched` records that you looked; `file` and `assertion` name what you
+  found. An entry whose `file` exists in the merged tree and whose
+  `assertion` is non-empty is downgraded to advisory instead of gating the
+  run. Omit the whole object if you did not search — omitting it gates,
+  which is the safe default.
 - `rationale`: 1–3 sentences on whether the merge correctly reconciles
   both sides' intended behavior.
 

--- a/tests/test_integration_judge_coverage.py
+++ b/tests/test_integration_judge_coverage.py
@@ -1,0 +1,480 @@
+"""`integration_judge` must not kill a run over a dropped *duplicate*.
+
+DESIGN §8 *Location is not coverage*. A merge that drops a duplicate is
+textually identical to one that drops the only copy — in both, content present
+in a parent is absent from the result — so the parent diffs alone cannot tell
+them apart.
+
+Measured incident: the gate killed a run at wave 3 with 28 subtasks complete
+and two waves integrated, over a dropped `describe` block whose assertions were
+a strict *subset* of a separate test file written 4h45m earlier. The textual
+claim was true; the behavioral claim was false. `dropped_change` is 10 of the
+14 findings this gate has ever emitted, and it has no bypass flag.
+
+The fix asks the judge to cite equivalent coverage in the merged tree and
+downgrades a *cited* `dropped_change` to advisory. Two properties are
+load-bearing and are pinned hardest here:
+
+1. **The citation field is asked for, never `required`.** Requiring a judge
+   field has three times in this codebase produced a worker emitting no
+   schema-valid output at all (`confidence` on 10 schemas; `artifact_paths`
+   dropping `plan_overlap_judge` to 40.9% validity; `severity` invalidating
+   9/66 `wiring_judge` runs). A gate that never runs catches nothing.
+2. **Absence gates.** The downgrade is the narrow exception, not the default,
+   because this is the last defence against a silently-lossy merge.
+"""
+from __future__ import annotations
+
+import ast
+import inspect
+import json
+import textwrap
+
+import pytest
+from jsonschema import Draft7Validator, validate
+
+
+def _defect(**over) -> dict:
+    d = {
+        "kind": "dropped_change",
+        "concrete_scenario": "feat-005's assertions are absent from the result.",
+        "location": "tests/export_route_test.py",
+        "why_broken": "Those assertions no longer run from this file.",
+    }
+    d.update(over)
+    return d
+
+
+class TestSchemaShape:
+    """The field must exist and must NOT be required — see the module
+    docstring for the three measured regressions behind that split."""
+
+    def test_coverage_elsewhere_is_a_property(self, leerie):
+        item = leerie.SCHEMAS["integration_judge"]["properties"]["defects"]["items"]
+        assert "coverage_elsewhere" in item["properties"]
+
+    def test_coverage_elsewhere_is_NOT_required(self, leerie):
+        item = leerie.SCHEMAS["integration_judge"]["properties"]["defects"]["items"]
+        assert "coverage_elsewhere" not in item["required"], (
+            "requiring a judge field has three times produced a worker "
+            "emitting no schema-valid output at all; a gate that never runs "
+            "catches nothing (DESIGN §8)")
+
+    def test_preexisting_required_fields_are_unchanged(self, leerie):
+        item = leerie.SCHEMAS["integration_judge"]["properties"]["defects"]["items"]
+        assert set(item["required"]) == {
+            "kind", "concrete_scenario", "location", "why_broken"}
+
+    def test_schema_is_valid_and_serializable(self, leerie):
+        s = leerie.SCHEMAS["integration_judge"]
+        Draft7Validator.check_schema(s)
+        json.loads(json.dumps(s))
+
+    def test_defect_without_the_field_still_validates(self, leerie):
+        """The whole point of not requiring it."""
+        validate({"merge_reviewed": True, "defects": [_defect()],
+                  "rationale": "x"}, leerie.SCHEMAS["integration_judge"])
+
+    def test_defect_with_a_full_citation_validates(self, leerie):
+        validate({"merge_reviewed": True,
+                  "defects": [_defect(coverage_elsewhere={
+                      "searched": True, "file": "tests/sibling_test.py",
+                      "assertion": "test_header_row"})],
+                  "rationale": "x"}, leerie.SCHEMAS["integration_judge"])
+
+    @pytest.mark.parametrize("bad", [
+        {"searched": True, "file": "", "assertion": "test_x"},
+        {"searched": True, "file": "tests/sibling_test.py", "assertion": ""},
+    ])
+    def test_blank_citation_still_parses_but_is_rejected_by_code(
+            self, leerie, bad, tmp_path):
+        """Blankness is enforced in `_coverage_citation_clears`, NOT by the
+        schema — see the `minLength` test below for why the schema must not
+        do it. The schema accepts a blank citation; the gate ignores it."""
+        validate({"merge_reviewed": True,
+                  "defects": [_defect(coverage_elsewhere=bad)],
+                  "rationale": "x"}, leerie.SCHEMAS["integration_judge"])
+        assert leerie._coverage_citation_clears(
+            _defect(coverage_elsewhere=bad), tmp_path) is None
+
+    def test_citation_strings_carry_no_minLength(self, leerie):
+        """A `minLength` on an OPTIONAL property is a trap:
+        `--dangerously-force-strict-output` forces every property into
+        `required`, and the grammar could then emit `""` — a value the CLI's
+        own validator rejects, trading a compile error for a validation
+        error. Pinned by `tests/test_strict_output_proxy.py`'s
+        forcing-a-field-never-makes-a-trivial-value-illegal invariant, which
+        this schema violated on first draft."""
+        item = leerie.SCHEMAS["integration_judge"]["properties"]["defects"]["items"]
+        cite = item["properties"]["coverage_elsewhere"]["properties"]
+        for k in ("file", "assertion"):
+            assert "minLength" not in cite[k], (
+                f"{k} carries minLength on an optional field — breaks the "
+                "strict-output grammar invariant")
+
+
+class TestCitationClears:
+    """`_coverage_citation_clears` — the mechanical half. A citation buys a
+    downgrade only when it names a file that really exists in the merged
+    tree."""
+
+    @pytest.fixture
+    def tree(self, tmp_path):
+        (tmp_path / "tests").mkdir()
+        (tmp_path / "tests" / "sibling_test.py").write_text("def test_x(): ...")
+        return tmp_path
+
+    def test_real_citation_clears(self, leerie, tree):
+        got = leerie._coverage_citation_clears(
+            _defect(coverage_elsewhere={
+                "searched": True, "file": "tests/sibling_test.py",
+                "assertion": "test_header_row"}), tree)
+        assert got == "tests/sibling_test.py: test_header_row"
+
+    def test_leading_dot_slash_is_normalized(self, leerie, tree):
+        assert leerie._coverage_citation_clears(
+            _defect(coverage_elsewhere={
+                "file": "./tests/sibling_test.py", "assertion": "test_x"}),
+            tree) == "tests/sibling_test.py: test_x"
+
+    def test_no_citation_gates(self, leerie, tree):
+        assert leerie._coverage_citation_clears(_defect(), tree) is None
+
+    def test_hallucinated_path_gates(self, leerie, tree):
+        """The load-bearing anti-gaming property: a judge cannot talk its way
+        out of a finding by naming a file that is not there."""
+        assert leerie._coverage_citation_clears(
+            _defect(coverage_elsewhere={
+                "searched": True, "file": "tests/does_not_exist.py",
+                "assertion": "test_x"}), tree) is None
+
+    def test_searched_true_alone_gates(self, leerie, tree):
+        """"I looked and found nothing" is the gating answer, not a bypass."""
+        assert leerie._coverage_citation_clears(
+            _defect(coverage_elsewhere={"searched": True}), tree) is None
+
+    @pytest.mark.parametrize("cite", [
+        {"file": "", "assertion": "test_x"},
+        {"file": "tests/sibling_test.py", "assertion": ""},
+        {"file": "tests/sibling_test.py", "assertion": "   "},
+        {"file": "   ", "assertion": "test_x"},
+    ])
+    def test_blank_halves_gate(self, leerie, tree, cite):
+        assert leerie._coverage_citation_clears(
+            _defect(coverage_elsewhere=cite), tree) is None
+
+    def test_non_dict_citation_gates(self, leerie, tree):
+        for junk in ("tests/sibling_test.py", ["a"], 3, None):
+            assert leerie._coverage_citation_clears(
+                _defect(coverage_elsewhere=junk), tree) is None
+
+    def test_directory_is_not_a_file(self, leerie, tree):
+        assert leerie._coverage_citation_clears(
+            _defect(coverage_elsewhere={
+                "file": "tests", "assertion": "test_x"}), tree) is None
+
+    def test_traversal_outside_the_tree_gates(self, leerie, tree, tmp_path):
+        """`_normalize_artifact_path` strips only leading `./` and `/`, so a
+        `..` segment survives it. A citation must not reach outside the
+        merged tree to find its evidence."""
+        outside = tmp_path.parent / "outside_test.py"
+        outside.write_text("x")
+        assert leerie._coverage_citation_clears(
+            _defect(coverage_elsewhere={
+                "file": f"../{outside.name}", "assertion": "test_x"}),
+            tree) is None
+
+    @pytest.mark.parametrize("kind", [
+        "reintroduced_conflict", "call_site_mismatch",
+        "semantic_regression", "incomplete_resolution"])
+    def test_only_dropped_change_is_eligible(self, leerie, tree, kind):
+        """The other four kinds describe breakage the merge INTRODUCED;
+        coverage living elsewhere cannot excuse them."""
+        assert leerie._coverage_citation_clears(
+            _defect(kind=kind, coverage_elsewhere={
+                "searched": True, "file": "tests/sibling_test.py",
+                "assertion": "test_x"}), tree) is None
+
+
+class TestIncidentReplay:
+    """The measured shape, end to end through the helper."""
+
+    def test_dropped_duplicate_is_downgraded(self, leerie, tmp_path):
+        (tmp_path / "tests").mkdir()
+        sibling = tmp_path / "tests" / "export_route_shape_test.py"
+        sibling.write_text(
+            "def test_export_header_row_and_rejects_unauthenticated(): ...")
+        assert leerie._coverage_citation_clears(
+            _defect(coverage_elsewhere={
+                "searched": True,
+                "file": "tests/export_route_shape_test.py",
+                "assertion":
+                    "test_export_header_row_and_rejects_unauthenticated"}),
+            tmp_path)
+
+    def test_genuinely_lossy_merge_still_gates(self, leerie, tmp_path):
+        """ANTI-VACUITY. If this ever returns a citation, the fix has traded a
+        false positive for a false negative on the one gate with no bypass."""
+        (tmp_path / "tests").mkdir()
+        assert leerie._coverage_citation_clears(
+            _defect(coverage_elsewhere={
+                "searched": True, "file": "tests/export_route_shape_test.py",
+                "assertion": "test_header_row"}), tmp_path) is None
+
+
+class TestWiring:
+    """The helper is inert unless `_check_integration` consults it. That
+    function is nested inside `integrate_wave`, so this is source-coupled."""
+
+    def test_gate_consults_the_helper(self, leerie):
+        """The citation check lives in `_partition_integration_defects`, which
+        `integrate_wave` must reach on both its call paths."""
+        part = inspect.getsource(leerie._partition_integration_defects)
+        assert "_coverage_citation_clears(" in part, (
+            "the downgrade is a no-op unless the partition calls it")
+        wave = inspect.getsource(leerie.integrate_wave)
+        assert wave.count("_partition_integration_defects(") >= 2, (
+            "both the `check=` adapter and the post-loop site must use it, or "
+            "the two paths can disagree")
+
+    def test_downgrade_short_circuits_before_the_issue_is_appended(self, leerie):
+        """A cleared defect must `continue`, not fall through and gate
+        anyway — the fix would be inert but look present."""
+        src = inspect.getsource(leerie._partition_integration_defects)
+        i = src.index("_coverage_citation_clears(")
+        window = src[i:i + 500]
+        assert "continue" in window
+        assert window.index("continue") < window.index("gating.append")
+
+    def test_helper_is_module_level_not_nested(self, leerie):
+        """Module-level so it is directly testable; `test_no_dead_functions`
+        also requires it to have a real caller, which the guard above pins."""
+        assert callable(getattr(leerie, "_coverage_citation_clears", None))
+
+    def test_anti_gaming_scenario_location_filter_survives(self, leerie):
+        """The pre-existing filter must not have been displaced by the new
+        clause when the logic moved into the partition helper."""
+        src = inspect.getsource(leerie._partition_integration_defects)
+        assert "if not scenario or not location:" in src
+
+    def test_gate_still_dies_on_remaining_defects(self, leerie):
+        """The downgrade narrows the gate; it must not have removed it."""
+        src = inspect.getsource(leerie.integrate_wave)
+        assert "integration gate found behavioral defect(s)" in src
+
+
+class TestPromptAsksForIt:
+    """§12: the prompt is advisory, the code enforces. But a field nothing
+    asks for is never filled, so the ask must exist."""
+
+    def test_prompt_requests_the_citation(self):
+        import pathlib
+        p = (pathlib.Path(__file__).resolve().parent.parent
+             / "prompts" / "integration_judge.md").read_text()
+        assert "coverage_elsewhere" in p
+        assert "merged tree" in p
+
+    def test_prompt_states_that_absence_gates(self):
+        import pathlib
+        p = (pathlib.Path(__file__).resolve().parent.parent
+             / "prompts" / "integration_judge.md").read_text().lower()
+        assert "gates" in p and "does not exist" in p
+
+
+class TestGateExecutes:
+    """RUN the real gate function, don't just read its source.
+
+    Every other test in this file either exercises `_coverage_citation_clears`
+    in isolation or asserts on `integrate_wave`'s *source text*. Neither
+    executes `_check_integration`, which is where the two are joined — and
+    `integrate_wave` is a large async function no unit test drives, so the
+    branch would otherwise ship unexecuted by anything.
+
+    That is exactly how the 0.10.0 coverage-gate bug shipped: every test
+    stubbed the layer above, so a `claude_p` call that raised `TypeError` on
+    EVERY invocation survived a whole release while the gate's own broad
+    `except Exception` logged it as a clean advisory degrade. Source-coupling
+    cannot see a runtime error; only running the code can.
+
+    So: lift `_check_integration` out of its enclosing function by AST and
+    execute it against a synthetic closure scope.
+    """
+
+    @staticmethod
+    def _extract(leerie, repo_root, sid="feat-014"):
+        fn = ast.parse(
+            textwrap.dedent(inspect.getsource(leerie.integrate_wave))).body[0]
+        found = [n for n in ast.walk(fn)
+                 if isinstance(n, ast.FunctionDef)
+                 and n.name == "_check_integration"]
+        assert found, (
+            "ANTI-VACUITY: _check_integration not found inside integrate_wave "
+            "— the harness would silently test nothing")
+        mod = ast.Module(body=[found[0]], type_ignores=[])
+        ast.fix_missing_locations(mod)
+        logs: list[str] = []
+        ns = {"log": logs.append,
+              "_coverage_citation_clears": leerie._coverage_citation_clears,
+              "_partition_integration_defects":
+                  leerie._partition_integration_defects,
+              "repo_root": repo_root, "sid": sid}
+        exec(compile(mod, "<extracted>", "exec"), ns)
+        return ns["_check_integration"], logs
+
+    @pytest.fixture
+    def gate(self, leerie, tmp_path):
+        (tmp_path / "tests").mkdir()
+        (tmp_path / "tests" / "sibling_test.py").write_text(
+            "def test_header_row(): ...")
+        check, logs = self._extract(leerie, tmp_path)
+        return check, logs
+
+    def test_uncited_dropped_change_gates(self, gate):
+        check, logs = gate
+        assert len(check({"defects": [_defect()]})) == 1
+
+    def test_cited_and_present_is_downgraded(self, gate):
+        check, _ = gate
+        assert check({"defects": [_defect(coverage_elsewhere={
+            "searched": True, "file": "tests/sibling_test.py",
+            "assertion": "test_header_row"})]}) == []
+
+    def test_the_adapter_is_pure(self, gate):
+        """REGRESSION PIN. `_check_integration` is invoked TWICE per judge
+        result — once by `_run_checked_loop` as its `check=`, once again
+        post-loop to decide the `die()` — and up to `judgment_check_rounds`+1
+        times when a WorkerError retry re-invokes. A `log()` inside it emitted
+        every advisory 2-4 times; the first version of this file shipped that
+        bug, and the test that should have caught it asserted `len(logs) == 1`
+        after a SINGLE call, which is precisely the shape that hides a
+        double-call.
+
+        Call it repeatedly, as production does, and assert nothing is
+        emitted."""
+        check, logs = gate
+        payload = {"defects": [
+            _defect(),
+            _defect(location="b.py", coverage_elsewhere={
+                "searched": True, "file": "tests/sibling_test.py",
+                "assertion": "test_header_row"}),
+        ]}
+        first = check(payload)
+        for _ in range(4):
+            assert check(payload) == first, "the adapter must be deterministic"
+        assert logs == [], (
+            "_check_integration must be side-effect free — it runs 2-4 times "
+            "per judge result, so a log() here duplicates every advisory")
+
+    def test_cited_but_absent_still_gates(self, gate):
+        """The anti-gaming property, exercised through the real gate rather
+        than the helper alone. If this ever passes, a hallucinated citation
+        can silence the only merge check with no operator bypass."""
+        check, _ = gate
+        assert len(check({"defects": [_defect(coverage_elsewhere={
+            "searched": True, "file": "tests/NOPE.py",
+            "assertion": "test_header_row"})]})) == 1
+
+    def test_citation_on_a_non_dropped_change_still_gates(self, gate):
+        check, _ = gate
+        assert len(check({"defects": [_defect(
+            kind="call_site_mismatch", coverage_elsewhere={
+                "searched": True, "file": "tests/sibling_test.py",
+                "assertion": "test_header_row"})]})) == 1
+
+    def test_preexisting_anti_gaming_filter_still_runs(self, gate):
+        """The new clause must not have displaced the scenario/location
+        filter that ran before it."""
+        check, _ = gate
+        assert check({"defects": [_defect(concrete_scenario="")]}) == []
+        assert check({"defects": [_defect(location="  ")]}) == []
+
+    def test_mixed_batch_keeps_only_the_uncleared(self, gate):
+        """The realistic shape: one real defect plus one dropped duplicate."""
+        check, _ = gate
+        issues = check({"defects": [
+            _defect(location="a.py"),
+            _defect(location="b.py", coverage_elsewhere={
+                "searched": True, "file": "tests/sibling_test.py",
+                "assertion": "test_header_row"}),
+        ]})
+        assert len(issues) == 1 and "a.py" in issues[0]
+
+
+class TestPartition:
+    """`_partition_integration_defects` — where both filters actually live,
+    and the only place the advisory text is produced."""
+
+    @pytest.fixture
+    def tree(self, tmp_path):
+        (tmp_path / "tests").mkdir()
+        (tmp_path / "tests" / "sibling_test.py").write_text("def t(): ...")
+        return tmp_path
+
+    def test_returns_both_lists_in_one_pass(self, leerie, tree):
+        gating, advisory = leerie._partition_integration_defects({"defects": [
+            _defect(location="a.py"),
+            _defect(location="b.py", coverage_elsewhere={
+                "searched": True, "file": "tests/sibling_test.py",
+                "assertion": "test_header_row"}),
+        ]}, tree)
+        assert len(gating) == 1 and "a.py" in gating[0]
+        assert len(advisory) == 1 and "b.py" in advisory[0]
+        assert "tests/sibling_test.py" in advisory[0], (
+            "the advisory must name where the coverage was found, or it is "
+            "unreviewable")
+
+    def test_advisory_is_empty_when_nothing_is_cited(self, leerie, tree):
+        gating, advisory = leerie._partition_integration_defects(
+            {"defects": [_defect()]}, tree)
+        assert len(gating) == 1 and advisory == []
+
+    def test_anti_gaming_drops_from_both_lists(self, leerie, tree):
+        """A defect with no concrete scenario is neither gating nor advisory —
+        it is not a finding at all."""
+        gating, advisory = leerie._partition_integration_defects(
+            {"defects": [_defect(concrete_scenario="")]}, tree)
+        assert gating == [] and advisory == []
+
+    def test_empty_and_malformed_input(self, leerie, tree):
+        assert leerie._partition_integration_defects({}, tree) == ([], [])
+        assert leerie._partition_integration_defects(
+            {"defects": None}, tree) == ([], [])
+        assert leerie._partition_integration_defects(
+            {"defects": ["not-a-dict", 7]}, tree) == ([], [])
+
+    def test_gating_text_keeps_the_INTEGRATION_DEFECT_prefix(self, leerie, tree):
+        """The die() message and any log scraping depend on this prefix."""
+        gating, _ = leerie._partition_integration_defects(
+            {"defects": [_defect()]}, tree)
+        assert gating[0].startswith("INTEGRATION_DEFECT (dropped_change)")
+
+
+class TestAdvisoryIsLoggedExactlyOnce:
+    """The other half of the purity fix: the caller must still surface
+    advisories, or the downgrade becomes silent."""
+
+    def test_post_loop_site_logs_the_advisories(self, leerie):
+        src = inspect.getsource(leerie.integrate_wave)
+        i = src.index("remaining_defects, advisories = ")
+        window = src[i:i + 400]
+        assert "for a in advisories:" in window and "log(" in window, (
+            "advisories must be logged at the single post-loop site")
+
+    def test_adapter_body_contains_no_log_call(self, leerie):
+        """Source-coupled twin of `test_the_adapter_is_pure`: catches a `log()`
+        reintroduced on a branch the behavioural test happens not to hit."""
+        fn = ast.parse(textwrap.dedent(
+            inspect.getsource(leerie.integrate_wave))).body[0]
+        ci = [n for n in ast.walk(fn) if isinstance(n, ast.FunctionDef)
+              and n.name == "_check_integration"][0]
+        calls = [n.func.id for n in ast.walk(ci)
+                 if isinstance(n, ast.Call) and isinstance(n.func, ast.Name)]
+        assert "log" not in calls, (
+            "_check_integration runs 2-4 times per judge result; a log() here "
+            "duplicates every advisory line")
+
+    def test_partition_helper_itself_never_logs(self, leerie):
+        calls = [n.func.id for n in ast.walk(ast.parse(textwrap.dedent(
+                    inspect.getsource(leerie._partition_integration_defects))))
+                 if isinstance(n, ast.Call) and isinstance(n.func, ast.Name)]
+        assert "log" not in calls and "print" not in calls

--- a/tests/test_replan_scoping_asymmetry.py
+++ b/tests/test_replan_scoping_asymmetry.py
@@ -1,0 +1,121 @@
+"""Only one of the two re-plan call sites scopes by domain — on purpose.
+
+| call site | gate | scoped? |
+|---|---|---|
+| `phase_overlap_judge` | cross-domain surface overlap | ✅ `domains=_replan_domain_closure(...)` |
+| `phase_adherence_gate` | plan-instruction adherence | ❌ re-plans every domain |
+
+The asymmetry is **structural, not an oversight**. The overlap judge's findings
+are pairwise between subtasks, so each carries sids a closure can expand. The
+adherence gate's findings are plan-global: its deterministic floor emits
+`PRESCRIBED_CMD_UNRUN` naming a *command*, and `adherence_judge`'s `violations`
+is an array of plain **strings** — there is no field that could carry a sid.
+
+This file exists because the asymmetry reads like a bug. Without it, the next
+reader "fixes" it by inventing an attribution the findings do not have —
+bolting a `suggested_domain` onto the judge and guessing when it is absent,
+which keeps the unscoped path alive anyway while adding a field the judge has
+no grounds to fill.
+
+Cost of the unscoped path is low and measured: repair-before-re-drive means it
+fired in **1 run of 130**.
+"""
+from __future__ import annotations
+
+import ast
+import inspect
+import textwrap
+
+
+def _phase_plan_kwargs(fn) -> list[set[str]]:
+    """Keyword names on every `phase_plan(...)` call inside `fn`.
+
+    Walks the AST rather than grepping: the adherence gate's call site now
+    carries a comment *explaining* the absent `domains=` argument, and a
+    substring check reads that explanation as the argument itself. That is
+    exactly the false positive this repo keeps paying for."""
+    tree = ast.parse(textwrap.dedent(inspect.getsource(fn)))
+    return [{k.arg for k in n.keywords if k.arg}
+            for n in ast.walk(tree)
+            if isinstance(n, ast.Call)
+            and isinstance(n.func, ast.Name) and n.func.id == "phase_plan"]
+
+
+class TestTheAsymmetryIsReal:
+    def test_overlap_judge_scopes_its_replan(self, leerie):
+        calls = _phase_plan_kwargs(leerie.phase_overlap_judge)
+        assert calls, "structure moved — no phase_plan call found"
+        assert any("domains" in kw for kw in calls), (
+            "the overlap judge's re-plan must stay scoped — its findings "
+            "carry sids, so the closure is derivable")
+
+    def test_adherence_gate_does_not_scope_its_replan(self, leerie):
+        calls = _phase_plan_kwargs(leerie.phase_adherence_gate)
+        assert calls, "structure moved — no phase_plan call found"
+        assert not any("domains" in kw for kw in calls), (
+            "the adherence gate must NOT pass domains= — its findings carry "
+            "no sid, so any scope would be invented")
+
+    def test_the_probe_is_not_fooled_by_the_comment(self, leerie):
+        """ANTI-VACUITY for the probe itself: the source DOES contain the
+        literal text `domains=` (in the explanatory comment), so a substring
+        check would report the opposite of the truth here."""
+        assert "domains=" in inspect.getsource(leerie.phase_adherence_gate)
+
+
+class TestTheReasonIsRecorded:
+    """A bare absence is indistinguishable from a forgotten argument."""
+
+    def test_the_call_site_explains_why(self, leerie):
+        src = inspect.getsource(leerie.phase_adherence_gate)
+        i = src.index("cur_plans[0] = await phase_plan(")
+        window = src[max(0, i - 1400):i]
+        assert "_replan_domain_closure" in window, (
+            "the comment must name the mechanism it is declining to use, so "
+            "the reader can see the choice was considered")
+        assert "violations" in window, (
+            "the comment must name the schema fact that makes scoping "
+            "underivable")
+
+    def test_the_comment_is_adjacent_to_the_call(self, leerie):
+        """Recorded 1400 chars above the call, not in a distant docstring."""
+        src = inspect.getsource(leerie.phase_adherence_gate)
+        i = src.index("cur_plans[0] = await phase_plan(")
+        assert "No `domains=` here" in src[max(0, i - 1400):i]
+
+
+class TestTheSchemaFactBehindIt:
+    """If this ever changes, the comment above becomes a lie and the closure
+    genuinely should be wired. That is the trigger to revisit."""
+
+    def test_violations_is_an_array_of_bare_strings(self, leerie):
+        v = leerie.SCHEMAS["adherence_judge"]["properties"]["violations"]
+        assert v["type"] == "array"
+        assert v["items"] == {"type": "string"}, (
+            "violations items gained structure — if one of those fields can "
+            "carry a subtask id, wire _replan_domain_closure into "
+            "phase_adherence_gate and delete this test")
+
+    def test_no_suggested_domain_field_was_bolted_on(self, leerie):
+        v = leerie.SCHEMAS["adherence_judge"]["properties"]["violations"]
+        assert "properties" not in v.get("items", {}), (
+            "the rejected patch was adding an attribution field to the judge; "
+            "it is not the fix")
+
+
+class TestAntiVacuity:
+    """`domains=` must still DO something, or the asymmetry is meaningless."""
+
+    def test_phase_plan_accepts_and_filters_on_domains(self, leerie):
+        sig = inspect.signature(leerie.phase_plan)
+        assert "domains" in sig.parameters
+        src = inspect.getsource(leerie.phase_plan)
+        assert "in domains" in src, (
+            "phase_plan must actually filter categories on domains — if it "
+            "does not, scoping the overlap judge's re-plan is also a no-op "
+            "and this whole distinction is theatre")
+
+    def test_replan_domain_closure_exists_and_is_used(self, leerie):
+        assert callable(leerie._replan_domain_closure)
+        assert "_replan_domain_closure(" in inspect.getsource(
+            leerie.phase_overlap_judge)


### PR DESCRIPTION
## Problem

A merge that drops a **duplicate** is textually identical to one that drops the only copy — both remove content present in a parent — so the parent diffs alone cannot tell them apart. The integration gate could not make that distinction, and it is **detect-and-die with no bypass flag**.

Measured: it killed a run at wave 3 with **28 subtasks complete and two waves integrated**, over a dropped `describe` block whose assertions were a strict *subset* of a separate test file written 4h45m earlier. The textual claim was true; the behavioral claim was false.

`dropped_change` is **10 of the 14** findings this gate has ever emitted — the shape with the most exposure.

## Fix

The judge is asked to search the merged tree and cite equivalent coverage (file + assertion). A cited `dropped_change` is downgraded to advisory; everything else gates exactly as before.

The citation is **checked mechanically** — the named file must exist in the merged tree, confined against `..` traversal — so a hallucinated path cannot silence a real finding. Only `dropped_change` is eligible; the other four kinds describe breakage the merge itself *introduced*, which coverage elsewhere cannot excuse.

Same correction already applied to the on-HEAD satisfied-probe: judge by **coverage**, not by **location**.

### Two deliberate non-obvious choices

**`coverage_elsewhere` is absent from `required`.** Requiring a judge field has three times in this codebase produced a worker emitting no schema-valid output at all — `confidence` on 10 schemas, `artifact_paths` dropping `plan_overlap_judge` to 40.9% validity, `severity` invalidating 9/66 `wiring_judge` runs. A gate that never runs catches nothing. **Absence gates**, which is the conservative direction on the one gate with no operator bypass.

**The citation strings carry no `minLength`.** An optional property with one breaks `--dangerously-force-strict-output`'s invariant that forcing a field must never make a trivial value illegal (that flag forces every property into `required`, and the grammar could then emit `""` for a value the CLI rejects). Caught by this repo's own `test_strict_output_proxy.py`. Blankness is rejected in `_coverage_citation_clears` instead — code enforces, schemas describe.

## Also in this change

- **P11** — record why `phase_adherence_gate` passes no `domains=` to its re-plan. Its findings are plan-global: the floor names a *command*, and `adherence_judge`'s `violations` is an array of bare **strings**, so no sid exists to seed `_replan_domain_closure` with. The gate was already correct; only the reason was unrecorded. Pinned by an **AST** test — a substring check is fooled by the very comment that explains the absence.
- **`_partition_integration_defects`** keeps the decision pure. `_check_integration` is invoked 2–4 times per judge result (once per `_run_checked_loop` round, once post-loop), so a `log()` inside it emitted every advisory that many times. The caller now logs exactly once.

## Three-layer order

`docs/DESIGN.md` §8 *Location is not coverage* → `docs/IMPLEMENTATION.md` schema surface → `orchestrator/leerie.py` → `prompts/integration_judge.md`.

## Testing

**Full suite: 5720 passed, 82 skipped, 0 failed** (serial, idle host — the configuration CLAUDE.md records as giving 0 failures 4/4). The 82 skips are all the pre-existing tree-sitter gate; neither new test file is among them.

Every new guard was falsified by mutation:

| mutant | caught by |
|---|---|
| drop the `is_file()` check (hallucinated citation clears) | `test_cited_but_absent_still_gates` |
| make the fix inert (never call the helper) | `TestWiring` |
| make `coverage_elsewhere` `required` | `TestSchemaShape` |
| re-introduce `log()` inside the adapter | `test_the_adapter_is_pure` + its AST twin |
| remove the post-loop advisory logging (silent downgrade) | `test_post_loop_site_logs_the_advisories` |

`TestGateExecutes` extracts the real nested `_check_integration` by AST and **executes** it — no source-coupling — because `integrate_wave` is a large async function no unit test drives. That is the 0.10.0 coverage-gate shape, where every test stubbed the layer above and a `TypeError` on every invocation shipped for a whole release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)