### PR TITLE
fix(state): forward leerie_commit on the ec2 launch path too

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2752,7 +2752,20 @@ their own unquoted `<<PY` heredoc. Both must forward the value, JSON-encoded
 (`_leerie_commit_json` / `_ec2_leerie_commit_json`) like every other
 substitution there; the Fly name additionally goes in the `${...}` allowlist in
 `tests/test_bedrock_bearer_token.py` or its stray-substitution scan fails
-(verified live: it does — EC2 has no equivalent scan, which is its own gap).
+(verified live: it does).
+**Both heredoc scans are themselves derived**, over every launch block rather
+than the one Fly slice they originally hard-coded: `_launch_env_blocks()` in
+`tests/test_bedrock_bearer_token.py` feeds both the stray-`${...}` allowlist
+scan and the backtick scan, each with a per-runtime allowlist
+(`_KNOWN_HEREDOC_SUBSTITUTIONS`). Before that, the scans covered a 31-line
+`TZ`→`AWS_REGION` slice of the Fly body and were **structurally blind** to the
+EC2 heredoc — an unquoted `<<PY` with identical failure modes: an unbound
+`${VAR}` anywhere in the body, comments included, aborts the launcher under
+`set -euo pipefail`, and a balanced backtick pair is read as command
+substitution, silently dropping that text from the script sent to the machine
+(`bash -n` does not catch it; `shellcheck -x` does). Falsified in both
+directions: injecting either defect into the EC2 body now fails naming `ec2`,
+and the old slice provably did not contain it.
 **The guard is derived, not enumerated**: `_child_env_blocks()` finds every
 `child_env = dict(os.environ)` in the launcher and requires each to forward the
 var, so a third runtime fails automatically. This exists because the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2746,11 +2746,22 @@ replacement walks `_run_phases`'s AST, locates the `args.resume` `If` node, and
 requires the key in `body` **and** `orelse`, with an anti-vacuity control
 asserting the same walk finds `leerie_version` (known to be in both) so a broken
 walk fails as a broken walk rather than a missing key. (2) The local `-e`
-forward covers only `--runtime local`; Fly/EC2 build their own `child_env` in
-the launch heredoc, so the value must be forwarded there too — JSON-encoded via
-`_leerie_commit_json`, since that heredoc is unquoted, and the new name added to
-the `${...}` allowlist in `tests/test_bedrock_bearer_token.py` or its
-stray-substitution scan fails (verified live: it does).
+forward covers only `--runtime local`, and there are **two** further launch
+blocks — Fly and EC2 each build their own `child_env = dict(os.environ)` inside
+their own unquoted `<<PY` heredoc. Both must forward the value, JSON-encoded
+(`_leerie_commit_json` / `_ec2_leerie_commit_json`) like every other
+substitution there; the Fly name additionally goes in the `${...}` allowlist in
+`tests/test_bedrock_bearer_token.py` or its stray-substitution scan fails
+(verified live: it does — EC2 has no equivalent scan, which is its own gap).
+**The guard is derived, not enumerated**: `_child_env_blocks()` finds every
+`child_env = dict(os.environ)` in the launcher and requires each to forward the
+var, so a third runtime fails automatically. This exists because the
+hard-coded version shipped covering Fly only while being *named*
+`..._fly_ec2_path_too` — EC2 recorded null and a reviewer caught it, not the
+suite. Two anti-vacuity controls are mandatory alongside it, since a splitter
+that finds nothing passes everything: at least two blocks must be found, and
+every block must also set `USER_REPO` (known present in both), so a broken
+slice fails as a broken slice rather than as a missing key.
 The `--dangerously-force-strict-output` context-window regression (DESIGN §7
 *Forcing constrained decoding*, §6 *A client-side context refusal*) is covered
 by three files. The defect: the flag works by owning `ANTHROPIC_BASE_URL`, and

