### PR TITLE
fix(state): record leerie_commit on fresh and remote runs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2736,6 +2736,21 @@ an absent commit yields no empty parens. Launcher-side: the `git` call carries
 user knob, and the auto-forward only carries exported vars), and it is **not**
 on the forwarding denylist — unlike `LEERIE_VERSION`, which is host-only for the
 image tag.
+**Two traps this file exists to pin, both of which shipped broken once.** (1)
+`_run_phases` initialises state in *two* branches — `if args.resume:` uses
+subscript assignments, the fresh-run `else:` a dict literal — so the key must be
+written in both. The original test compared `src.index()` of two strings that
+both live in the resume branch, so it passed while the field was absent from
+every fresh run, i.e. the common case and the whole point of the field. The
+replacement walks `_run_phases`'s AST, locates the `args.resume` `If` node, and
+requires the key in `body` **and** `orelse`, with an anti-vacuity control
+asserting the same walk finds `leerie_version` (known to be in both) so a broken
+walk fails as a broken walk rather than a missing key. (2) The local `-e`
+forward covers only `--runtime local`; Fly/EC2 build their own `child_env` in
+the launch heredoc, so the value must be forwarded there too — JSON-encoded via
+`_leerie_commit_json`, since that heredoc is unquoted, and the new name added to
+the `${...}` allowlist in `tests/test_bedrock_bearer_token.py` or its
+stray-substitution scan fails (verified live: it does).
 The `--dangerously-force-strict-output` context-window regression (DESIGN §7
 *Forcing constrained decoding*, §6 *A client-side context refusal*) is covered
 by three files. The defect: the flag works by owning `ANTHROPIC_BASE_URL`, and

--- a/leerie
+++ b/leerie
@@ -6882,6 +6882,11 @@ print(json.dumps(sys.argv[1:]))
         # exactly the kind of value likely to contain such bytes), applied
         # to every substituted value here for consistency.
         _host_tz_json="$(python3 -c 'import json, sys; print(json.dumps(sys.argv[1]))' "$_host_tz")"
+        # JSON-encoded like every other heredoc substitution: the heredoc is
+        # unquoted, so a raw value could break out of the Python literal. A sha
+        # is alphanumeric and carries no such risk, but the pattern is the
+        # pattern — and the stray-substitution guard fails loudly if skipped.
+        _leerie_commit_json="$(python3 -c 'import json, sys; print(json.dumps(sys.argv[1]))' "${LEERIE_COMMIT:-}")"
         _bedrock_bearer_token_json="$(python3 -c 'import json, sys; print(json.dumps(sys.argv[1]))' "${AWS_BEARER_TOKEN_BEDROCK:-}")"
         _bedrock_use_bedrock_json="$(python3 -c 'import json, sys; print(json.dumps(sys.argv[1]))' "${CLAUDE_CODE_USE_BEDROCK:-1}")"
         _bedrock_bearer_region_json="$(python3 -c 'import json, sys; print(json.dumps(sys.argv[1]))' "${AWS_REGION:-}")"
@@ -6959,6 +6964,10 @@ child_env["USER_REPO"] = "$(basename "$USER_REPO")"
 # (e.g. /etc/localtime not a symlink), the substitution yields ""
 # and Python's astimezone() falls back to UTC — same as today.
 child_env["TZ"] = ${_host_tz_json}
+# Recorded beside leerie_version in state.json. Forwarded here as well as on
+# the local nerdctl path: a remote run that records only the version cannot be
+# attributed to a commit, and remote is where that matters most.
+child_env["LEERIE_COMMIT"] = ${_leerie_commit_json}
 # Bedrock bearer-token activation (AWS_BEARER_TOKEN_BEDROCK) -- takes
 # precedence over the SSO/profile block below, mirroring the nerdctl path's
 # AUTH_MOUNTS ordering above. Every value is JSON-encoded host-side before

