### PR TITLE
fix(strict-output): restore the 1M context window behind the proxy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2711,6 +2711,61 @@ walks the AST of `_run_phases`, because the obvious
 No coverage
 target is set — the suite was introduced from scratch and a number
 now would be arbitrary.
+The `--dangerously-force-strict-output` context-window regression (DESIGN §7
+*Forcing constrained decoding*, §6 *A client-side context refusal*) is covered
+by three files. The defect: the flag works by owning `ANTHROPIC_BASE_URL`, and
+the CLI treats any custom base URL as an **LLM gateway** — behind which it can
+no longer confirm the answering model and falls back to a conservative
+client-side context ceiling instead of Sonnet 5's native 1M. It then refuses
+prompts *itself* at ~224K, emitting a synthetic assistant message
+(`model=<synthetic>`, usage all zeros) with **no API call**.
+`tests/test_strict_proxy_context_window.py` pins `_model_arg`: `sonnet`/`opus`
+gain the `[1m]` suffix only while `_STRICT_PROXY` is active, `haiku` never does
+(it has no 1M variant and the CLI rejects the suffix), a full model id passes
+through untouched, the suffix is not doubled, `_ONE_M_CONTEXT_MODELS` is a
+subset of `MODEL_VALUES` (a typo there would silently disable the fix rather
+than fail), and — the wiring pin — `claude_p`'s source builds `--model` via
+`_model_arg(model)` and no longer contains a bare `"--model", model,`. The
+suffix is applied automatically and is deliberately **not** admitted to
+`MODEL_VALUES`: it is inert whenever the proxy is off, so an operator gains
+nothing by setting it by hand and could set it on `haiku`, where it breaks.
+`tests/test_context_overflow_classifier.py` pins `_is_context_overflow` and
+`ContextOverflow` against verbatim `result` envelopes from that probe. Both
+signals are required — `terminal_reason == "blocking_limit"` **and** the result
+text — because the reason alone is shared (sibling arms ended `max_turns`, a
+healthy run `completed`) and the text alone can appear in a worker's own
+correct output; `subtype` is a misleading `"success"` and must never be keyed
+on, the same trap `_is_transient_transport_failure` documents. Gated on
+`is_error` and exempting `_leerie_synthetic`, mirroring
+`_is_terminal_auth_failure`, plus disjointness pins against both auth
+classifiers. `ContextOverflow` subclasses `BaseException` and explicitly **not**
+`WorkerError` — `_run_checked_loop` retries WorkerError across its whole round
+budget, which for a deterministic client-side refusal is pure waste — and
+source-coupling guards require `claude_p` to raise before the generic
+two-attempt failure and `main()` to route it to a resumable `EXIT_LOCKED` pause
+whose message never says "schema". That message is the point: unclassified,
+this surfaced as *"worker failed schema-valid output twice: Prompt is too
+long,"* which cost three successive misdiagnoses on 2026-08-06. When extracting
+the handler arm in a test, split on `"\n    except "` (a top-level handler), not
+a bare `"except "` — the latter truncates at the inner `except Exception:`
+guarding the cleanup call and hides the `exit_code` assignment after it.
+`tests/test_task_file_globbing.py` covers the independent `_glob_task_references`
+defect the same incident surfaced but which did **not** cause it (the failing
+run's very first request was already over the ceiling, before the planner read
+anything): markdown emphasis is stripped before glob classification, since `*`
+is a `_GLOB_CHARS` member and `glob("*")` matches every file in the repo root —
+measured, that handed the planner 18 files / 1.86 MB as required reading,
+including `LICENSE`, `.claude.json` and a prior run's 847 KB log. Pinned: prose
+(`*`, `**`, `**Root**`, `_em_`, backticks) resolves nothing; genuine references
+(`spec.md`, `tests/*.py`, `docs/DESIGN.md`, `spec.{md,txt}`, and a path wrapped
+in bold) still resolve; absolute paths and `../` traversal resolve nothing —
+admitting separator-bearing tokens without that guard reached **outside the
+repo** (`repo_root / "/bin/sh"` discards the root, so a task mentioning
+`/bin/bash` matched a 1.4 MB binary), which is why containment is re-checked
+against `repo_root.resolve()` independently of the token-level test; and a task
+file never lists itself, while a same-named file with *different* contents
+still does. Falsification is recorded: replaying the pre-fix token filter
+against the prose-only fixture matches 4 files where the test expects none.
 The two read-mostly verbs that still assumed a two-runtime world —
 `accept-blocked` (validated `--runtime` against only `fly`/`local` and
 defaulted anything non-fly to `local`, silently mislabeling an EC2 run)

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -2649,6 +2649,30 @@ Claude Code's own remedy for a mid-stream drop is an automatic retry
 backoff is the fresh-session complement for when the CLI's in-session
 retries are exhausted.
 
+**A client-side context refusal is a fourth class, and it is terminal.**
+Claude Code enforces a context ceiling *itself*: when the assembled prompt
+exceeds the window it believes the model has, it emits a synthetic assistant
+message (`model=<synthetic>`, usage all zeros) and ends the session with
+`terminal_reason` = `"blocking_limit"` and result text `"Prompt is too long"`
+— **without issuing an API call at all**. Retrying identical input therefore
+cannot succeed, which puts this in the same bucket as terminal auth rather
+than the transient classes above. `_is_context_overflow` requires *both* that
+`terminal_reason` and the result text: the reason alone is shared with other
+blocking limits, and the text alone could appear in a worker's own correct
+output. It is checked immediately after the terminal-auth classifier and
+before the generic corrective-note retry, and routed to the same resumable
+`EXIT_LOCKED` pause — the remedy is an operator change, not a wait.
+
+Left unclassified this failure was actively misleading rather than merely
+unhandled: the envelope fell through to the two-attempt schema loop and
+surfaced as *"worker failed schema-valid output twice: Prompt is too long,"*
+blaming schema validation for a context refusal. On 2026-08-06 that wording
+cost three successive misdiagnoses before the real cause was measured, which
+is why the pause message names the actual contributors — the task text and
+the repo's CLAUDE.md are both loaded into every worker's context — and, when
+the strict-output proxy is active, names it first (see §7 *Forcing
+constrained decoding*).
+
 **Worktree-only cleanup, always.** Whether triggered by Ctrl-C,
 SIGTERM, SIGHUP, WorkerError, or any other exception:
 
@@ -4991,6 +5015,35 @@ proxy is never contacted and the operator is silently handed the post-hoc
 validation they explicitly asked to replace — or it misroutes every worker call.
 Since a run cannot tell those apart from a healthy one, leerie refuses that
 combination too rather than guessing.
+
+**Owning that variable also costs the model's native context window, and
+leerie has to buy it back.** The Claude Code CLI treats any custom
+`ANTHROPIC_BASE_URL` as an LLM gateway, and behind a gateway it can no longer
+confirm which model actually answers, so it falls back to a conservative
+client-side context ceiling instead of the model's real window. Sonnet 5
+natively carries 1M on the first-party API; behind the proxy the CLI refuses
+prompts at roughly 224K. That refusal is client-side and silent — no API call,
+no server error (see §6 *A client-side context refusal*) — so nothing in the
+run explains why an otherwise-fine prompt was rejected.
+
+The remedy is the documented gateway-side selector: leerie appends `[1m]` to
+the model alias whenever the proxy is active (`_model_arg`), which is a no-op
+on the direct path where the native window already applies. It is scoped to
+the aliases that *have* a 1M variant — `haiku` has none and rejects the
+suffix — and is applied automatically rather than exposed as a flag, since an
+operator gains nothing by setting by hand a value that is inert whenever the
+proxy is off.
+
+Measured across five arms on one 225 KB worker payload, varying only
+`ANTHROPIC_BASE_URL`: direct sustained 235,805 tokens over 20 requests with no
+refusal; a *passthrough* proxy that rewrites nothing refused after 224,127,
+and the real strict proxy after 224,247 — two reproductions 120 tokens apart,
+which is what establishes the base-URL override rather than the schema
+rewriting as the cause. Adding `[1m]` cleared both paths (261,014 and 276,579
+tokens, the latter completing successfully), with the proxy's
+rewritten/passed-through/fell-back counters identical under either alias — so
+the window is bought back without giving up the constrained decoding the flag
+exists for.
 
 What happens after a hard worker error depends on whether partial progress can
 be salvaged. An **implementer** has a worktree branch and possibly a checkpoint,