--- a/leerie
+++ b/leerie
@@ -7408,6 +7408,7 @@ print(json.dumps(sys.argv[1:]))
           # break out of a raw Python string literal on this remote machine.
           _ec2_oauth_token_json="$(python3 -c 'import json, sys; print(json.dumps(sys.argv[1]))' "${CLAUDE_CODE_OAUTH_TOKEN:-}")"
           _ec2_oauth_tokens_json="$(python3 -c 'import json, sys; print(json.dumps(sys.argv[1]))' "${CLAUDE_CODE_OAUTH_TOKENS:-}")"
+          _ec2_leerie_commit_json="$(python3 -c 'import json, sys; print(json.dumps(sys.argv[1]))' "${LEERIE_COMMIT:-}")"
           _ec2_launch_script="$(cat <<PY
 import fcntl, os, pwd, subprocess, sys, time
 argv = ${_ec2_launch_argv_json}
@@ -7444,6 +7445,10 @@ child_env["USER"] = "leerie"
 child_env["LOGNAME"] = "leerie"
 child_env["USER_REPO"] = "$(basename "$USER_REPO")"
 child_env["TZ"] = "${_ec2_host_tz}"
+# Recorded beside leerie_version in state.json. Every orchestrator launch
+# path must forward this -- local, fly AND ec2 -- or the field is null for
+# whichever runtime is missed, which is how ec2 was skipped once already.
+child_env["LEERIE_COMMIT"] = ${_ec2_leerie_commit_json}
 # CLAUDE_CODE_OAUTH_TOKEN(S) -- forwarded unconditionally (empty JSON string
 # is falsy) so the in-machine orchestrator's multi-token probe/rotation
 # (DESIGN §6 *Multi-token rotation*) sees the full list, not just the single

--- a/tests/test_bedrock_bearer_token.py
+++ b/tests/test_bedrock_bearer_token.py
@@ -434,6 +434,58 @@ def test_fly_heredoc_values_are_json_encoded_not_raw() -> None:
     assert "child_env[\"AWS_BEARER_TOKEN_BEDROCK\"] = ${_bedrock_bearer_token_json}" in src
 
 
+# Intentional `${...}` substitution names, per launch heredoc. Both heredocs are
+# unquoted `<<PY`, so bash expands every `${...}`-shaped token in their bodies --
+# including inside what reads as a Python comment. Anything not listed here is
+# either a typo or prose that will be expanded anyway.
+_KNOWN_HEREDOC_SUBSTITUTIONS = {
+    "fly": {
+        "_host_tz_json", "_leerie_commit_json",
+        "_oauth_token_json", "_oauth_tokens_json",
+        "_bedrock_bearer_token_json", "_bedrock_use_bedrock_json",
+        "_bedrock_bearer_region_json", "_BEDROCK_BEARER_ACTIVE",
+        "_bedrock_profile_json", "_BEDROCK_ACTIVE", "_bedrock_region_json",
+    },
+    "ec2": {
+        "_ec2_host_tz", "_ec2_leerie_commit_json",
+        "_ec2_oauth_token_json", "_ec2_oauth_tokens_json",
+    },
+}
+
+
+def _launch_env_blocks() -> list[tuple[str, str]]:
+    """Every orchestrator launch heredoc's env block, as (runtime, body).
+
+    Derived rather than enumerated. These scans originally covered the Fly
+    body only -- a narrow `child_env["TZ"]`-to-`AWS_REGION` slice -- while the
+    EC2 launch heredoc, an unquoted `<<PY` with the identical failure modes,
+    had no coverage at all. Deriving the set means a third runtime is scanned
+    the day it is added.
+    """
+    src = LAUNCHER.read_text()
+    out: list[tuple[str, str]] = []
+    for m in re.finditer(r"child_env = dict\(os\.environ\)", src):
+        end = src.find("\nPY\n", m.start())
+        body = src[m.start():end if end > 0 else len(src)]
+        preamble = src[max(0, m.start() - 1200):m.start()]
+        out.append(("ec2" if "--runtime ec2" in preamble else "fly", body))
+    return out
+
+
+def test_launch_block_discovery_is_not_vacuous() -> None:
+    """A splitter that finds nothing makes both scans below pass trivially."""
+    blocks = _launch_env_blocks()
+    assert len(blocks) >= 2, (
+        f"expected at least the fly and ec2 launch heredocs, found "
+        f"{len(blocks)} -- the splitter is broken, so the scans prove nothing")
+    assert {rt for rt, _ in blocks} == set(_KNOWN_HEREDOC_SUBSTITUTIONS), (
+        "discovered runtimes do not match the allowlist keys")
+    for rt, body in blocks:
+        assert 'child_env["USER_REPO"]' in body, (
+            f"{rt} block lacks USER_REPO -- the slice is wrong")
+
+
+
 def test_child_env_heredoc_body_has_no_stray_unbound_var_substitution() -> None:
     """Regression guard for a second, more severe defect found alongside the
     injection one: the heredoc is UNQUOTED (`<<PY`, not `<<'PY'`), so bash
@@ -449,23 +501,18 @@ def test_child_env_heredoc_body_has_no_stray_unbound_var_substitution() -> None:
     `bash: line N: VAR: unbound variable` when the surrounding script is
     executed. Only the KNOWN, intentional substitution names may appear in
     `${...}` form inside this region."""