--- a/orchestrator/leerie.py
+++ b/orchestrator/leerie.py
@@ -26606,7 +26606,13 @@ async def _run_phases(args, caps: dict, leerie_dir: Path, st: State,
                    "strict_conformer": bool(args.strict_conformer),
                    "skip_base_baseline": bool(args.skip_base_baseline),
                    "skip_repo_map": bool(args.skip_repo_map),
-                   "leerie_version": _read_version()}
+                   "leerie_version": _read_version(),
+                   # Must stay beside leerie_version in BOTH branches: the
+                   # resume path above sets these as subscript assignments,
+                   # this fresh path as a dict literal, and a source-order
+                   # check cannot tell which branch it covered — which is
+                   # exactly how this key shipped absent from the common path.
+                   "leerie_commit": os.environ.get("LEERIE_COMMIT") or None}
         st.save()
         # Fail-closed containment gate + recording, before the first
         # worker (phase_classify below). Must come after the

--- a/tests/test_bedrock_bearer_token.py
+++ b/tests/test_bedrock_bearer_token.py
@@ -451,7 +451,8 @@ def test_child_env_heredoc_body_has_no_stray_unbound_var_substitution() -> None:
     `${...}` form inside this region."""
     block = _extract_child_env_bedrock_block()
     known = {
-        "_host_tz_json", "_bedrock_bearer_token_json", "_bedrock_use_bedrock_json",
+        "_host_tz_json", "_leerie_commit_json",
+        "_bedrock_bearer_token_json", "_bedrock_use_bedrock_json",
         "_bedrock_bearer_region_json", "_BEDROCK_BEARER_ACTIVE", "_bedrock_profile_json",
         "_BEDROCK_ACTIVE", "_bedrock_region_json",
     }

--- a/tests/test_leerie_commit.py
+++ b/tests/test_leerie_commit.py
@@ -18,6 +18,7 @@ import json
 import re
 import subprocess
 import sys
+import textwrap
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "orchestrator"))
@@ -67,10 +68,58 @@ class TestWriteSite:
         assert 'os.environ.get("LEERIE_COMMIT") or None' in src, (
             "an unset LEERIE_COMMIT must record None, not an empty string")
 
-    def test_written_beside_the_version(self):
-        src = self._write_src()
-        assert (src.index('st.data["leerie_version"]')
-                < src.index('st.data["leerie_commit"]'))
+    def test_written_in_BOTH_state_init_branches(self):
+        """The resume path and the fresh path are separate initialisations.
+
+        `_run_phases` sets state under `if args.resume:` with subscript
+        assignments, and under its `else:` with a dict literal. The original
+        version of this test compared `src.index(...)` of two strings, both of
+        which live in the resume branch — so it passed while the key was absent
+        from the fresh path entirely, which is the overwhelmingly common case
+        and the one the field exists for. A source-order check across a
+        two-branch function cannot tell you which branch it covered.
+
+        This walks the AST instead and requires the key in each branch.
+        """
+        import ast
+        import inspect
+        tree = ast.parse(textwrap.dedent(inspect.getsource(leerie._run_phases)))
+        resume_ifs = [
+            n for n in ast.walk(tree)
+            if isinstance(n, ast.If) and "args.resume" in ast.unparse(n.test)
+        ]
+        assert resume_ifs, "could not locate the `if args.resume:` split"
+        node = resume_ifs[0]
+        assert node.orelse, "the fresh-run `else:` branch was not found"
+
+        def mentions(body) -> bool:
+            return any("leerie_commit" in ast.unparse(s) for s in body)
+
+        assert mentions(node.body), "resume branch does not record leerie_commit"
+        assert mentions(node.orelse), (
+            "FRESH-RUN branch does not record leerie_commit — the field would "
+            "be null for every non-resume run")
+
+    def test_both_branches_also_record_the_version(self):
+        """Anti-vacuity control for the test above.
+
+        If the branch-finding logic were wrong (wrong node, empty bodies), the
+        `leerie_commit` assertions could pass or fail for reasons unrelated to
+        the key. `leerie_version` is known to be in both branches, so it must
+        be found by the same walk — if it is not, the walk is broken, not the
+        code.
+        """
+        import ast
+        import inspect
+        tree = ast.parse(textwrap.dedent(inspect.getsource(leerie._run_phases)))
+        node = [n for n in ast.walk(tree)
+                if isinstance(n, ast.If) and "args.resume" in ast.unparse(n.test)][0]
+
+        def mentions(body) -> bool:
+            return any("leerie_version" in ast.unparse(s) for s in body)
+
+        assert mentions(node.body) and mentions(node.orelse), (
+            "the branch walk is broken — leerie_version is known to be in both")
 
 
 class TestRoundTrip:
@@ -148,3 +197,24 @@ class TestLauncher:
         r = subprocess.run(["bash", "-n", str(REPO / "leerie")],
                            capture_output=True, text=True)
         assert r.returncode == 0, r.stderr
+
+    def test_forwarded_on_the_fly_ec2_path_too(self):
+        """The local `-e` forward covers only `--runtime local`.
+
+        Remote runs build their own `child_env` in the Fly launch heredoc. A
+        field that records only on the local path is absent exactly where
+        attribution is hardest, which is how this shipped.
+        """
+        assert 'child_env["LEERIE_COMMIT"] = ${_leerie_commit_json}' in LAUNCHER
+
+    def test_remote_value_is_json_encoded(self):
+        """The launch heredoc is unquoted, so raw substitution is unsafe.
+
+        A sha carries no injection risk itself, but the encoding is the
+        established pattern (`_host_tz_json`, `_bedrock_*_json`) adopted after a
+        raw value broke out of a Python literal — and deviating from it silently
+        is what the stray-substitution guard exists to prevent.
+        """
+        assert "_leerie_commit_json=\"$(python3 -c 'import json, sys; " \
+               "print(json.dumps(sys.argv[1]))'" in LAUNCHER
+        assert '"${LEERIE_COMMIT:-}"' in LAUNCHER


### PR DESCRIPTION
**#181 shipped the field inert on the common path.** `leerie_commit` populated only for local **resume** runs. Every fresh run and every remote run recorded `null` — including the exact case it was built for.

| runtime | path | before | after |
|---|---|---|---|
| local | resume | ✅ | ✅ |
| local | **fresh** | ❌ `null` | ✅ |
| fly / ec2 | any | ❌ `null` | ✅ |

## Two causes, both incomplete propagation

**Fresh-run branch.** `_run_phases` initialises state in two places: `if args.resume:` uses subscript assignments and carried the write; the fresh-run `else:` builds a **dict literal** and did not. Fresh runs are the common case.

**Remote runtimes.** `LEERIE_COMMIT` was forwarded only by the local `nerdctl run`. Fly/EC2 build their own `child_env` in the launch heredoc, so remote runs — where attribution matters most — never saw it. Now forwarded via `_leerie_commit_json`, JSON-encoded because that heredoc is unquoted, with the name added to the `${...}` allowlist in `tests/test_bedrock_bearer_token.py`. Verified live: omitting the allowlist entry fails the stray-substitution scan.

## The third fix is why this shipped

The test asserted:

```python
src.index('st.data["leerie_version"]') < src.index('st.data["leerie_commit"]')
```

Both strings live in the resume branch, so it passed while proving nothing about the fresh path. **A source-order check across a two-branch function cannot tell you which branch it covered.**

It now walks `_run_phases`'s AST, locates the `args.resume` `If` node, and requires the key in both `body` and `orelse` — plus an anti-vacuity control asserting the same walk finds `leerie_version` (known to be in both), so a broken walk fails *as a broken walk* rather than as a missing key.

## Falsification

All three reverted and confirmed failing, with the substitution count asserted (`n == 1`) so the falsification isn't itself vacuous:

- remove the fresh-run key → `test_written_in_BOTH_state_init_branches` fails
- remove the `child_env` line → `test_forwarded_on_the_fly_ec2_path_too` fails
- revert the allowlist entry → the stray-substitution scan fails

58 tests green across `test_leerie_commit`, `test_bedrock_bearer_token`, `test_state_fields`, `test_launcher_env_forwarding`; `bash -n leerie`; `ast.parse`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)