--- a/docs/IMPLEMENTATION.md
+++ b/docs/IMPLEMENTATION.md
@@ -3351,6 +3351,21 @@ request, 2026-08-04). Measured across the run corpus, **2,861 of 9,924
 submissions (28.8%)** are malformed as a result. Setting `strict: true` compiles
 the schema into a sampling grammar and makes those shapes unrepresentable.
 
+**Context-window side effect (`_model_arg`).** Owning `ANTHROPIC_BASE_URL`
+makes the CLI treat the session as gateway-routed, so it applies a
+conservative client-side context ceiling instead of the model's native
+window. `_model_arg(model)` therefore appends `[1m]` — the documented
+gateway-side selector for the 1M window — to any alias in
+`_ONE_M_CONTEXT_MODELS` (`sonnet`, `opus`; **not** `haiku`, which has no 1M
+variant and rejects the suffix) whenever `_STRICT_PROXY` is active. Inert on
+the direct path, where `sonnet` already resolves to Sonnet 5's native 1M.
+Measured over five arms on one 225 KB payload, varying only the base URL:
+direct sustained 235,805 tokens; a *passthrough* proxy that rewrites nothing
+refused after 224,127 and the real strict proxy after 224,247 — so the cause
+is the base-URL override, not the rewrite. Adding `[1m]` cleared both
+(261,014 and 276,579 tokens, the latter completing successfully), with
+rewritten/passed_through/fell_back counters identical under either alias.
+
 **Mechanism.** `_StrictOutputProxy` — an `asyncio.start_server` listener on
 `127.0.0.1`, **one per run**, started in `_orchestrate()` before the first
 worker and closed in its `finally` — which covers normal completion, `die()`,
@@ -3791,6 +3806,28 @@ CLI's own in-session retry (the `claude -p` mid-stream fix landed in CLI
 v2.1.219); leerie sees the drop only once the CLI's retries are exhausted.
 Measured basis and rationale: DESIGN §6 *Cleanup on abnormal exit* (56 of
 58 dropped sids were pure-transport, 83% recovering on a later attempt).
+
+#### Context overflow (client-side refusal)
+
+`_is_context_overflow(envelope)` is checked in `claude_p()` immediately
+after `_is_terminal_auth_failure` and **before** the generic 2-attempt
+loop, raising `ContextOverflow` (a `BaseException`, deliberately **not** a
+`WorkerError` — `_run_checked_loop` retries those across its whole round
+budget). Claude Code enforces a context ceiling client-side: it emits a
+synthetic assistant message (`model=<synthetic>`, usage all zeros) and ends
+the session with **no API call**, so replaying identical input cannot
+succeed. Before this classifier the envelope surfaced as `worker failed
+schema-valid output twice: Prompt is too long`, blaming schema validation
+for a context refusal.
+
+Match requires **both** `terminal_reason == "blocking_limit"` and the
+phrase in `result`: the reason alone is shared with other blocking limits
+(sibling probe arms ended `max_turns`), and the text alone could appear in
+a worker's own correct output. Gated on `is_error` and exempting
+`_leerie_synthetic`, mirroring `_is_terminal_auth_failure`. Do **not** key
+on `subtype`, which is a misleading `"success"`. `main()` treats it as a
+resumable `EXIT_LOCKED` pause and names the likely remedy — dropping
+`--dangerously-force-strict-output` (see `_model_arg` below).
 
 #### Terminal auth failure
 
@@ -4983,7 +5020,8 @@ DESIGN.md §8 for the full rationale and the incident this replaced).
 | Function | Purpose |
 |----------|---------|
 | `_expand_braces(pattern)` | Pre-expands `{a,b}` brace groups that Python's `glob.glob` does not handle. Recursive for nested braces. |
-| `_glob_task_references(task, repo_root)` | Scans the task string for file-path tokens, expands braces, globs each pattern. Returns deduplicated `list[Path]`. |
+| `_glob_task_references(task, repo_root)` | Scans the task string for file-path tokens, expands braces, globs each pattern. Returns deduplicated `list[Path]`. Tokens are stripped of markdown emphasis (`*`, `_`, backticks) **before** classification and must still look like a path afterwards — some alphanumeric content plus an extension or a `/`. Without that, `*` (a `_GLOB_CHARS` member, and ordinary emphasis in a markdown task) globs to every file in the repo root: measured on a 185 KB task carrying 134 bare `*` and 217 `**`, the planner was handed 18 files / 1.86 MB as required reading, including `LICENSE` and a prior run's 847 KB log. Absolute-path tokens are refused (`repo_root / "/etc/x"` discards the root — pathlib lets an absolute right-hand side win), and every glob result is independently re-checked for containment under `repo_root.resolve()` so `../` segments cannot escape either. The task file never appears in its own list (`_is_same_document`). |
+| `_is_same_document(path, text_len, text)` | True when `path` holds exactly `text` modulo surrounding whitespace. Keeps a task file out of its own reference list: the planner already has the task verbatim, so listing the file asks it to re-read content it holds — ~71K tokens of duplication on the measured incident (185,565 B at the measured 2.6 B/token). `resolve_task_argument` returns stripped contents and discards the path, so identity is re-established by content rather than by threading the path through every caller. A size pre-check (±8 bytes) means only a same-length candidate is ever opened; `text_len` is the task's encoded length, passed in rather than recomputed because this runs once per candidate and the task can be hundreds of KB. |
 | `_repo_rel(path, repo_root)` | Repo-relative string for a path, falling back to its basename when it resolves outside the repo. Pure path arithmetic. |
 | `_format_task_file_references(files, repo_root)` | Names the files the task references so the planner reads them itself. A list of paths and nothing else — it must not open them. `None` when the task names no files. |
 
@@ -7935,6 +7973,7 @@ written somewhere in `orchestrator/leerie.py`. The coupling test in
 | `source_of_truth_pref` | str | resolved preference (`codebase` / `research` / `both`) |
 | `clarify` | bool | whether asking the user is allowed for this run (resolved from `--clarify` / `LEERIE_CLARIFY` / `leerie.toml` / default `False`) |
 | `dangerously_skip_permissions` | bool | whether every `claude -p` worker — including the judgment workers running in the real repo cwd — is invoked with `--dangerously-skip-permissions`. Resolved from `--dangerously-skip-permissions` / `LEERIE_DANGEROUSLY_SKIP_PERMISSIONS` / `leerie.toml` / default `False`. When `True`, waives the DESIGN §12 mechanical read-only enforcement on the classifier / planner / reconciler / plan_overlap_judge / provision workers; trust shifts onto their prompts. Re-resolved fresh on every run, including `resume`, so the user can flip it without editing state |
+| `dangerously_force_strict_output` | bool | whether this run forced constrained decoding via the per-run loopback proxy (`--dangerously-force-strict-output` / `LEERIE_DANGEROUSLY_FORCE_STRICT_OUTPUT` / `dangerously_force_strict_output` in leerie.toml). Mirrored from `caps["force_strict_output"]`. Recorded because the flag changes worker behaviour invisibly — it owns `ANTHROPIC_BASE_URL`, which makes the CLI treat the session as gateway-routed and apply a conservative client-side context ceiling instead of the model's native window (see `_model_arg`). Without this field a run's failure cannot be attributed to the flag after the fact. |
 | `skip_overlap_judge` | bool | whether the phase 2¾ `plan_overlap_judge` worker is suppressed even on multi-planner runs (DESIGN §5 *Cross-domain surface overlap*). Resolved from `--skip-overlap-judge` / `LEERIE_SKIP_OVERLAP_JUDGE` / `leerie.toml` / default `False`. The cheap-skip on single-planner / <2-subtask runs is automatic and not gated by this field — this flag only affects runs where the worker would otherwise fire. Re-resolved fresh on every run, including `resume`, so the user can flip it without editing state |
 | `skip_adherence_check` | bool | whether the instruction-adherence gate (the deterministic prescribed-command-coverage floor + the `adherence_judge` worker in the planner check loop) is suppressed. Resolved from `--skip-adherence-check` / `LEERIE_SKIP_ADHERENCE_CHECK` / `skip_adherence_check` in `leerie.toml` / default `False`. When True, a plan that diverges from an explicitly prescribed procedure is not caught before `phase_execute` spends. Re-resolved fresh on every run, including `resume`, so the user can flip it without editing state |
 | `skip_coverage_check` | bool | whether the phase 2⅞½ task-coverage gate (a single advisory `task_coverage_judge` invocation since 2026-08-04; the deterministic `check_required_items_coverage` floor it used to compose with was deleted) is suppressed. Resolved from `--skip-coverage-check` / `LEERIE_SKIP_COVERAGE_CHECK` / `skip_coverage_check` in `leerie.toml` / default `False`. When True, the review does not run at all — no gap is surfaced before `phase_execute` spends. Since the gate is advisory, this suppresses the report and its worker call, not a block. Added after run 488c42e5, where the judge counted a task item the task itself deferred as `missing_work` — unsatisfiable by any planner, with no operator override, unlike every sibling gate. Re-resolved fresh on every run, including `resume` |

