### PR TITLE
feat(state): record leerie_commit; document the strict-output boundary

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2004,7 +2004,10 @@ empty diff.
 **`scripts/remote/collect-subtrees.sh` embeds a second copy of
 `SCHEMAS["integrator"]`** as a single-quoted shell string, because it invokes
 `claude -p --json-schema` directly from bash on the remote machine and cannot
-import the orchestrator. **Any edit to that schema must update both.**
+import the orchestrator. **Any edit to that schema must update both.** That same
+direct invocation also puts the script outside the `--dangerously-force-strict-output`
+path — it runs only after the orchestrator (which owns the proxy) has exited, so
+output there is schema-validated but not constrained during generation.
 `tests/test_collect_subtrees_integrator_schema.py` is the guard: it parses the
 `integrator_schema='{...}'` assignment out of the real script and asserts
 whole-object equality with the live `SCHEMAS["integrator"]` — deliberately
@@ -2711,6 +2714,28 @@ walks the AST of `_run_phases`, because the obvious
 No coverage
 target is set — the suite was introduced from scratch and a number
 now would be arbitrary.
+`tests/test_leerie_commit.py` pins the `leerie_commit` state field, which
+disambiguates `leerie_version`. `plugin.json` only moves on a `chore(release):`
+commit while `install.sh` tracks `main` (`DEFAULT_REF`), so every run between
+releases records the same version whether or not it carries a given fix — a bug
+report citing `v0.11.1` cannot be placed on either side of it. The launcher
+computes the short sha (`git -C "$LEERIE_REPO" rev-parse --short HEAD`) and
+forwards it as `LEERIE_COMMIT`; the orchestrator records it beside the version.
+Pinned: the key is in `STATE_FIELDS`, **adjacent to `leerie_version`** (the two
+are only useful together, and adjacency is what stops one moving without the
+other) and carries an IMPLEMENTATION.md §8 row; the write reads the env var and
+uses `or None` — **load-bearing**, since an empty `LEERIE_COMMIT` arrives
+whenever leerie was installed from a tarball or an older launcher runs against a
+newer orchestrator, and recording `""` would render as a real-but-blank sha in
+the PR footer; a real `State.save()` round-trip preserves both a sha and a
+`null`; the rendered suffix appends `(sha)` only when both parts are present, so
+an absent commit yields no empty parens. Launcher-side: the `git` call carries
+`2>/dev/null || true` so a non-checkout install cannot abort under `set -e`
+(absence is a normal state, never an error), it is forwarded explicitly with
+`-e` rather than via the `LEERIE_*` auto-forward (it is launcher-computed, not a
+user knob, and the auto-forward only carries exported vars), and it is **not**
+on the forwarding denylist — unlike `LEERIE_VERSION`, which is host-only for the
+image tag.
 The `--dangerously-force-strict-output` context-window regression (DESIGN §7
 *Forcing constrained decoding*, §6 *A client-side context refusal*) is covered
 by three files. The defect: the flag works by owning `ANTHROPIC_BASE_URL`, and

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -5016,6 +5016,25 @@ validation they explicitly asked to replace — or it misroutes every worker cal
 Since a run cannot tell those apart from a healthy one, leerie refuses that
 combination too rather than guessing.
 
+**The guarantee is scoped to a run's workers, and one LLM call sits outside
+it by construction.** The proxy is owned by the orchestrator process and torn
+down when that process exits. The recovery integrator in
+`scripts/remote/collect-subtrees.sh` invokes `claude -p` directly, and it runs
+only *after* the orchestrator is confirmed dead — the `finalize --force` path
+calls it following a force-stop, and the non-force path only as recovery once
+`force_finalize_remote` has succeeded, which by design refuses while the run is
+alive. There is therefore no proxy left to route it through, and the later
+`finalize` invocation need not even carry the flag. Erasing this boundary would
+mean standing up a second proxy on the machine purely for a post-mortem salvage
+step, which buys a generation-time guarantee on an operation that is not part
+of the run.
+
+So it is stated rather than closed. That integrator still validates its output
+against its own copy of `SCHEMAS["integrator"]` — output is checked, just not
+constrained during generation. The distinction matters because the failure this
+section otherwise refuses to permit is silence: an operator who asked for
+constrained decoding should know exactly which calls got it.
+
 **Owning that variable also costs the model's native context window, and
 leerie has to buy it back.** The Claude Code CLI treats any custom
 `ANTHROPIC_BASE_URL` as an LLM gateway, and behind a gateway it can no longer