-    block = _extract_child_env_bedrock_block()
-    known = {
-        "_host_tz_json", "_leerie_commit_json",
-        "_bedrock_bearer_token_json", "_bedrock_use_bedrock_json",
-        "_bedrock_bearer_region_json", "_BEDROCK_BEARER_ACTIVE", "_bedrock_profile_json",
-        "_BEDROCK_ACTIVE", "_bedrock_region_json",
-    }
-    found = set(re.findall(r"\$\{([A-Za-z_][A-Za-z0-9_]*)", block))
-    unexpected = found - known
-    assert not unexpected, (
-        f"unexpected ${{...}}-shaped substitution(s) in the unquoted Fly "
-        f"heredoc body: {sorted(unexpected)} — if these are meant to be "
-        f"literal text (e.g. inside a comment), the heredoc's unquoted "
-        f"nature means bash will still try to substitute them, crashing "
-        f"under `set -u` if unset. Rephrase the comment to avoid the "
-        f"${{...}} shape entirely."
-    )
+    for runtime, block in _launch_env_blocks():
+        known = _KNOWN_HEREDOC_SUBSTITUTIONS[runtime]
+        found = set(re.findall(r"\$\{([A-Za-z_][A-Za-z0-9_]*)", block))
+        unexpected = found - known
+        assert not unexpected, (
+            f"unexpected ${{...}}-shaped substitution(s) in the unquoted "
+            f"{runtime} heredoc body: {sorted(unexpected)} — if these are meant "
+            f"to be literal text (e.g. inside a comment), the heredoc's "
+            f"unquoted nature means bash will still try to substitute them, "
+            f"crashing under `set -u` if unset. Rephrase the comment to avoid "
+            f"the ${{...}} shape entirely."
+        )
 
 
 def test_child_env_heredoc_body_has_no_backtick_characters() -> None:
@@ -484,14 +531,15 @@ def test_child_env_heredoc_body_has_no_backtick_characters() -> None:
     `git stash` is how this was originally caught; `bash -n` alone does not
     catch it. This heredoc's content is pure Python, which never needs a
     literal backtick, so the invariant is simply: none allowed."""
-    block = _extract_child_env_bedrock_block()
-    assert "`" not in block, (
-        "a backtick character appeared in the unquoted Fly heredoc body — "
-        "bash will treat a balanced pair as command substitution even "
-        "inside a comment, corrupting the script and printing a spurious "
-        "syntax error to the user on every launch. Rephrase to avoid "
-        "backticks entirely (e.g. drop inline code-formatting in prose)."
-    )
+    for runtime, block in _launch_env_blocks():
+        assert "`" not in block, (
+            f"a backtick character appeared in the unquoted {runtime} heredoc "
+            f"body — bash will treat a balanced pair as command substitution "
+            f"even inside a comment, corrupting the script and printing a "
+            f"spurious syntax error to the user on every launch. Rephrase to "
+            f"avoid backticks entirely (e.g. drop inline code-formatting in "
+            f"prose)."
+        )
 
 
 def test_fly_heredoc_bearer_precedes_sso_elif() -> None:

--- a/tests/test_leerie_commit.py
+++ b/tests/test_leerie_commit.py
@@ -28,6 +28,26 @@ REPO = Path(__file__).resolve().parents[1]
 LAUNCHER = (REPO / "leerie").read_text()
 
 
+
+def _child_env_blocks() -> list[tuple[str, str]]:
+    """Every in-heredoc orchestrator launch env block, as (runtime, source).
+
+    Derived from the launcher rather than enumerated: each remote runtime
+    builds its own `child_env = dict(os.environ)` inside its launch heredoc,
+    and a hard-coded list silently stops covering a runtime the moment one is
+    added. The runtime label comes from the `--runtime <rt>` string in the
+    duplicate-run message just above each block.
+    """
+    out: list[tuple[str, str]] = []
+    for m in re.finditer(r"child_env = dict\(os\.environ\)", LAUNCHER):
+        end = LAUNCHER.find("\nPY\n", m.start())
+        block = LAUNCHER[m.start():end if end > 0 else len(LAUNCHER)]
+        preamble = LAUNCHER[max(0, m.start() - 1200):m.start()]
+        rt = "ec2" if "--runtime ec2" in preamble else "fly"
+        out.append((rt, block))
+    return out
+
+
 class TestStateSurface:
     def test_declared_in_state_fields(self):
         # Guard-the-guard for the parity sweep in test_state_fields.py: that
@@ -198,14 +218,52 @@ class TestLauncher:
                            capture_output=True, text=True)
         assert r.returncode == 0, r.stderr
 
-    def test_forwarded_on_the_fly_ec2_path_too(self):
-        """The local `-e` forward covers only `--runtime local`.
+    def test_every_remote_launch_block_forwards_it(self):
+        """EVERY orchestrator launch path must forward this, not just the one
+        in front of whoever last edited it.
 
-        Remote runs build their own `child_env` in the Fly launch heredoc. A
-        field that records only on the local path is absent exactly where
-        attribution is hardest, which is how this shipped.
+        The local `-e` forward covers only `--runtime local`; remote runtimes
+        build their own `child_env` inside their launch heredocs, and there are
+        **two** of them (fly and ec2). #182 added the fly one and shipped
+        claiming ec2 worked -- its test asserted a single hard-coded fly string
+        while being named `..._fly_ec2_path_too`. So this derives the set from
+        the launcher instead of listing it: a third runtime fails here
+        automatically.
         """