--- a/orchestrator/leerie.py
+++ b/orchestrator/leerie.py
@@ -325,6 +325,7 @@ STATE_FIELDS = (
     "artifact_registry",
     "needs_source_of_truth", "source_of_truth_pref", "clarify",
     "dangerously_skip_permissions",
+    "dangerously_force_strict_output",
     "skip_overlap_judge",
     "skip_adherence_check",
     "skip_coverage_check",
@@ -2563,6 +2564,40 @@ class RateLimitedExit(BaseException):
         self.reset_at = reset_at
         self.raw_message = raw_message
         self.out_of_credits = out_of_credits
+
+
+class ContextOverflow(BaseException):
+    """Raised when Claude Code refuses a prompt *itself* for exceeding the
+    context window it believes the model has.
+
+    Not a server rejection: the CLI emits a synthetic assistant message
+    (`model=<synthetic>`, usage all zeros) and terminates with
+    `terminal_reason: "blocking_limit"` and `result: "Prompt is too long"`
+    without issuing an API call. So retrying identical input cannot
+    succeed — yet before this class existed the envelope fell through to
+    claude_p()'s generic 2-attempt loop and surfaced as `worker failed
+    schema-valid output twice: Prompt is too long`, blaming schema
+    validation for a context-window refusal. That mislabelling is what
+    made the 2026-08-06 incident unreadable: three separate diagnoses were
+    proposed and falsified before the real cause was measured.
+
+    Inherits BaseException for the same reason as TerminalAuthFailure and
+    RateLimitedExit — it must propagate through asyncio's gather and broad
+    `except Exception` handlers. Critically it must NOT be a WorkerError:
+    `_run_checked_loop` deliberately *retries* WorkerError against its
+    whole round budget (CLAUDE.md, crash policy), which for a
+    deterministic refusal is pure waste.
+
+    Treated by main() as a resumable pause (EXIT_LOCKED), because the
+    remedy is an operator change — usually dropping
+    `--dangerously-force-strict-output`, whose `ANTHROPIC_BASE_URL`
+    override is what lowers the ceiling in the first place (see
+    `_model_arg`) — after which `leerie resume` picks the run back up.
+
+    Carries only raw_message: str — the verbatim envelope `result`."""
+    def __init__(self, raw_message: str):
+        super().__init__(raw_message)
+        self.raw_message = raw_message
 
 
 class TerminalAuthFailure(BaseException):
@@ -7432,6 +7467,27 @@ def _format_task_file_references(
     )
 
 
+def _is_same_document(path: Path, text_len: int, text: str) -> bool:
+    """True when `path` holds exactly `text` (modulo surrounding whitespace).
+
+    Used to keep a task file out of its own reference list. The planner is
+    already handed the task verbatim, so listing the file again asks it to
+    re-read content it has — ~71K tokens of pure duplication on the measured
+    incident (185,565 B at the measured 2.6 B/token). `resolve_task_argument` returns the file's stripped contents and
+    discards the path, so identity is re-established by content rather than by
+    plumbing the path through every caller. The size pre-check keeps this from
+    reading large candidates: only a file already within a few bytes of the
+    task's length is opened at all. `text_len` is the task's encoded length,
+    passed in rather than recomputed because this runs once per candidate and
+    the task can be hundreds of KB."""
+    try:
+        if abs(path.stat().st_size - text_len) > 8:
+            return False
+        return path.read_text(errors="replace").strip() == text
+    except (OSError, ValueError):
+        return False
+
+
 def _glob_task_references(task: str, repo_root: Path) -> list[Path]:
     """Find file references in the task string via glob expansion.
 
@@ -7445,20 +7501,56 @@ def _glob_task_references(task: str, repo_root: Path) -> list[Path]:
     import glob as _glob
     candidates: list[str] = []
     for token in task.split():
-        token = token.strip("\"'(),;:")
+        # Markdown emphasis is stripped before classification because `*` is
+        # in _GLOB_CHARS: an unstripped bare `*` globs to EVERY file in the
+        # repo root. Measured on a 185 KB markdown task carrying 134 bare `*`
+        # and 217 `**`, that pulled in 18 files / 1.86 MB — LICENSE,
+        # .claude.json and a prior run's 847 KB log among them — all of which
+        # `_format_task_file_references` then told the planner to read.
+        token = token.strip("\"'(),;:").strip("*_`")
         if not token:
             continue
+        # After de-emphasis a reference must still look like a path: some
+        # alphanumeric content, plus an extension or a separator. DESIGN §6
+        # scopes this feature to "files the user explicitly pointed to", and a
+        # stray emphasis marker is not that. `**`, `**Root` and `**log**` fail
+        # here; `spec.md`, `spec-*.md`, `tests/*.py` and `docs/DESIGN.md` pass.
+        if not any(c.isalnum() for c in token):
+            continue
+        # Absolute paths are never repo references, and `repo_root / "/etc/x"`
+        # silently discards the root (pathlib lets an absolute right-hand side
+        # win), so admitting them would reach outside the repo entirely — a
+        # task mentioning `/bin/bash` matched a 1.4 MB binary before this guard.
+        if token.startswith("/"):
+            continue
         has_ext = "." in token and not token.startswith(".")
-        has_glob = any(c in token for c in _GLOB_CHARS)
-        if has_ext or has_glob:
+        has_sep = "/" in token
+        if has_ext or has_sep:
             candidates.append(token)
     matched: list[Path] = []
     seen: set[str] = set()
+    root = repo_root.resolve()
+    task_stripped = task.strip()
+    task_len = len(task_stripped.encode())
     for cand in candidates:
         for expanded in _expand_braces(cand):
             for m in sorted(_glob.glob(str(repo_root / expanded))):
                 p = Path(m)
+                # Containment re-check, independent of the token-level guard
+                # above: `../` segments survive the startswith("/") test and
+                # would otherwise escape the same way. `resolve()` follows
+                # symlinks deliberately — an in-repo symlink whose target sits
+                # outside the repo is an escape by another name, and dropping
+                # it is the conservative reading of "files the user explicitly
+                # pointed to" (DESIGN §6 *Task-referenced file extraction*).
+                try:
+                    if not p.resolve().is_relative_to(root):
+                        continue
+                except (OSError, ValueError):
+                    continue
                 if p.is_file() and str(p) not in seen:
+                    if _is_same_document(p, task_len, task_stripped):
+                        continue
                     seen.add(str(p))
                     matched.append(p)
     return matched
@@ -9672,7 +9764,8 @@ async def _backstop_capture_prior_runs(
         # `except Exception` would let them escape this best-effort call and
         # abort the backstop loop (or, in main()'s exit handlers, skip the
         # EXIT_LOCKED pause). Catch them here so capture stays non-fatal.
-        except (Exception, TerminalAuthFailure, RateLimitedExit) as exc:
+        except (Exception, TerminalAuthFailure, RateLimitedExit,
+                ContextOverflow) as exc:
             log(f"backstop: non-fatal error capturing {run_dir.name}: {exc}")
 
 
@@ -9756,7 +9849,8 @@ def run_recapture_deps(
             ran_any = True
         # See the backstop guard above: TerminalAuthFailure / RateLimitedExit
         # are BaseException subclasses that a bare `except Exception` misses.
-        except (Exception, TerminalAuthFailure, RateLimitedExit) as exc:
+        except (Exception, TerminalAuthFailure, RateLimitedExit,
+                ContextOverflow) as exc:
             log(f"recapture: error during dep_capture for {target_run_dir.name}: {exc}")
 
     if not ran_any and not force:
@@ -9886,7 +9980,8 @@ def run_rebaser(
     # RateLimitedExit are BaseException subclasses a bare `except Exception`
     # would miss, and this call must never propagate past host-finalize.sh's
     # best-effort rebase step.
-    except (Exception, TerminalAuthFailure, RateLimitedExit) as exc:
+    except (Exception, TerminalAuthFailure, RateLimitedExit,
+            ContextOverflow) as exc:
         return {
             "status": "failed",
             "final_branch_state": "worker invocation error",
@@ -10772,6 +10867,40 @@ def _api_error_category(status: int | None) -> str | None:
     return {401: "auth", 429: "quota", 529: "overload"}.get(status)
 
 
+def _is_context_overflow(envelope: dict) -> bool:
+    """True when Claude Code refused the prompt itself as too long.
+
+    The CLI enforces a context ceiling client-side: it emits a synthetic
+    assistant message (`model=<synthetic>`, usage all zeros) and ends the
+    session with no API call. Retrying identical input is therefore
+    guaranteed to fail the same way, which is why claude_p() raises
+    `ContextOverflow` on a match instead of spending its 2-attempt loop.
+
+    Measured envelope (reproduced twice, arms B and C of the 2026-08-06
+    probe): `is_error: true`, `terminal_reason: "blocking_limit"`,
+    `api_error_status: null`, `result: "Prompt is too long"`, and —
+    misleadingly — `subtype: "success"`, so do NOT key on subtype, the
+    same trap `_is_transient_transport_failure` documents.
+
+    BOTH signals are required. `terminal_reason` alone is insufficient:
+    it is shared with other blocking limits, and the sibling arms of the
+    same probe ended `max_turns` while a healthy run ended `completed`.
+    The text alone is insufficient too — a worker could legitimately
+    discuss the phrase in its own output — so, mirroring
+    `_is_terminal_auth_failure`, this is gated on `is_error` (a
+    successful, schema-valid envelope never matches) and exempts
+    `_leerie_synthetic` envelopes, whose `result` interpolates the
+    worker's raw stderr and could carry the phrase without the CLI having
+    refused anything."""
+    if not envelope.get("is_error"):
+        return False
+    if envelope.get("_leerie_synthetic"):
+        return False
+    if envelope.get("terminal_reason") != "blocking_limit":
+        return False
+    return "prompt is too long" in str(envelope.get("result") or "").lower()
+
+
 def _is_terminal_auth_failure(envelope: dict) -> bool:
     """True when auth cannot recover without a human running `claude
     /login` (or a fresh `CLAUDE_CODE_OAUTH_TOKEN`).
@@ -11185,6 +11314,43 @@ _STRICT_PROXY_TIMEOUT_SEC = DEFAULT_CAPS["worker_timeout_sec"]
 # the call stack and threading it through every caller would touch far more
 # surface than the feature warrants. One per run, owned by `_orchestrate`.
 _STRICT_PROXY: "_StrictOutputProxy | None" = None
+
+# Model aliases with a 1M-token context window. Haiku is absent: it has no 1M
+# variant, so the suffix would be rejected rather than ignored.
+_ONE_M_CONTEXT_MODELS = frozenset({"sonnet", "opus"})
+
+
+def _model_arg(model: str) -> str:
+    """The `--model` value, restoring the 1M window behind the strict proxy.
+
+    Owning `ANTHROPIC_BASE_URL` — which is how `--dangerously-force-strict-output`
+    reaches workers — makes the CLI treat the session as gateway-routed. It then
+    applies a conservative client-side context ceiling instead of the model's
+    native window and refuses an oversized prompt *itself*, emitting a synthetic
+    `Prompt is too long` assistant message (`model=<synthetic>`, usage all zeros)
+    with no API call at all. `[1m]` is the documented way to select the 1M window
+    behind a gateway; on the direct path it is a no-op, since `sonnet` already
+    resolves to Sonnet 5's native 1M.
+
+    Measured on one 225 KB worker payload, same model/tools/cwd, varying only
+    `ANTHROPIC_BASE_URL` (5 arms): direct sustained 235,805 tokens over 20
+    requests with no refusal. Through a *passthrough* proxy that rewrites
+    nothing the CLI refused after 224,127, and through the real strict proxy
+    after 224,247 — two reproductions 120 tokens apart, so the refusal comes
+    from the base-URL override alone, not the schema rewriting. Adding `[1m]`
+    cleared it both times: 261,014 tokens passthrough, 276,579 through the
+    strict proxy, zero refusals. The rewrite is unaffected — rewritten/
+    passed_through/fell_back counters are identical under both aliases, so the
+    suffix does not suppress `StructuredOutput` injection.
+
+    Applied automatically rather than admitted to `MODEL_VALUES`: the suffix is
+    inert whenever the proxy is off, so an operator gains nothing by setting it
+    by hand — and could set it on `haiku`, where the CLI rejects it.
+    """
+    if _STRICT_PROXY is None or model not in _ONE_M_CONTEXT_MODELS:
+        return model
+    return f"{model}[1m]"
+
 
 # How many upstream error responses get their body echoed before the proxy
 # falls back to counting them. A rejected rewrite is systematic — every worker
@@ -13859,7 +14025,7 @@ async def claude_p(user_prompt: str, system_prompt: str, *, schema_key: str,
                 "--allowedTools", allowed_tools,
                 "--disallowedTools", DISALLOWED_TOOLS,
                 "--max-turns", str(max_turns),
-                "--model", model,
+                "--model", _model_arg(model),
             ])
             # IMPLEMENTATION.md §2 "Effort selection". When effort is None
             # (e.g. satisfied_probe, or the post-run judge/heal workers) the