--- a/docs/IMPLEMENTATION.md
+++ b/docs/IMPLEMENTATION.md
@@ -7750,7 +7750,12 @@ un-integrated subtask branches on the machine and merges them into the
 run branch via `setup-run.sh` (idempotent) + `integrate.sh`.
 Conflicts are resolved by spawning `claude -p` with the integrator
 prompt and schema (same invocation as `integrate_wave()` in the
-orchestrator). The integrator runs in the staging worktree with the
+orchestrator). That direct invocation puts this script **outside** the
+`--dangerously-force-strict-output` path: `collect_subtrees_remote` runs only
+after the orchestrator — which owns the proxy — has exited, so there is no
+listener left to reach. Output is still schema-validated by the script's
+embedded `SCHEMAS["integrator"]` copy; it is not constrained during
+generation. See DESIGN §7 *Forcing constrained decoding*. The integrator runs in the staging worktree with the
 merge left in-progress. On success, the merge commit is verified
 (`MERGE_HEAD` must not exist, no staged-but-uncommitted changes). On
 failure, the merge is aborted and the branch is skipped. Wave ordering from
@@ -8008,6 +8013,7 @@ written somewhere in `orchestrator/leerie.py`. The coupling test in
 | `working_branch` | str | the user's branch at the moment `phase_classify` runs (`git rev-parse --abbrev-ref HEAD`). Captured once and mirrored to three locations: `run.json.working_branch`, `<state-root>/runs/<id>/working-branch` (written later by `setup-run.sh`), and `state.json` via this field. Read by `_compose_pr_via_llm` as the `git diff` base for the PR-writer payload and by `_run_final_conformance` as the `DIFF_BASE` for the post-integration whole-tree pass. Empty string when the host `git` invocation failed (interactive fallback path); the readers tolerate this. |
 | `pr_base_branch` | str | the final branch this run's PR merges into — overridable via `--pr-base-branch` / `LEERIE_PR_BASE_BRANCH` / `pr_base_branch` in `leerie.toml` (resolved by `resolve_pr_base_branch`, CLI > env > file precedence, mirroring `resolve_pr_template`). Defaults to `working_branch` when unset (`resolve_pr_base_branch(...) or working_branch`, computed once at run start alongside `working_branch`). Mirrored to `run.json.pr_base_branch`. This is the PR base ONLY — never the diff fork-point, which stays `working_branch` (`rev_range = working_branch..run_branch`; `_run_final_conformance`'s `DIFF_BASE`); overloading `working_branch` for both roles would corrupt the diff base if the override branch isn't the actual fork point. |
 | `leerie_version` | str | the leerie version string from `.claude-plugin/plugin.json` at the time the run started (or resumed). Persisted so the PR footer and Run metadata block can show the exact version that produced the run, which aids debugging when a run was produced by an older release. |