-        assert 'child_env["LEERIE_COMMIT"] = ${_leerie_commit_json}' in LAUNCHER
+        blocks = _child_env_blocks()
+        missing = [rt for rt, blk in blocks
+                   if 'child_env["LEERIE_COMMIT"]' not in blk]
+        assert not missing, (
+            f"launch block(s) {missing} do not forward LEERIE_COMMIT — the "
+            f"field records null for those runtimes")
+
+    def test_launch_block_discovery_is_not_vacuous(self):
+        """A splitter that finds nothing makes the test above pass trivially.
+
+        Two independent controls: at least two blocks exist (fly + ec2), and
+        every block sets `USER_REPO`, which is known present in both. If either
+        fails, the splitter is broken — and it fails *as* a broken splitter
+        rather than masquerading as a missing key.
+        """
+        blocks = _child_env_blocks()
+        assert len(blocks) >= 2, (
+            f"expected at least the fly and ec2 launch blocks, found "
+            f"{len(blocks)} — the block splitter is broken")
+        for rt, blk in blocks:
+            assert 'child_env["USER_REPO"]' in blk, (
+                f"block {rt} lacks USER_REPO — the slice is wrong, so the "
+                f"LEERIE_COMMIT result above cannot be trusted")
+
+    def test_remote_values_are_json_encoded(self):
+        """Both launch heredocs are unquoted `<<PY`, so raw substitution is
+        unsafe. A sha carries no injection risk, but deviating silently from
+        the established `*_json` pattern is what the Fly stray-substitution
+        guard exists to prevent."""
+        for name in ("_leerie_commit_json", "_ec2_leerie_commit_json"):
+            assert (f"""{name}="$(python3 -c 'import json, sys; """
+                    f"""print(json.dumps(sys.argv[1]))'""") in LAUNCHER, (
+                f"{name} is not JSON-encoded host-side")
+        assert '"${LEERIE_COMMIT:-}"' in LAUNCHER
 
     def test_remote_value_is_json_encoded(self):
         """The launch heredoc is unquoted, so raw substitution is unsafe.


### PR DESCRIPTION
**#182 claimed `fly / ec2 → ✅`. That was wrong for EC2.** This PR fixes it, then closes the guard gap that let it through.

## 1. The EC2 forward

The launcher has **two** in-heredoc orchestrator launch blocks; #182 updated only Fly's. Every `--runtime ec2` run recorded `leerie_commit` as `null`.

| block | runtime | before | after |
|---|---|---|---|
| `:6947` | fly | ✅ | ✅ |
| `:7442` | **ec2** | ❌ `null` | ✅ |
| `:7759` | local (`-e`) | ✅ | ✅ |

The EC2 heredoc is unquoted `<<PY` like Fly's and already JSON-encodes its substitutions, so this follows suit: `_ec2_leerie_commit_json` + `child_env["LEERIE_COMMIT"]`.

**The forwarding guard is now derived.** The shipped test asserted one hard-coded Fly string *while being named* `test_forwarded_on_the_fly_ec2_path_too` — it claimed coverage it never had, and a reviewer caught the gap, not the suite. `_child_env_blocks()` now finds every launch block and requires each to forward the var, naming the failing one:

```
AssertionError: launch block(s) ['ec2'] do not forward LEERIE_COMMIT
```

## 2. Both heredoc scans generalised

The same blindness existed one level up. The guards protecting the Fly heredoc — one for stray `${...}`, one for backticks — covered a **31-line `TZ`→`AWS_REGION` slice** and were structurally blind to the EC2 heredoc, which has identical failure modes:

- an unbound `${VAR}` anywhere in the body, comments included, aborts the launcher under `set -euo pipefail` (this once fired on *every* Bedrock Fly launch)
- a balanced backtick pair is read as command substitution, silently dropping that text from the script sent to the machine — `bash -n` misses it, `shellcheck -x` catches it

Both now derive their input from `_launch_env_blocks()`, with a per-runtime allowlist.

**No defect was found.** I predicted the EC2 scan would fail on first run; it did not — four substitutions, all intentional, zero backticks. The value is prospective coverage, not a caught bug. Widening the Fly scan from its slice to the whole block surfaced two further legitimate names (`_oauth_token_json`, `_oauth_tokens_json`) that were merely outside the old region.

## Falsification

Every guard reverted and confirmed failing, with occurrence counts asserted so the falsification isn't itself vacuous:

| revert | result |
|---|---|
| remove ec2 forward | fails naming `['ec2']` |
| remove fly forward | fails naming `['fly']` |
| break the block splitter | anti-vacuity assertions trip |
| stray `${...}` in **ec2** body | fails naming `ec2` |
| backtick in **ec2** body | fails naming `ec2` |

Plus a directional proof: the pre-generalisation 31-line slice **provably does not contain** the injected EC2 text, so the old scans could not have caught it.

61 tests green across `test_bedrock_bearer_token`, `test_leerie_commit`, `test_launcher_env_forwarding`, `test_state_fields`; `bash -n leerie`.

## Pattern

Fourth instance in this arc of extending a family and covering only the instance in view — after `ContextOverflow` in 1 of 9 capture guards, telemetry recording the alias rather than the effective model, and `leerie_commit` written in 1 of 2 state-init branches. Every fix that stuck replaced an enumeration with a derivation; this PR does it twice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