@@ -13939,7 +14105,12 @@ async def claude_p(user_prompt: str, system_prompt: str, *, schema_key: str,
                     "call_id": str(uuid.uuid4()),
                     "run_id": st.run_id,
                     "call_type": schema_key,
-                    "model": model,
+                    # The EFFECTIVE value, not the resolved alias: `_model_arg`
+                    # rewrites it on the way to argv (appending `[1m]` behind
+                    # the strict proxy), and telemetry that disagrees with what
+                    # the CLI was handed is worse than none — reconstructing a
+                    # run's real invocation is exactly what this file is for.
+                    "model": _model_arg(model),
                     "system_prompt": system_prompt,
                     "user_content": user_prompt + retry_note,
                     "response_content": str(envelope.get("result") or ""),
@@ -14036,6 +14207,13 @@ async def claude_p(user_prompt: str, system_prompt: str, *, schema_key: str,
             # EXIT_LOCKED pause instead of the generic WorkerError exit(1).
             if _is_terminal_auth_failure(envelope):
                 raise TerminalAuthFailure(str(envelope.get("result") or ""))
+
+            # Client-side context refusal: the CLI never sent a request, so
+            # the 2-attempt loop below would replay identical input and fail
+            # identically, then report it as a *schema* failure. Raised here
+            # instead, before any retry, so the operator sees the real cause.
+            if _is_context_overflow(envelope):
+                raise ContextOverflow(str(envelope.get("result") or ""))
 
             # Envelope-level rotation (surface (a) above): the ACTIVE
             # token is rate-limited (not a transport disconnect, not
@@ -26119,10 +26297,12 @@ async def phase_finalize(leerie_dir: Path, st: State, no_push: bool,
             Path(os.getcwd()), st,
             caps=caps, models=models, efforts=efforts,
         )
-    # TerminalAuthFailure / RateLimitedExit are BaseException subclasses that a
+    # TerminalAuthFailure / RateLimitedExit / ContextOverflow are BaseException
+    # subclasses that a
     # bare `except Exception` would let escape — derailing a clean finalize into
     # a crash. Capture is best-effort; catch them so it never blocks the run.
-    except (Exception, TerminalAuthFailure, RateLimitedExit) as _cap_exc:
+    except (Exception, TerminalAuthFailure, RateLimitedExit,
+            ContextOverflow) as _cap_exc:
         log(f"capture: non-fatal error during dep capture ({_cap_exc}); "
             "continuing")
 
@@ -26341,6 +26521,13 @@ async def _run_phases(args, caps: dict, leerie_dir: Path, st: State,
         st.data["clarify"] = bool(args.clarify)
         st.data["dangerously_skip_permissions"] = bool(
             args.dangerously_skip_permissions)
+        # Recorded because this flag changes worker behaviour invisibly: it
+        # owns ANTHROPIC_BASE_URL, which lowers the CLI's context ceiling
+        # (see `_model_arg`). Without it in state, a run's failure cannot be
+        # attributed to the flag after the fact — which is exactly what made
+        # the 2026-08-06 incident take three attempts to diagnose.
+        st.data["dangerously_force_strict_output"] = bool(
+            caps.get("force_strict_output"))
         st.data["skip_overlap_judge"] = bool(args.skip_overlap_judge)
         st.data["skip_adherence_check"] = bool(
             getattr(args, "skip_adherence_check", False))
@@ -27704,6 +27891,51 @@ See README.md "Launcher verbs" for full details and sub-flags.""")
         st.save()
         exit_message = str(e)
         exit_code = 1
+    except ContextOverflow as e:
+        # Claude Code refused the prompt client-side for exceeding the
+        # context window it believes the model has — no API call was made,
+        # so retrying identical input cannot help. Resumable, because the
+        # remedy is an operator change rather than a wait: the usual cause
+        # is `--dangerously-force-strict-output`, whose ANTHROPIC_BASE_URL
+        # override makes the CLI treat the session as gateway-routed and
+        # apply a conservative ceiling instead of the model's real window.
+        full_purge = False
+        st.save()
+        log(f"context window exceeded — {e.raw_message}")
+        log("  Claude Code refused this prompt itself; no request was sent, "
+            "so a retry would fail identically.")
+        if _STRICT_PROXY is not None:
+            log("  --dangerously-force-strict-output is active: it sets "
+                "ANTHROPIC_BASE_URL, which lowers the CLI's context ceiling. "
+                "Re-running without it is usually enough.")
+        log("  Otherwise shrink what every worker carries: the task text and "
+            "the repo's CLAUDE.md are both loaded into each worker's context.")
+        log(f"  then resume with: leerie resume {st.run_id}")
+        abnormal = False
+        try:
+            _cleanup_on_abnormal_exit(st, full_purge=False)
+        except Exception:
+            pass
+        # Best-effort dep_capture in its own asyncio.run (DESIGN §6½), matching
+        # every other terminating arm. Worth attempting rather than skipping:
+        # dep_capture's payload is manifests plus install commands, bounded by
+        # `_DEPCAP_TOTAL_BUDGET`, a far smaller shape than whatever prompt
+        # overflowed — so it can succeed where the failing worker could not.
+        # Guarded against the whole exit-signal family for the reason the
+        # auth-locked arm documents below: these subclass BaseException, and a
+        # re-raise escaping here would skip the `exit_code` assignment and
+        # crash the run with exit 1 instead of pausing resumably.
+        try:
+            asyncio.run(capture_repo_deps(
+                repo_root, st,
+                caps=caps, models=models, efforts=efforts,
+            ))
+        except (Exception, TerminalAuthFailure, RateLimitedExit,
+                ContextOverflow) as _cap_exc:
+            log(f"capture: non-fatal error during context-overflow pause "
+                f"({_cap_exc})")
+        exit_code = EXIT_LOCKED
+
     except TerminalAuthFailure as e:
         # Expired/absent OAuth session (`claude /login` required) —
         # unlike the transient 401/429/529 case, Claude Code sends no
@@ -27731,12 +27963,14 @@ See README.md "Launcher verbs" for full details and sub-flags.""")
                 caps=caps, models=models, efforts=efforts,
             ))
         # The auth-locked pause is *guaranteed* to re-hit the same terminal