+| `leerie_commit` | str \| null | short sha of `$LEERIE_REPO`'s HEAD at run start, forwarded by the launcher as `LEERIE_COMMIT`. `null` when leerie was installed from a tarball rather than a git checkout — a normal state, never an error (the launcher's `rev-parse` is local-only and its failure can never fail a run). Recorded because `leerie_version` alone cannot attribute a run: `plugin.json` only moves on a `chore(release):` commit while `install.sh` tracks `main` (`DEFAULT_REF`), so every run between releases reports the same version whether or not it carries a given fix. Rendered beside the version in the PR footer / Run-metadata block as `v0.11.1 (abc1234)`. |
 | `dep_capture_done` | bool | set to `True` in `state.json` by `capture_repo_deps` after a successful write. Combined with the sibling sentinel file `<run_dir>/dep_capture.done`, this makes the next-run backstop idempotent: the backstop skips runs whose sentinel file is present, and the cancel-arm capture skips already-captured runs. Absent on runs where capture was skipped or has not yet run. |
 
 `pending-questions.json` (written by `gather_answers` on non-TTY exit, read by

--- a/leerie
+++ b/leerie
@@ -52,6 +52,15 @@ LEERIE_VERSION="$(awk -F'"' '/"version"/ {print $4; exit}' \
                   "$LEERIE_REPO/.claude-plugin/plugin.json" 2>/dev/null || echo dev)"
 IMAGE_TAG="leerie:$LEERIE_VERSION"
 
+# The commit the launcher is actually running, recorded alongside the version.
+# plugin.json only moves on a `chore(release):` commit, while install.sh tracks
+# `main` (DEFAULT_REF), so every run between releases reports the same version
+# whether or not it carries a given fix — enough to look attributable, not
+# enough to attribute. Empty when $LEERIE_REPO is not a git checkout (a tarball
+# install), which is a normal state, never an error: `rev-parse` is local-only,
+# so this cannot hang, and a failure here must never fail a run.
+LEERIE_COMMIT="$(git -C "$LEERIE_REPO" rev-parse --short HEAD 2>/dev/null || true)"
+
 # --- fast paths that don't need the container ----------------------------
 # `leerie version` should answer immediately without spinning up a container
 # — used by the installer's end-to-end smoke test and by anyone who just
@@ -7735,6 +7744,10 @@ else
     # orchestrator's cwd=/work falls back to basename "work" and every line
     # reads [leerie] [work]. Mirrors the Fly path's child_env["USER_REPO"].
     -e "USER_REPO=$(basename "$USER_REPO")"
+    # Explicit rather than relying on the LEERIE_* auto-forward below: this is
+    # launcher-computed, not a user knob, and the forward only carries vars
+    # that are exported.
+    -e "LEERIE_COMMIT=${LEERIE_COMMIT:-}"
     ${_leerie_env_args[@]+"${_leerie_env_args[@]}"}
     ${CGROUP_MOUNT_ARG[@]+"${CGROUP_MOUNT_ARG[@]}"}
     --cgroupns=host

--- a/orchestrator/leerie.py
+++ b/orchestrator/leerie.py
@@ -455,6 +455,13 @@ STATE_FIELDS = (
     # the time the run started (or resumed). Persisted so the PR footer can
     # show the exact version that produced the run, which aids debugging.
     "leerie_version",
+    # leerie_commit: the short sha of $LEERIE_REPO's HEAD at run start, from
+    # the launcher's LEERIE_COMMIT. None when leerie was installed from a
+    # tarball rather than a checkout. Recorded because leerie_version alone
+    # cannot attribute a run: plugin.json only moves on a `chore(release):`
+    # commit while install.sh tracks `main`, so every run between releases
+    # reports the same version whether or not it carries a given fix.
+    "leerie_commit",
     # dep_capture_done: set to True in state.json and written as a sentinel
     # file (<run_dir>/dep_capture.done) after capture_repo_deps completes a
     # successful write. The run-start backstop checks the sentinel file to
@@ -3529,7 +3536,14 @@ def compose_pr_body(state: dict, run_id: str) -> str:
     worker_count = state.get("worker_count")
     working_branch = state.get("working_branch")
     leerie_version = state.get("leerie_version")
+    # The commit disambiguates the version: plugin.json only moves on a
+    # release commit while install.sh tracks `main`, so `v0.11.1` alone cannot
+    # tell a reader whether a given post-release fix was present. Omitted
+    # entirely when absent (tarball install), rather than rendered empty.
+    leerie_commit = state.get("leerie_commit")
     version_suffix = f" v{leerie_version}" if leerie_version else ""
+    if version_suffix and leerie_commit:
+        version_suffix = f"{version_suffix} ({leerie_commit})"
     duration = _format_run_duration(started_at, finished_at)
     # Cost line — rendered only when the telemetry aggregate is present (it is
     # absent on pre-classify orphans). Keep the bash fallback in
@@ -26542,6 +26556,10 @@ async def _run_phases(args, caps: dict, leerie_dir: Path, st: State,
         st.data["skip_base_baseline"] = bool(args.skip_base_baseline)
         st.data["skip_repo_map"] = bool(args.skip_repo_map)
         st.data["leerie_version"] = _read_version()
+        # `or None` rather than the bare value: an unset or empty
+        # LEERIE_COMMIT (tarball install, or a launcher predating this field)
+        # must record absence, not an empty string that reads as a real sha.
+        st.data["leerie_commit"] = os.environ.get("LEERIE_COMMIT") or None
         st.save()
         # Fail-closed containment gate + recording, now that st.data is
         # loaded and this resume is past the completed/no-work short-

--- a/tests/test_leerie_commit.py
+++ b/tests/test_leerie_commit.py
@@ -1,0 +1,150 @@
+"""`leerie_commit` disambiguates `leerie_version` (O1).
+
+`st.data["leerie_version"]` comes from `.claude-plugin/plugin.json`, which only
+moves on a `chore(release):` commit — while `install.sh` tracks `main`
+(`DEFAULT_REF="main"`). So every run between releases records the same version
+whether or not it carries a given fix, and a bug report citing `v0.11.1` cannot
+be placed on either side of it.
+
+That is the same shape as the gap `dangerously_force_strict_output` closed:
+enough recorded to *look* attributable, not enough to actually attribute.
+
+The launcher computes the short sha and forwards it as `LEERIE_COMMIT`; the
+orchestrator records it beside the version. Absence is a normal state (a tarball
+install has no checkout to read), so it must degrade to `None` rather than fail
+a run or write a misleading empty string.
+"""
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "orchestrator"))
+import leerie  # noqa: E402
+
+REPO = Path(__file__).resolve().parents[1]
+LAUNCHER = (REPO / "leerie").read_text()
+
+
+class TestStateSurface:
+    def test_declared_in_state_fields(self):
+        # Guard-the-guard for the parity sweep in test_state_fields.py: that
+        # file checks STATE_FIELDS against the spec table generically, so a
+        # named pin here is what fails loudly if this specific key is dropped.
+        assert "leerie_commit" in leerie.STATE_FIELDS
+
+    def test_declared_next_to_leerie_version(self):
+        # The two are only useful together; keeping them adjacent is what stops
+        # one being added or removed without the other.
+        fields = list(leerie.STATE_FIELDS)
+        assert abs(fields.index("leerie_commit")
+                   - fields.index("leerie_version")) == 1
+
+    def test_documented_in_the_spec_table(self):
+        impl = (REPO / "docs" / "IMPLEMENTATION.md").read_text()
+        assert re.search(r"^\| `leerie_commit` \|", impl, re.M), (
+            "every STATE_FIELDS entry needs an IMPLEMENTATION.md §8 row")
+
+
+class TestWriteSite:
+    def _write_src(self):
+        import inspect
+        return inspect.getsource(leerie._run_phases)
+
+    def test_reads_the_env_var(self):
+        assert 'os.environ.get("LEERIE_COMMIT")' in self._write_src()
+
+    def test_empty_env_records_none_not_empty_string(self):
+        """`or None` is load-bearing.
+
+        An empty `LEERIE_COMMIT` reaches the orchestrator whenever leerie was
+        installed from a tarball, or when a launcher predating this field runs
+        against a newer orchestrator. Recording `""` would render as a real but
+        blank sha in the PR footer; `None` is honest absence.
+        """
+        src = self._write_src()
+        assert 'os.environ.get("LEERIE_COMMIT") or None' in src, (
+            "an unset LEERIE_COMMIT must record None, not an empty string")
+
+    def test_written_beside_the_version(self):
+        src = self._write_src()
+        assert (src.index('st.data["leerie_version"]')
+                < src.index('st.data["leerie_commit"]'))
+
+
+class TestRoundTrip:
+    def test_survives_a_real_state_save(self, tmp_path):
+        st = leerie.State(tmp_path, "run-abc", repo_root=tmp_path)
+        st.data["leerie_version"] = "0.11.1"
+        st.data["leerie_commit"] = "abc1234"
+        st.save()
+        on_disk = json.loads((tmp_path / "runs" / "run-abc"
+                              / "state.json").read_text())
+        assert on_disk["leerie_commit"] == "abc1234"
+
+    def test_none_round_trips_as_null(self, tmp_path):
+        st = leerie.State(tmp_path, "run-def", repo_root=tmp_path)
+        st.data["leerie_commit"] = None
+        st.save()
+        on_disk = json.loads((tmp_path / "runs" / "run-def"
+                              / "state.json").read_text())
+        assert on_disk["leerie_commit"] is None
+
+
+class TestRendering:
+    """The commit is only useful if a reader sees it beside the version."""
+
+    def test_suffix_includes_the_commit_when_present(self):
+        import inspect
+        src = inspect.getsource(leerie)
+        assert 'f"{version_suffix} ({leerie_commit})"' in src
+
+    def test_suffix_omits_it_when_absent(self):
+        import inspect
+        src = inspect.getsource(leerie)
+        # Guarded on both: no version means no suffix at all, and no commit
+        # must not render an empty pair of parens.
+        assert "if version_suffix and leerie_commit:" in src
+
+
+class TestLauncher:
+    def test_computes_the_short_sha(self):
+        assert 'LEERIE_COMMIT="$(git -C "$LEERIE_REPO" rev-parse --short HEAD' \
+            in LAUNCHER
+
+    def test_git_failure_cannot_fail_a_run(self):
+        """A tarball install has no checkout; that is normal, not an error."""
+        m = re.search(r'LEERIE_COMMIT="\$\([^\n]*\)"', LAUNCHER)
+        assert m, "LEERIE_COMMIT assignment not found"
+        line = m.group(0)
+        assert "2>/dev/null" in line, "git stderr must not reach the operator"
+        assert "|| true" in line, (
+            "a non-checkout install must yield empty, not abort under set -e")
+
+    def test_forwarded_into_the_container(self):
+        # `${VAR:-}`, not a bare `$VAR`: the run-argv array is extracted and
+        # evaluated standalone under `set -u` by
+        # tests/test_launcher_env_forwarding.py, so an unbound reference there
+        # aborts the harness. Production always binds it at launcher start;
+        # the defensive form just keeps the array self-contained.
+        assert '-e "LEERIE_COMMIT=${LEERIE_COMMIT:-}"' in LAUNCHER
+
+    def test_forward_survives_set_u_without_the_var(self):
+        """The argv array must not require LEERIE_COMMIT to be bound."""
+        m = re.search(r'-e "LEERIE_COMMIT=[^"]*"', LAUNCHER)
+        assert m and ":-" in m.group(0), (
+            "a bare $LEERIE_COMMIT breaks any standalone evaluation of the "
+            "run-argv array under `set -u`")
+
+    def test_not_on_the_forwarding_denylist(self):
+        """`LEERIE_VERSION` is denied (host-only, used for the image tag); this
+        one must reach the orchestrator."""
+        m = re.search(r"_leerie_env_denylist=\"[^\"]*\"", LAUNCHER, re.S)
+        assert m, "denylist not found"
+        assert "LEERIE_COMMIT" not in m.group(0)
+
+    def test_launcher_still_parses(self):
+        r = subprocess.run(["bash", "-n", str(REPO / "leerie")],
+                           capture_output=True, text=True)
+        assert r.returncode == 0, r.stderr


### PR DESCRIPTION
Two gaps found auditing #180. **Neither was introduced by it** — both predate it.

## O1 — a run can't be attributed pre/post-fix by its version

`leerie_version` comes from `.claude-plugin/plugin.json`, which only moves on a `chore(release):` commit — while `install.sh` tracks `main` (`DEFAULT_REF="main"`). So every run between releases records the same version whether or not it carries a given fix. A report citing `v0.11.1` can't be placed on either side of #180.

That is the same shape as the gap `dangerously_force_strict_output` closed one commit earlier: **enough recorded to look attributable, not enough to attribute.**

The launcher now computes the short sha of `$LEERIE_REPO`'s HEAD, forwards it as `LEERIE_COMMIT`, and the orchestrator records it beside the version — rendered as `v0.11.1 (abc1234)` in the PR footer and Run-metadata block.

Absence is a **normal state**, not an error (a tarball install has no checkout):

- the `git` call carries `2>/dev/null || true` — it can never fail a run, and `rev-parse` is local-only so it can't hang
- the write uses `or None`, so an empty value records honest absence rather than a real-but-blank sha
- the forward is `${LEERIE_COMMIT:-}`, because the run-argv array is extracted and evaluated standalone under `set -u` by `test_launcher_env_forwarding.py` (a bare `$VAR` aborts that harness — caught by running it)

## O2 — the strict-output flag's scope was never written down

`--dangerously-force-strict-output` doesn't cover the recovery integrator in `scripts/remote/collect-subtrees.sh`, and that was documented nowhere.

**It is not fixable by routing through the proxy, because no proxy is alive.** `collect_subtrees_remote` runs in both finalize paths only after the orchestrator is confirmed dead — the force path after a force-stop, the recovery path only once `force_finalize_remote` succeeds, which by design refuses while the run is alive — and `_STRICT_PROXY` is torn down in `_orchestrate`'s `finally`. Closing it would mean standing up a second proxy purely for a post-mortem salvage step that a later `finalize` need not even carry the flag for.

So the boundary is **stated** instead. DESIGN §7 already refuses to let this flag be silently inert — it rejects Bedrock because *"the proxy is never contacted and the operator is silently handed the post-hoc validation they explicitly asked to replace."* The same sentence was owed here and never written. That integrator's output is still schema-validated by the script's embedded `SCHEMAS["integrator"]` copy; it is simply not constrained during generation — and an operator who asked for constrained decoding should know which calls got it.

No code change for O2. Recording a boundary that exists by construction is the honest fix; inventing machinery to erase it is not.

## Tests

`tests/test_leerie_commit.py` — 16 tests. Both load-bearing pins falsified by reverting them: dropping `or None` fails the write-site pin, and dropping the `STATE_FIELDS` entry fails the parity sweep in `test_state_fields.py`.

Verified: 45 tests across `test_leerie_commit`, `test_state_fields`, `test_launcher_env_forwarding`, `test_stale_install_warning`; `bash -n leerie`; `ast.parse`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)