-        # auth failure inside capture_repo_deps -> claude_p. TerminalAuthFailure
-        # (and RateLimitedExit) subclass BaseException, so a bare
+        # auth failure inside capture_repo_deps -> claude_p. Every member of
+        # the exit-signal family (TerminalAuthFailure, RateLimitedExit,
+        # ContextOverflow) subclasses BaseException, so a bare
         # `except Exception` cannot catch the re-raise: it would escape main()
         # entirely, skip the `exit_code = EXIT_LOCKED` assignment below, and
         # crash the run with exit 1 — defeating this whole resumable-pause arm.
-        except (Exception, TerminalAuthFailure, RateLimitedExit) as _cap_exc:
+        except (Exception, TerminalAuthFailure, RateLimitedExit,
+                ContextOverflow) as _cap_exc:
             log(f"capture: non-fatal error during auth-locked pause "
                 f"({_cap_exc})")
         exit_code = EXIT_LOCKED
@@ -27790,7 +28024,8 @@ See README.md "Launcher verbs" for full details and sub-flags.""")
             # RateLimitedExit are BaseException subclasses a bare
             # `except Exception` misses, which would skip the `exit_code =
             # EXIT_LOCKED` below and crash the pause with exit 1.
-            except (Exception, TerminalAuthFailure, RateLimitedExit) as _cap_exc:
+            except (Exception, TerminalAuthFailure, RateLimitedExit,
+                    ContextOverflow) as _cap_exc:
                 log(f"capture: non-fatal error during out-of-credits pause "
                     f"({_cap_exc})")
             exit_code = EXIT_LOCKED
@@ -27838,10 +28073,12 @@ See README.md "Launcher verbs" for full details and sub-flags.""")
                 repo_root, st,
                 caps=caps, models=models, efforts=efforts,
             ))
-        # TerminalAuthFailure / RateLimitedExit are BaseException subclasses a
+        # TerminalAuthFailure / RateLimitedExit / ContextOverflow are
+        # BaseException subclasses a
         # bare `except Exception` misses; catching them keeps capture non-fatal
         # so the cancel arm still reaches its `exit_code = 130`.
-        except (Exception, TerminalAuthFailure, RateLimitedExit) as _cap_exc:
+        except (Exception, TerminalAuthFailure, RateLimitedExit,
+                ContextOverflow) as _cap_exc:
             log(f"capture: non-fatal error during cancel-arm capture "
                 f"({_cap_exc})")
         exit_code = 130
@@ -27861,10 +28098,12 @@ See README.md "Launcher verbs" for full details and sub-flags.""")
                 repo_root, st,
                 caps=caps, models=models, efforts=efforts,
             ))
-        # TerminalAuthFailure / RateLimitedExit are BaseException subclasses a
+        # TerminalAuthFailure / RateLimitedExit / ContextOverflow are
+        # BaseException subclasses a
         # bare `except Exception` misses; catching them keeps capture non-fatal
         # so the signal arm still reaches its `exit_code = 128 + signum`.
-        except (Exception, TerminalAuthFailure, RateLimitedExit) as _cap_exc:
+        except (Exception, TerminalAuthFailure, RateLimitedExit,
+                ContextOverflow) as _cap_exc:
             log(f"capture: non-fatal error during signal-arm capture "
                 f"({_cap_exc})")
         # 128 + signal number; SIGTERM=15 → 143, SIGHUP=1 → 129.

--- a/tests/test_capture_swallows_exit_signals.py
+++ b/tests/test_capture_swallows_exit_signals.py
@@ -109,6 +109,48 @@ _GUARD_FUNCS = [
 ]
 
 
+# Control-flow signals that a best-effort capture must NOT swallow. These are
+# `BaseException` subclasses like the exit signals, but they are raised by
+# leerie's own signal handlers rather than by a worker call, so catching them
+# inside a capture guard would mean a SIGTERM arriving mid-capture is silently
+# ignored. Deliberately an explicit denylist, not an inferred one: a NEW
+# BaseException class fails `test_every_capture_guard_catches_the_exit_signals`
+# until someone classifies it, which is the loud default this file wants.
+_NOT_CAPTURE_SWALLOWED = {"InterruptedBySignal"}
+
+
+def _exit_signal_classes(leerie) -> set:
+    """Every exit-signal class leerie defines, derived rather than listed.
+
+    An exit signal is a `BaseException` subclass that is deliberately NOT an
+    `Exception` subclass, so it propagates through `asyncio.gather` and worker
+    `except Exception` blocks. `TerminalAuthFailure` and `RateLimitedExit` were
+    the original two; `ContextOverflow` (client-side context refusal) joined
+    them later.
+
+    Deriving the set is the point. The hard-coded version of this guard passed
+    green when `ContextOverflow` was added and left out of all eight capture
+    tuples -- re-opening the very escape this file exists to prevent, because a
+    name-by-name check cannot know about a family member it has never heard of.
+    Any future addition is now caught automatically.
+    """
+    out = set()
+    for name, obj in vars(leerie).items():
+        if (isinstance(obj, type) and issubclass(obj, BaseException)
+                and not issubclass(obj, Exception)
+                and obj.__module__ == leerie.__name__
+                and name not in _NOT_CAPTURE_SWALLOWED):
+            out.add(name)
+    return out
+
+
+def test_exit_signal_family_is_discovered(leerie):
+    """Anti-vacuity: a derived guard that discovers nothing asserts nothing."""
+    fam = _exit_signal_classes(leerie)
+    assert {"TerminalAuthFailure", "RateLimitedExit", "ContextOverflow"} <= fam, (
+        f"expected the known exit signals to be discovered, got {sorted(fam)}")
+
+
 def test_every_capture_guard_catches_the_exit_signals(leerie):
     """Every best-effort capture guard must name both TerminalAuthFailure and
     RateLimitedExit alongside Exception. A bare `except Exception` cannot catch
@@ -123,12 +165,11 @@ def test_every_capture_guard_catches_the_exit_signals(leerie):
         for h in handlers:
             names = _handler_type_names(h)
             total += 1
-            assert "TerminalAuthFailure" in names, (
-                f"{fname}: a capture guard does not catch TerminalAuthFailure "
-                f"(names={sorted(names)}) — the 2026-07-19 escape re-opens")
-            assert "RateLimitedExit" in names, (
-                f"{fname}: a capture guard does not catch RateLimitedExit "
-                f"(names={sorted(names)}) — same BaseException escape class")
+            missing = _exit_signal_classes(leerie) - names
+            assert not missing, (
+                f"{fname}: a capture guard does not catch {sorted(missing)} "
+                f"(names={sorted(names)}) — the 2026-07-19 escape re-opens for "
+                f"every exit-signal class it omits")
             assert "Exception" in names, (
                 f"{fname}: a capture guard dropped Exception (names="
                 f"{sorted(names)}) — ordinary capture errors must still be "
@@ -148,8 +189,10 @@ def test_finalize_capture_guard_is_hardened(leerie):
     assert handlers, "phase_finalize: no best-effort capture guard found"
     for h in handlers:
         names = _handler_type_names(h)
-        assert {"TerminalAuthFailure", "RateLimitedExit"} <= names, (
-            f"phase_finalize capture guard not hardened (names={sorted(names)})")
+        missing = _exit_signal_classes(leerie) - names
+        assert not missing, (
+            f"phase_finalize capture guard not hardened; missing "
+            f"{sorted(missing)} (names={sorted(names)})")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_context_overflow_classifier.py
+++ b/tests/test_context_overflow_classifier.py
@@ -1,0 +1,176 @@
+"""`Prompt is too long` is terminal, not a schema failure (S2).
+
+Claude Code enforces a context ceiling client-side: it emits a synthetic
+assistant message (`model=<synthetic>`, usage all zeros) and ends the session
+WITHOUT issuing an API call. Retrying identical input therefore cannot succeed.
+
+Before `_is_context_overflow` existed the envelope fell through to `claude_p`'s
+generic 2-attempt loop and surfaced as `worker failed schema-valid output twice:
+Prompt is too long` — blaming schema validation for a context refusal. That
+mislabelling is what made the 2026-08-06 incident unreadable: three separate
+diagnoses were proposed and falsified before the cause was measured.
+
+Envelope fixtures below are verbatim `result` events from that probe.
+"""
+import inspect
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "orchestrator"))
+import leerie  # noqa: E402
+
+
+# Measured: arm C, leerie's real strict proxy, plain `sonnet`.
+OVERFLOW = {
+    "type": "result",
+    "subtype": "success",          # misleading -- must NOT be keyed on
+    "is_error": True,
+    "terminal_reason": "blocking_limit",
+    "api_error_status": None,
+    "result": "Prompt is too long",
+    "num_turns": 11,
+}
+
+# Measured: arm A, direct. Same is_error, different terminal_reason.
+MAX_TURNS = {
+    "type": "result", "subtype": "success", "is_error": True,
+    "terminal_reason": "max_turns", "api_error_status": None,
+    "result": None, "num_turns": 7,
+}
+
+# Measured: arm E, strict proxy + sonnet[1m] -- the healthy outcome.
+COMPLETED = {
+    "type": "result", "subtype": "success", "is_error": False,
+    "terminal_reason": "completed", "api_error_status": None,
+    "result": '{"domain":"documentation","status":"ready"}', "num_turns": 21,
+}
+
+
+class TestClassifier:
+    def test_measured_overflow_envelope_matches(self):
+        assert leerie._is_context_overflow(OVERFLOW) is True
+
+    def test_max_turns_does_not_match(self):
+        # `blocking_limit` is the discriminator against this: both are
+        # is_error=True, and keying on is_error alone would swallow every
+        # max-turns exhaustion as a context overflow.
+        assert leerie._is_context_overflow(MAX_TURNS) is False
+
+    def test_successful_envelope_never_matches(self):
+        assert leerie._is_context_overflow(COMPLETED) is False
+
+    def test_success_envelope_discussing_the_phrase_does_not_match(self):
+        # A worker may legitimately write about context limits in its own
+        # correct output. Gating on is_error is what keeps that inert.
+        env = dict(COMPLETED, result="the planner prompt is too long, so split it")
+        assert leerie._is_context_overflow(env) is False
+
+    def test_terminal_reason_alone_is_insufficient(self):
+        env = dict(OVERFLOW, result="some other blocking limit")
+        assert leerie._is_context_overflow(env) is False
+
+    def test_text_alone_is_insufficient(self):
+        env = dict(OVERFLOW, terminal_reason="api_error")
+        assert leerie._is_context_overflow(env) is False
+
+    def test_synthetic_envelope_is_exempt(self):
+        # `_leerie_synthetic` interpolates the worker's raw stderr into
+        # `result`, so it can carry the phrase without the CLI having refused
+        # anything. Same exemption `_is_terminal_auth_failure` carries, and for
+        # the same measured reason.
+        env = dict(OVERFLOW, _leerie_synthetic="no_result_event")
+        assert leerie._is_context_overflow(env) is False
+
+    def test_case_insensitive(self):
+        assert leerie._is_context_overflow(dict(OVERFLOW, result="PROMPT IS TOO LONG"))
+
+    def test_missing_and_non_string_fields_are_safe(self):
+        assert leerie._is_context_overflow({}) is False
+        assert leerie._is_context_overflow({"is_error": True}) is False
+        assert leerie._is_context_overflow(dict(OVERFLOW, result=None)) is False
+        assert leerie._is_context_overflow(dict(OVERFLOW, result=12345)) is False
+
+
+class TestDisjointFromTheOtherClassifiers:
+    """Overflow must not be absorbed by the auth/quota or transport paths."""
+
+    def test_overflow_is_not_an_auth_failure(self):
+        assert leerie._is_terminal_auth_failure(OVERFLOW) is False
+        assert leerie._is_auth_or_quota_failure(OVERFLOW) is False
+
+    def test_auth_failure_is_not_an_overflow(self):
+        auth = {"is_error": True, "terminal_reason": "api_error",
+                "result": "Failed to authenticate: OAuth session expired"}
+        assert leerie._is_context_overflow(auth) is False
+
+
+class TestExceptionContract:
+    def test_inherits_baseexception_not_workererror(self):
+        # Must survive asyncio.gather and broad `except Exception`. Critically
+        # it must NOT be a WorkerError: `_run_checked_loop` deliberately
+        # RETRIES WorkerError across its whole round budget, which for a
+        # deterministic refusal is pure waste.
+        assert issubclass(leerie.ContextOverflow, BaseException)
+        assert not issubclass(leerie.ContextOverflow, Exception)
+        assert not issubclass(leerie.ContextOverflow, leerie.WorkerError)
+
+    def test_carries_raw_message(self):
+        assert leerie.ContextOverflow("Prompt is too long").raw_message == \
+            "Prompt is too long"
+
+
+class TestWiring:
+    """Classifier and handler are both inert unless actually called."""
+
+    def test_claude_p_raises_before_the_retry_loop(self):
+        src = inspect.getsource(leerie.claude_p)
+        assert "_is_context_overflow(envelope)" in src
+        assert "raise ContextOverflow(" in src
+        # Must precede the generic 2-attempt failure, or the retry happens
+        # anyway and the operator still sees a schema-failure message.
+        assert (src.index("_is_context_overflow")
+                < src.index("worker failed schema-valid output twice"))
+
+    def test_main_handles_it_as_a_resumable_pause(self):
+        src = inspect.getsource(leerie.main)
+        assert "except ContextOverflow as e:" in src
+        # Split on the next TOP-LEVEL handler (4-space indent). A bare
+        # "except " would truncate at the inner `except Exception:` guarding
+        # the cleanup call, hiding the `exit_code` assignment that follows it.
+        arm = src.split("except ContextOverflow as e:", 1)[1].split("\n    except ", 1)[0]
+        assert "EXIT_LOCKED" in arm, "must pause resumably, not exit(1)"
+        assert "resume" in arm, "must tell the operator how to continue"
+
+    def test_message_does_not_blame_schema_validation(self):
+        src = inspect.getsource(leerie.main)
+        # Split on the next TOP-LEVEL handler (4-space indent). A bare
+        # "except " would truncate at the inner `except Exception:` guarding
+        # the cleanup call, hiding the `exit_code` assignment that follows it.
+        arm = src.split("except ContextOverflow as e:", 1)[1].split("\n    except ", 1)[0]
+        assert "schema" not in arm.lower()
+
+    def test_arm_runs_a_guarded_dep_capture_like_its_siblings(self):
+        """Every other terminating arm makes a best-effort `capture_repo_deps`
+        call (DESIGN §6½); this one must too, and it must be guarded against
+        the whole exit-signal family.
+
+        `capture_repo_deps` invokes `claude_p` again, so an unguarded call can
+        re-raise a BaseException that escapes `main()`, skips the `exit_code`
+        assignment below it, and crashes the run with exit 1 instead of pausing
+        resumably — the verbatim 2026-07-19 incident that
+        `tests/test_capture_swallows_exit_signals.py` exists to prevent.
+        """
+        src = inspect.getsource(leerie.main)
+        arm = src.split("except ContextOverflow as e:", 1)[1] \
+                 .split("\n    except ", 1)[0]
+        assert "capture_repo_deps(" in arm, (
+            "the ContextOverflow arm skips the best-effort dep capture its "
+            "sibling terminating arms all perform")
+        assert "ContextOverflow)" in arm, (
+            "the arm's own capture guard must catch ContextOverflow — "
+            "capture_repo_deps calls claude_p, which can raise it again")
+        # The capture must precede the exit_code assignment; an escape past an
+        # unguarded call skips it. The ordering *is* the property under test.
+        assert arm.index("capture_repo_deps(") < arm.index("exit_code =")

--- a/tests/test_strict_proxy_context_window.py
+++ b/tests/test_strict_proxy_context_window.py
@@ -1,0 +1,123 @@
+"""`--model` carries `[1m]` behind the strict-output proxy (S1).
+
+Owning `ANTHROPIC_BASE_URL` — which is how `--dangerously-force-strict-output`
+reaches workers — makes the Claude Code CLI treat the session as gateway-routed
+and apply a conservative client-side context ceiling instead of the model's
+native window. It then refuses an oversized prompt *itself*, with no API call.
+
+Measured across five arms on one 225 KB worker payload (same model, tools and
+cwd, varying only `ANTHROPIC_BASE_URL`):
+
+    direct            sonnet       20 reqs  235,805 tok  0 refusals
+    passthrough proxy sonnet        2 reqs  224,127 tok  1 refusal
+    strict proxy      sonnet       12 reqs  224,247 tok  1 refusal
+    passthrough proxy sonnet[1m]   27 reqs  261,014 tok  0 refusals
+    strict proxy      sonnet[1m]   21 reqs  276,579 tok  0 refusals  <- completed
+
+The two refusals reproduce 120 tokens apart, so the cause is the base-URL
+override alone and not the schema rewriting (the passthrough arm rewrites
+nothing). `[1m]` cleared it on both proxy paths.
+"""
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "orchestrator"))
+import leerie  # noqa: E402
+
+
+class _FakeProxy:
+    """Stand-in for a live `_StrictOutputProxy` — only its presence matters."""
+    port = 51234
+
+
+@pytest.fixture
+def proxy_on(monkeypatch):
+    monkeypatch.setattr(leerie, "_STRICT_PROXY", _FakeProxy())
+
+
+@pytest.fixture
+def proxy_off(monkeypatch):
+    monkeypatch.setattr(leerie, "_STRICT_PROXY", None)
+
+
+class TestSuffixAppliedOnlyBehindTheProxy:
+    def test_sonnet_gets_the_suffix_when_proxy_active(self, proxy_on):
+        assert leerie._model_arg("sonnet") == "sonnet[1m]"
+
+    def test_opus_gets_the_suffix_when_proxy_active(self, proxy_on):
+        assert leerie._model_arg("opus") == "opus[1m]"
+
+    def test_no_suffix_when_proxy_inactive(self, proxy_off):
+        # On the direct path `sonnet` already resolves to Sonnet 5's native
+        # 1M window, so the suffix would be redundant. Keeping argv identical
+        # to the pre-feature invocation is what makes this fix inert for the
+        # overwhelmingly common case.
+        assert leerie._model_arg("sonnet") == "sonnet"
+        assert leerie._model_arg("opus") == "opus"
+
+    def test_haiku_never_gets_the_suffix(self, proxy_on):
+        # Haiku 4.5 has no 1M variant; the CLI rejects the suffix rather than
+        # ignoring it, so appending it would break every haiku worker behind
+        # the proxy.
+        assert leerie._model_arg("haiku") == "haiku"
+
+    def test_unknown_model_string_passes_through_untouched(self, proxy_on):
+        # `resolve_models` is not restricted to MODEL_VALUES on the env/TOML
+        # path, so a full model id can reach here. Only the two aliases known
+        # to have a 1M variant are rewritten.
+        assert leerie._model_arg("claude-sonnet-5") == "claude-sonnet-5"
+
+    def test_suffix_is_not_doubled(self, proxy_on):
+        # Guards a re-entrancy mistake: an already-suffixed value must not
+        # become `sonnet[1m][1m]`.
+        assert leerie._model_arg("sonnet[1m]") == "sonnet[1m]"
+
+
+class TestOneMModelSet:
+    def test_membership(self):
+        assert "sonnet" in leerie._ONE_M_CONTEXT_MODELS
+        assert "opus" in leerie._ONE_M_CONTEXT_MODELS
+        assert "haiku" not in leerie._ONE_M_CONTEXT_MODELS
+
+    def test_every_member_is_a_real_alias(self):
+        # A typo here would silently disable the fix rather than fail loudly.
+        assert leerie._ONE_M_CONTEXT_MODELS <= set(leerie.MODEL_VALUES)
+
+
+class TestCallSiteIsWired:
+    """The helper is inert unless `claude_p` actually calls it.
+
+    A present-but-unwired fix is the failure mode this repo has already shipped
+    once (the coverage gate that raised TypeError on every invocation while its
+    own broad `except` logged a clean degrade), so the wiring gets its own pin.
+    """
+
+    def test_claude_p_builds_model_arg_via_the_helper(self):
+        import inspect
+        src = inspect.getsource(leerie.claude_p)
+        assert '"--model", _model_arg(model)' in src, (
+            "claude_p must route --model through _model_arg; a bare "
+            "`model` re-introduces the lowered context ceiling")
+        assert '"--model", model,' not in src
+
+    def test_telemetry_records_the_effective_model(self):
+        """`calls.ndjson` must record what the CLI was actually handed.
+
+        `_model_arg` rewrites the alias on the way to argv, so a capture record
+        holding the bare alias would disagree with the invocation it claims to
+        describe. Reconstructing a run's real invocation is the entire purpose
+        of that file — and this investigation lost hours to exactly that class
+        of gap, where `dangerously_force_strict_output` was not recorded at all
+        and the flag's effects could not be attributed after the fact.
+        """
+        import inspect
+        src = inspect.getsource(leerie.claude_p)
+        assert '"model": _model_arg(model)' in src, (
+            "telemetry must record the effective --model value, not the "
+            "resolved alias")
+        # Guard the guard: a bare `"model": model,` would silently reintroduce
+        # the divergence, and the assertion above alone would not catch a
+        # second capture site.
+        assert '"model": model,' not in src

--- a/tests/test_task_file_globbing.py
+++ b/tests/test_task_file_globbing.py
@@ -1,0 +1,137 @@
+"""Markdown prose is not a glob pattern (S5).
+
+`_glob_task_references` classifies any whitespace token containing a
+`_GLOB_CHARS` member (`*?[{`) as a file pattern, and `_format_task_file_references`
+then tells the planner "Read each one before decomposing". A markdown task file
+is prose: `*` and `**` are emphasis, not globs -- and `glob("*")` matches EVERY
+file in the repo root.
+
+Measured on a real 185 KB markdown task carrying 134 bare `*` and 217 `**`: the
+planner was handed 18 files / 1.86 MB as required reading, including LICENSE,
+CODE_OF_CONDUCT.md, `.claude.json`, and a prior run's 847 KB log.
+
+Note this defect did NOT cause the incident that surfaced it -- the failing
+run's very first request was already over the ceiling, before the planner read
+anything. It is fixed on its own merits.
+"""
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "orchestrator"))
+import leerie  # noqa: E402
+
+
+@pytest.fixture
+def repo(tmp_path):
+    """A repo root with a representative spread of files."""
+    (tmp_path / "LICENSE").write_text("MIT")
+    (tmp_path / "README.md").write_text("readme")
+    (tmp_path / "spec.md").write_text("spec")
+    (tmp_path / "notes.log").write_text("log")
+    (tmp_path / ".hidden.json").write_text("{}")
+    (tmp_path / "docs").mkdir()
+    (tmp_path / "docs" / "DESIGN.md").write_text("design")
+    (tmp_path / "tests").mkdir()
+    (tmp_path / "tests" / "test_a.py").write_text("a")
+    (tmp_path / "tests" / "test_b.py").write_text("b")
+    return tmp_path
+
+
+def names(paths):
+    return sorted(p.name for p in paths)
+
+
+class TestMarkdownEmphasisIsNotAGlob:
+    def test_bare_asterisk_matches_nothing(self, repo):
+        assert leerie._glob_task_references("fix the * thing", repo) == []
+
+    def test_double_asterisk_matches_nothing(self, repo):
+        assert leerie._glob_task_references("this is ** important", repo) == []
+
+    def test_bold_word_matches_nothing(self, repo):
+        assert leerie._glob_task_references("**Root** cause **log**", repo) == []
+
+    def test_realistic_markdown_prose_matches_nothing(self, repo):
+        task = ("## **Severity: HIGH**\n\n"
+                "The *planner* fails because **every** worker is affected.\n"
+                "- **Root cause**: unclear\n- *Solution*: unknown\n")
+        assert leerie._glob_task_references(task, repo) == []
+
+    def test_underscore_and_backtick_emphasis_stripped(self, repo):
+        assert leerie._glob_task_references("_emphasis_ and `code`", repo) == []
+
+
+class TestGenuineReferencesStillResolve:
+    def test_plain_filename_with_extension(self, repo):
+        assert names(leerie._glob_task_references("implement spec.md", repo)) == ["spec.md"]
+
+    def test_glob_pattern_with_extension(self, repo):
+        got = names(leerie._glob_task_references("update tests/*.py", repo))
+        assert got == ["test_a.py", "test_b.py"]
+
+    def test_path_with_separator(self, repo):
+        assert names(leerie._glob_task_references("read docs/DESIGN.md", repo)) == ["DESIGN.md"]
+
+    def test_reference_survives_surrounding_bold(self, repo):
+        # The emphasis strip must not damage the path inside it.
+        assert names(leerie._glob_task_references("see **spec.md**", repo)) == ["spec.md"]
+
+    def test_brace_group_still_expands(self, repo):
+        got = names(leerie._glob_task_references("touch spec.{md,txt}", repo))
+        assert got == ["spec.md"]
+
+
+class TestPathEscapeIsRefused:
+    """`repo_root / "/etc/passwd"` discards the root -- pathlib lets an
+    absolute right-hand side win. Admitting separator-bearing tokens without
+    this guard reached outside the repo entirely (a task mentioning
+    `/bin/bash` matched a 1.4 MB binary)."""
+
+    def test_absolute_path_matches_nothing(self, repo):
+        assert leerie._glob_task_references("run /bin/sh and /etc/hosts", repo) == []
+
+    def test_parent_traversal_matches_nothing(self, repo, tmp_path):
+        (tmp_path.parent / "outside.md").write_text("x")
+        assert leerie._glob_task_references("see ../outside.md", repo) == []
+
+    def test_containment_holds_for_a_glob_that_escapes(self, repo, tmp_path):
+        (tmp_path.parent / "escaped.md").write_text("x")
+        assert leerie._glob_task_references("see ../*.md", repo) == []
+
+
+class TestTaskFileDoesNotListItself:
+    """The planner already has the task verbatim; listing the file again asks
+    it to re-read content it holds -- 51K tokens of duplication on the
+    measured incident."""
+
+    def test_self_reference_excluded(self, repo):
+        task = "Work through everything in spec.md and report back."
+        (repo / "spec.md").write_text(task)
+        assert leerie._glob_task_references(task, repo) == []
+
+    def test_self_reference_excluded_despite_whitespace(self, repo):
+        task = "Work through spec.md."
+        (repo / "spec.md").write_text("\n  " + task + "  \n")
+        assert leerie._glob_task_references(task, repo) == []
+
+    def test_a_different_file_with_the_same_name_is_kept(self, repo):
+        # Only content identity excludes; a same-named file with other
+        # contents is a genuine reference.
+        (repo / "spec.md").write_text("entirely different contents here")
+        task = "Work through everything in spec.md and report back."
+        assert names(leerie._glob_task_references(task, repo)) == ["spec.md"]
+
+
+class TestRegressionOnTheMeasuredShape:
+    def test_repo_root_is_not_swept_by_prose(self, repo):
+        """The headline regression: emphasis must not enumerate the root."""
+        task = "**Findings**\n\n* one\n* two\n\n**Severity: HIGH** — see *below*."
+        got = leerie._glob_task_references(task, repo)
+        assert got == [], f"prose swept in {names(got)}"
+
+    def test_prose_plus_one_real_reference_yields_only_that_reference(self, repo):
+        task = ("**N1** — *critical*. See docs/DESIGN.md for the rationale.\n"
+                "* bullet one\n* bullet two\n**Root cause**: unknown\n")
+        assert names(leerie._glob_task_references(task, repo)) == ["DESIGN.md"]


### PR DESCRIPTION
## The failure

A run using `--dangerously-force-strict-output` died in planning having written no code:

```
[planner-testing-s2 text] Prompt is too long
planner-testing round 0/1/2: worker crashed: worker failed schema-valid output twice: Prompt is too long
leerie: error: all 3 planner samples for bug-fixing crashed — no plan produced
```

## The cause

The flag works by owning `ANTHROPIC_BASE_URL`. The CLI treats **any** custom base URL as an LLM gateway, and behind a gateway it can no longer confirm which model answers — so it falls back to a conservative client-side context ceiling instead of Sonnet 5's native 1M, and refuses the prompt **itself**: a synthetic assistant message (`model=<synthetic>`, usage all zeros) with **no API call**.

Measured across five arms on one 225 KB worker payload — same model, tools and cwd, varying only `ANTHROPIC_BASE_URL`:

| arm | model | requests | max context | refusals |
|---|---|---:|---:|---:|
| direct | `sonnet` | 20 | 235,805 | 0 |
| passthrough proxy | `sonnet` | 2 | 224,127 | **1** |
| strict proxy | `sonnet` | 12 | 224,247 | **1** |
| passthrough proxy | `sonnet[1m]` | 27 | 261,014 | 0 |
| strict proxy | `sonnet[1m]` | 21 | **276,579** | 0 |

The two refusals reproduce **120 tokens apart**, and the passthrough arm rewrites nothing — so the cause is the base-URL override, not the schema hardening.

## The fix

`_model_arg` appends the documented `[1m]` gateway selector to `sonnet`/`opus` while the proxy is active. A no-op on the direct path, and never applied to `haiku` (no 1M variant — the CLI rejects the suffix). The proxy's rewritten / passed-through / fell-back counters are **identical** under either alias, so the window is bought back without giving up constrained decoding.

## Also in this change

- **`ContextOverflow` classifies the refusal as terminal.** Deterministic for identical input, yet `claude_p` retried it and reported it as a *schema* failure — mislabelling that cost three successive misdiagnoses before the cause was measured. Now a resumable `EXIT_LOCKED` pause whose message names the real contributors.
- **`ContextOverflow` added to all best-effort capture guards.** Like its siblings it subclasses `BaseException`, so omitting it re-opened the 2026-07-19 escape where a re-raise inside `capture_repo_deps` skips the `exit_code` assignment and crashes with exit 1. The guard test now **derives** its required set from the module's actual exit-signal classes rather than listing them, so the next addition cannot slip through the same way.
- **`dangerously_force_strict_output` recorded in `state.json`**; without it the flag's effects could not be attributed after the fact — which is what made this take three attempts to diagnose. Telemetry likewise records the *effective* `--model` value rather than the resolved alias.
- **`_glob_task_references` no longer treats markdown emphasis as a glob.** A bare `*` matched every file in the repo root: measured on a 185 KB markdown task, the planner was handed **18 files / 1.86 MB** as required reading, including `LICENSE` and a prior run's 847 KB log. Absolute paths and `../` traversal refused, containment re-checked against `repo_root`, and a task file no longer lists itself. This defect did **not** cause the incident — the failing run's first request was already over the ceiling — and is fixed on its own merits.

## Tests

3 new files (44 tests) plus the generalised exit-signal guard. Each fix falsified by reverting it: removing `[1m]`, dropping `ContextOverflow` from one tuple, reverting the telemetry field, and replaying the pre-fix token filter (which sweeps 4 files where the test expects none) all fail their pins.

## Known limits

Measured on **one** payload shape (225 KB planner call). Cause and fix each reproduced twice; a worker with a much larger schema under strict hardening is untested. The extension-or-separator rule also drops bare-name globs like `Makefile*` — deliberate, documented, and a lopsided trade against a `*` that swept the repo root.

🤖 Generated with [Claude Code](https://claude.com/claude-code)