### PR TITLE
test(launcher): one shared derivation of the launch blocks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2721,7 +2721,11 @@ that would otherwise be replicated per consumer: the block marker, the `\nPY\n`
 terminator, and the preamble window searched for the `--runtime` label. Both
 `test_leerie_commit.py` (LEERIE_COMMIT forwarding) and
 `test_bedrock_bearer_token.py` (stray-`${...}` and backtick scans) import
-`launch_env_blocks()` from it; a neutral module rather than a cross-test import
+`launch_env_blocks()` from it — package-qualified as
+`from tests.launcher_blocks import ...`, the same form every shared test module
+here uses (`tests.ec2_stub`, `tests.conftest`), with no `sys.path` juggling:
+`tests/__init__.py` exists, so `tests` is a real package. A neutral module
+rather than a cross-test import
 because the two consumers are unrelated concerns and neither should own it
 (`tests/ec2_stub.py` is the precedent for the shape). It reads the launcher
 itself rather than taking the source as an argument, so callers holding a `str`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2714,6 +2714,29 @@ walks the AST of `_run_phases`, because the obvious
 No coverage
 target is set — the suite was introduced from scratch and a number
 now would be arbitrary.
+`tests/test_launcher_integrity.py` is the **only** thing that checks the
+`leerie` launcher parses. CI does not: `shellcheck.yml` lints `scripts/*.sh`
+and the launcher has no `.sh` extension nor lives there, while `syntax.yml`
+AST-parses Python only. No test runs shellcheck at all — every occurrence of
+the word under `tests/` is prose describing this gap. So a `bash -n`-level
+syntax error in a 7k-line launcher would otherwise ship green.
+That check first appeared inside `test_leerie_commit.py`, a file about one
+state field, where it was coverage by accident: restructuring that file would
+have removed the launcher's only validation silently. It is now named and
+owned, with a derived guard (`_files_checking_launcher_syntax`) asserting some
+file still runs `bash -n` against the launcher — scanning `tests/` rather than
+naming itself, so moving the check again is fine and deleting it is not. The
+scan requires the invocation shape *and* a launcher reference in the same file,
+since `container-entry.sh` is `bash -n`-checked elsewhere and must not be
+mistaken for launcher coverage; an anti-vacuity test requires the scan to find
+its own file, so a broken scan fails as a broken scan.
+**Known shortfall, deliberately not papered over:** `bash -n` does not catch
+the backtick class — a balanced pair inside what reads as a comment is parsed
+as command substitution, silently dropping that text from the script sent to a
+remote machine. leerie has shipped that defect once; it was caught by diffing
+`shellcheck -x leerie`, with `bash -n` clean throughout. Linting the whole
+launcher with shellcheck is the real fix and needs a measured baseline of
+pre-existing findings first.
 `tests/launcher_blocks.py` is the **single** derivation of the launcher's
 orchestrator launch blocks — the `child_env = dict(os.environ)` regions inside
 each unquoted `<<PY` heredoc, one per remote runtime. It owns three constants

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2714,6 +2714,31 @@ walks the AST of `_run_phases`, because the obvious
 No coverage
 target is set — the suite was introduced from scratch and a number
 now would be arbitrary.
+`tests/launcher_blocks.py` is the **single** derivation of the launcher's
+orchestrator launch blocks — the `child_env = dict(os.environ)` regions inside
+each unquoted `<<PY` heredoc, one per remote runtime. It owns three constants
+that would otherwise be replicated per consumer: the block marker, the `\nPY\n`
+terminator, and the preamble window searched for the `--runtime` label. Both
+`test_leerie_commit.py` (LEERIE_COMMIT forwarding) and
+`test_bedrock_bearer_token.py` (stray-`${...}` and backtick scans) import
+`launch_env_blocks()` from it; a neutral module rather than a cross-test import
+because the two consumers are unrelated concerns and neither should own it
+(`tests/ec2_stub.py` is the precedent for the shape). It reads the launcher
+itself rather than taking the source as an argument, so callers holding a `str`
+or a `Path` are equally served.
+**Why a shared module and not two local copies**: PRs #180–#183 each replaced a
+hard-coded enumeration with a derivation after a missed instance shipped —
+`ContextOverflow` in 1 of 9 capture guards, `leerie_commit` in 1 of 2
+state-init branches, then 1 of 2 launch blocks (that last one caught by a
+reviewer, not the suite). The derivation was then written twice, once per
+consumer. Two copies of a *rule* drift exactly the way two copies of a *list*
+do. `tests/test_no_duplicate_launcher_splitters.py` enforces the single owner
+and carries two anti-vacuity controls, since a scan that matches nothing would
+certify 'no duplicates' forever: the marker must be found *inside* the owner,
+and at least two other files must actually import `launch_env_blocks`. The
+load-bearing falsification is breaking the shared splitter and confirming
+guards in **both** consuming files fail — that is what proves they share it
+rather than merely importing it.
 `tests/test_leerie_commit.py` pins the `leerie_commit` state field, which
 disambiguates `leerie_version`. `plugin.json` only moves on a `chore(release):`
 commit while `install.sh` tracks `main` (`DEFAULT_REF`), so every run between

--- a/tests/launcher_blocks.py
+++ b/tests/launcher_blocks.py
@@ -1,0 +1,65 @@
+"""The single derivation of the launcher's orchestrator launch blocks.
+
+Each remote runtime builds its own `child_env = dict(os.environ)` inside its own
+unquoted `<<PY` launch heredoc. Several guards need that set — the
+`LEERIE_COMMIT` forwarding check in `test_leerie_commit.py`, and the
+stray-`${...}` and backtick scans in `test_bedrock_bearer_token.py` — and all of
+them must derive it rather than enumerate it, because a hard-coded list stops
+covering reality the moment a runtime is added.
+
+This module exists because that lesson applied to the guards themselves. PRs
+#180-#183 each replaced a hard-coded enumeration with a derivation, after a
+missed instance shipped: `ContextOverflow` in 1 of 9 capture guards,
+`leerie_commit` in 1 of 2 state-init branches, then in 1 of 2 launch blocks --
+the last caught by a reviewer, not the suite. The derivation was then written
+*twice*, once per consuming test file, replicating three magic constants. Two
+copies of a rule drift exactly the way two copies of a list do, so there is one
+copy, here.
+
+Deliberately a neutral module rather than a cross-test import (both patterns are
+idiomatic in this repo -- cf. `tests/ec2_stub.py` for the former,
+`test_fetch_branch_leerie_streamback` importing `test_fetch_branch_sh` for the
+latter): the two consumers are unrelated concerns, and neither should own it.
+It reads the launcher itself rather than accepting the source as a parameter, so
+it does not care whether a caller happens to hold a `str` or a `Path` -- the
+incidental difference that made the two copies look unalike.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+LAUNCHER_PATH = Path(__file__).resolve().parents[1] / "leerie"
+
+# What marks the start of a launch env block. Each launch heredoc builds its
+# child environment from scratch because `ssh console` sets HOME=/root.
+_BLOCK_START = re.compile(r"child_env = dict\(os\.environ\)")
+
+# The heredoc terminator that bounds a block. Both launch heredocs use `<<PY`.
+# Many unrelated heredocs in the launcher share this delimiter, so the bound is
+# "first terminator after the block start" -- verified disjoint, see
+# `test_no_duplicate_launcher_splitters.py`.
+_BLOCK_END = "\nPY\n"
+
+# How far above a block to look for its runtime label. The launcher prints a
+# `leerie resume <id> --runtime <rt>` hint in each heredoc's duplicate-run
+# guard, which sits a few dozen lines above the env block.
+_PREAMBLE_WINDOW = 1200
+
+
+def launch_env_blocks() -> list[tuple[str, str]]:
+    """Every orchestrator launch env block, as `(runtime, body)`.
+
+    `runtime` is `"ec2"` or `"fly"`, taken from the `--runtime <rt>` string in
+    the duplicate-run message above each block. The label is for diagnostics —
+    it is what lets a failing guard say *which* block is broken — so a
+    mislabel would degrade a message, not weaken an assertion.
+    """
+    src = LAUNCHER_PATH.read_text()
+    out: list[tuple[str, str]] = []
+    for m in _BLOCK_START.finditer(src):
+        end = src.find(_BLOCK_END, m.start())
+        body = src[m.start():end if end > 0 else len(src)]
+        preamble = src[max(0, m.start() - _PREAMBLE_WINDOW):m.start()]
+        out.append(("ec2" if "--runtime ec2" in preamble else "fly", body))
+    return out

--- a/tests/test_bedrock_bearer_token.py
+++ b/tests/test_bedrock_bearer_token.py
@@ -21,16 +21,13 @@ from __future__ import annotations
 
 import json
 import re
-import sys
-from pathlib import Path as _Path
-
-sys.path.insert(0, str(_Path(__file__).resolve().parent))
-# One shared derivation of the launcher's launch blocks — see
-# tests/launcher_blocks.py for why it is not re-implemented per consumer.
-from launcher_blocks import launch_env_blocks  # noqa: E402
 import shutil
 import subprocess
 from pathlib import Path
+
+# One shared derivation of the launcher's launch blocks — see
+# tests/launcher_blocks.py for why it is not re-implemented per consumer.
+from tests.launcher_blocks import launch_env_blocks
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 LAUNCHER = REPO_ROOT / "leerie"

--- a/tests/test_bedrock_bearer_token.py
+++ b/tests/test_bedrock_bearer_token.py
@@ -21,6 +21,13 @@ from __future__ import annotations
 
 import json
 import re
+import sys
+from pathlib import Path as _Path
+
+sys.path.insert(0, str(_Path(__file__).resolve().parent))
+# One shared derivation of the launcher's launch blocks — see
+# tests/launcher_blocks.py for why it is not re-implemented per consumer.
+from launcher_blocks import launch_env_blocks  # noqa: E402
 import shutil
 import subprocess
 from pathlib import Path
@@ -453,28 +460,9 @@ _KNOWN_HEREDOC_SUBSTITUTIONS = {
 }
 
 
-def _launch_env_blocks() -> list[tuple[str, str]]:
-    """Every orchestrator launch heredoc's env block, as (runtime, body).
-
-    Derived rather than enumerated. These scans originally covered the Fly
-    body only -- a narrow `child_env["TZ"]`-to-`AWS_REGION` slice -- while the
-    EC2 launch heredoc, an unquoted `<<PY` with the identical failure modes,
-    had no coverage at all. Deriving the set means a third runtime is scanned
-    the day it is added.
-    """
-    src = LAUNCHER.read_text()
-    out: list[tuple[str, str]] = []
-    for m in re.finditer(r"child_env = dict\(os\.environ\)", src):
-        end = src.find("\nPY\n", m.start())
-        body = src[m.start():end if end > 0 else len(src)]
-        preamble = src[max(0, m.start() - 1200):m.start()]
-        out.append(("ec2" if "--runtime ec2" in preamble else "fly", body))
-    return out
-
-
 def test_launch_block_discovery_is_not_vacuous() -> None:
     """A splitter that finds nothing makes both scans below pass trivially."""
-    blocks = _launch_env_blocks()
+    blocks = launch_env_blocks()
     assert len(blocks) >= 2, (
         f"expected at least the fly and ec2 launch heredocs, found "
         f"{len(blocks)} -- the splitter is broken, so the scans prove nothing")
@@ -501,7 +489,7 @@ def test_child_env_heredoc_body_has_no_stray_unbound_var_substitution() -> None:
     `bash: line N: VAR: unbound variable` when the surrounding script is
     executed. Only the KNOWN, intentional substitution names may appear in
     `${...}` form inside this region."""
-    for runtime, block in _launch_env_blocks():
+    for runtime, block in launch_env_blocks():
         known = _KNOWN_HEREDOC_SUBSTITUTIONS[runtime]
         found = set(re.findall(r"\$\{([A-Za-z_][A-Za-z0-9_]*)", block))
         unexpected = found - known
@@ -531,7 +519,7 @@ def test_child_env_heredoc_body_has_no_backtick_characters() -> None:
     `git stash` is how this was originally caught; `bash -n` alone does not
     catch it. This heredoc's content is pure Python, which never needs a
     literal backtick, so the invariant is simply: none allowed."""
-    for runtime, block in _launch_env_blocks():
+    for runtime, block in launch_env_blocks():
         assert "`" not in block, (
             f"a backtick character appeared in the unquoted {runtime} heredoc "
             f"body — bash will treat a balanced pair as command substitution "

--- a/tests/test_launcher_integrity.py
+++ b/tests/test_launcher_integrity.py
@@ -1,0 +1,88 @@
+"""The `leerie` launcher parses — nothing else in CI checks that.
+
+Verified when this file was written:
+
+- `.github/workflows/shellcheck.yml` lints `scripts/*.sh` only. The launcher has
+  no `.sh` extension and does not live in `scripts/`, so it is not covered.
+- `.github/workflows/syntax.yml` AST-parses `orchestrator/leerie.py` and
+  `tests/**/*.py` — Python only.
+- No test runs shellcheck. Every "shellcheck" occurrence under `tests/` is prose
+  in a docstring describing this gap, most explicitly
+  `test_ec2_launcher_finalize.py`: *"Nothing else covers this: CI's shellcheck
+  job lints `scripts/...`"*.
+
+So a `bash -n`-level syntax error in the launcher would ship green were it not
+for this file. That check previously lived as one method inside
+`test_leerie_commit.py`, whose subject is a single state field — coverage that
+existed incidentally, and would have vanished silently the moment anyone
+restructured that file. It has a home of its own now.
+
+**This is not sufficient, and the shortfall is documented rather than implied.**
+`bash -n` does not catch the backtick class: a balanced pair inside what reads as
+a comment is parsed by bash as command substitution, printing a spurious syntax
+error and silently dropping that comment's text from the script actually sent to
+a remote machine. leerie has shipped that defect once (see CLAUDE.md, and
+`tests/test_bedrock_bearer_token.py::test_child_env_heredoc_body_has_no_backtick_characters`,
+which guards one heredoc body against it specifically). It was caught by diffing
+`shellcheck -x leerie` output, with `bash -n` clean throughout. Linting the whole
+launcher with shellcheck is the real fix; it needs a measured baseline of
+pre-existing findings first, which is why it is not attempted here.
+"""
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+LAUNCHER = REPO_ROOT / "leerie"
+TESTS_DIR = Path(__file__).resolve().parent
+
+# What a launcher syntax check looks like, whoever writes it. Matched against
+# test sources so the guard below finds the check wherever it lives rather than
+# hard-coding this file's name — the same derive-don't-enumerate discipline as
+# `tests/launcher_blocks.py`.
+_BASH_N = re.compile(r'"bash",\s*"-n"')
+
+
+def test_launcher_parses() -> None:
+    """`bash -n leerie` — the launcher is a 7k-line script CI never lints."""
+    r = subprocess.run(["bash", "-n", str(LAUNCHER)],
+                       capture_output=True, text=True)
+    assert r.returncode == 0, f"leerie does not parse:\n{r.stderr}"
+
+
+def _files_checking_launcher_syntax() -> list[str]:
+    """Test files that run `bash -n` against the launcher specifically.
+
+    Requires both the invocation shape and a reference to the launcher path in
+    the same file — `container-entry.sh` is also `bash -n`-checked elsewhere,
+    and that must not be mistaken for coverage of the launcher.
+    """
+    out: list[str] = []
+    for path in sorted(TESTS_DIR.rglob("*.py")):
+        text = path.read_text(errors="replace")
+        if _BASH_N.search(text) and 'LAUNCHER' in text or (
+                _BASH_N.search(text) and '"leerie"' in text):
+            out.append(path.name)
+    return out
+
+
+def test_launcher_syntax_check_is_not_silently_dropped() -> None:
+    """Someone must still be running `bash -n` on the launcher.
+
+    Derived by scanning `tests/` rather than asserting on this file's own name,
+    so moving the check again is fine and deleting it is not.
+    """
+    checkers = _files_checking_launcher_syntax()
+    assert checkers, (
+        "no test runs `bash -n` against the launcher any more. CI does not "
+        "check it either — shellcheck.yml lints scripts/*.sh and syntax.yml is "
+        "Python-only — so a syntax error in `leerie` would now ship green.")
+
+
+def test_the_scan_finds_this_file() -> None:
+    """Anti-vacuity: a scan matching nothing would certify coverage forever."""
+    assert Path(__file__).name in _files_checking_launcher_syntax(), (
+        "the launcher-syntax-check scan does not find this file, so its result "
+        "above is meaningless — the scan is broken, not the coverage")

--- a/tests/test_leerie_commit.py
+++ b/tests/test_leerie_commit.py
@@ -16,7 +16,6 @@ a run or write a misleading empty string.
 """
 import json
 import re
-import subprocess
 import sys
 import textwrap
 from pathlib import Path
@@ -199,11 +198,6 @@ class TestLauncher:
         m = re.search(r"_leerie_env_denylist=\"[^\"]*\"", LAUNCHER, re.S)
         assert m, "denylist not found"
         assert "LEERIE_COMMIT" not in m.group(0)
-
-    def test_launcher_still_parses(self):
-        r = subprocess.run(["bash", "-n", str(REPO / "leerie")],
-                           capture_output=True, text=True)
-        assert r.returncode == 0, r.stderr
 
     def test_every_remote_launch_block_forwards_it(self):
         """EVERY orchestrator launch path must forward this, not just the one

--- a/tests/test_leerie_commit.py
+++ b/tests/test_leerie_commit.py
@@ -24,10 +24,9 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "orchestrator"))
 import leerie  # noqa: E402
 
-sys.path.insert(0, str(Path(__file__).resolve().parent))
 # One shared derivation of the launcher's launch blocks — see
 # tests/launcher_blocks.py for why it is not re-implemented per consumer.
-from launcher_blocks import launch_env_blocks  # noqa: E402
+from tests.launcher_blocks import launch_env_blocks  # noqa: E402
 
 REPO = Path(__file__).resolve().parents[1]
 LAUNCHER = (REPO / "leerie").read_text()

--- a/tests/test_leerie_commit.py
+++ b/tests/test_leerie_commit.py
@@ -24,28 +24,16 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "orchestrator"))
 import leerie  # noqa: E402
 
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+# One shared derivation of the launcher's launch blocks — see
+# tests/launcher_blocks.py for why it is not re-implemented per consumer.
+from launcher_blocks import launch_env_blocks  # noqa: E402
+
 REPO = Path(__file__).resolve().parents[1]
 LAUNCHER = (REPO / "leerie").read_text()
 
 
 
-def _child_env_blocks() -> list[tuple[str, str]]:
-    """Every in-heredoc orchestrator launch env block, as (runtime, source).
-
-    Derived from the launcher rather than enumerated: each remote runtime
-    builds its own `child_env = dict(os.environ)` inside its launch heredoc,
-    and a hard-coded list silently stops covering a runtime the moment one is
-    added. The runtime label comes from the `--runtime <rt>` string in the
-    duplicate-run message just above each block.
-    """
-    out: list[tuple[str, str]] = []
-    for m in re.finditer(r"child_env = dict\(os\.environ\)", LAUNCHER):
-        end = LAUNCHER.find("\nPY\n", m.start())
-        block = LAUNCHER[m.start():end if end > 0 else len(LAUNCHER)]
-        preamble = LAUNCHER[max(0, m.start() - 1200):m.start()]
-        rt = "ec2" if "--runtime ec2" in preamble else "fly"
-        out.append((rt, block))
-    return out
 
 
 class TestStateSurface:
@@ -230,7 +218,7 @@ class TestLauncher:
         the launcher instead of listing it: a third runtime fails here
         automatically.
         """
-        blocks = _child_env_blocks()
+        blocks = launch_env_blocks()
         missing = [rt for rt, blk in blocks
                    if 'child_env["LEERIE_COMMIT"]' not in blk]
         assert not missing, (
@@ -245,7 +233,7 @@ class TestLauncher:
         fails, the splitter is broken — and it fails *as* a broken splitter
         rather than masquerading as a missing key.
         """
-        blocks = _child_env_blocks()
+        blocks = launch_env_blocks()
         assert len(blocks) >= 2, (
             f"expected at least the fly and ec2 launch blocks, found "
             f"{len(blocks)} — the block splitter is broken")

--- a/tests/test_no_duplicate_launcher_splitters.py
+++ b/tests/test_no_duplicate_launcher_splitters.py
@@ -20,9 +20,13 @@ from pathlib import Path
 TESTS_DIR = Path(__file__).resolve().parent
 OWNER = "launcher_blocks.py"
 
-# The load-bearing token of the derivation. Any file re-deriving launch blocks
-# has to match the block marker somehow, and this is the shape it takes.
-_MARKER = "child_env = dict"
+# The load-bearing token of the derivation, in its ESCAPED regex form. Prose
+# describing the concept writes the marker plainly (`child_env = dict(...)`);
+# only an actual implementation escapes the paren for `re`. Matching the plain
+# substring instead would report a file that merely *documents* why the
+# derivation is shared as if it re-implemented it — and the natural response to
+# a false-positive guard is to weaken it, which is how guards die.
+_MARKER = r"child_env = dict\("
 
 
 def _files_matching_marker() -> dict[str, int]:

--- a/tests/test_no_duplicate_launcher_splitters.py
+++ b/tests/test_no_duplicate_launcher_splitters.py
@@ -1,0 +1,78 @@
+"""The launch-block derivation lives in exactly one place.
+
+`tests/launcher_blocks.py` derives the launcher's orchestrator launch blocks
+(the `child_env = dict(os.environ)` regions inside each unquoted `<<PY`
+heredoc). Several guards consume it, and every one of them must derive rather
+than enumerate — a hard-coded list of runtimes stops covering reality the moment
+one is added, which is how `--runtime ec2` shipped recording `leerie_commit` as
+null while a test *named* `..._fly_ec2_path_too` passed.
+
+The derivation was then written twice, once per consuming test file, replicating
+the block marker, the heredoc terminator, and the preamble window. Two copies of
+a rule drift exactly the way two copies of a list do: change the launcher's
+heredoc structure and one copy gets fixed while the other keeps passing. This
+guard makes a third copy impossible to add quietly.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+TESTS_DIR = Path(__file__).resolve().parent
+OWNER = "launcher_blocks.py"
+
+# The load-bearing token of the derivation. Any file re-deriving launch blocks
+# has to match the block marker somehow, and this is the shape it takes.
+_MARKER = "child_env = dict"
+
+
+def _files_matching_marker() -> dict[str, int]:
+    """Every file under tests/ containing the block marker, and its count."""
+    hits: dict[str, int] = {}
+    for path in sorted(TESTS_DIR.rglob("*.py")):
+        try:
+            text = path.read_text(errors="replace")
+        except OSError:
+            continue
+        # Skip this file: it necessarily names the marker to check for it.
+        if path.name == Path(__file__).name:
+            continue
+        n = text.count(_MARKER)
+        if n:
+            hits[path.name] = n
+    return hits
+
+
+def test_only_the_shared_module_derives_launch_blocks() -> None:
+    hits = _files_matching_marker()
+    strays = {name: n for name, n in hits.items() if name != OWNER}
+    assert not strays, (
+        f"{sorted(strays)} re-implement the launch-block derivation that "
+        f"tests/{OWNER} owns. Import `launch_env_blocks` from it instead — two "
+        f"copies of this rule drift the same way two copies of a runtime list "
+        f"do, which is the defect class PRs #180-#183 exist to close."
+    )
+
+
+def test_the_owner_actually_contains_it() -> None:
+    """Anti-vacuity: a scan that matches nothing passes the test above.
+
+    If the marker string ever stops appearing in the shared module — renamed,
+    refactored, or the scan simply broken — this fails as a broken scan rather
+    than silently certifying "no duplicates found".
+    """
+    hits = _files_matching_marker()
+    assert OWNER in hits, (
+        f"tests/{OWNER} does not contain {_MARKER!r} — the duplicate scan is "
+        f"matching nothing, so its result above is meaningless")
+
+
+def test_the_shared_module_is_actually_used() -> None:
+    """A single owner nobody imports is dead code, not deduplication."""
+    importers = [
+        p.name for p in sorted(TESTS_DIR.rglob("*.py"))
+        if p.name not in (OWNER, Path(__file__).name)
+        and "launch_env_blocks" in p.read_text(errors="replace")
+    ]
+    assert len(importers) >= 2, (
+        f"expected at least the two known consumers to import "
+        f"`launch_env_blocks`, found {importers}")


### PR DESCRIPTION
**Structural debt from #183, not a live defect.** Both copies are correct today and nothing is failing — this is worth closing only because the entire premise of #180–#183 is that this class doesn't stay harmless.

## The duplication

#183 landed **two copies of the same derivation**:

- `tests/test_leerie_commit.py` — `_child_env_blocks()`
- `tests/test_bedrock_bearer_token.py` — `_launch_env_blocks()`

Byte-for-byte equivalent logic, differing only in local names and whether the file held the launcher as a `str` or a `Path`. Both replicated three magic constants:

| constant | meaning |
|---|---|
| `r"child_env = dict\(os\.environ\)"` | what marks a launch env block |
| `"\nPY\n"` | the heredoc terminator bounding it |
| `1200` | preamble window searched for the `--runtime` label |

## Why this matters

**It's the arc's own failure mode, one level up.** #180–#183 each replaced a hard-coded enumeration with a derivation, after a missed instance shipped:

- `ContextOverflow` in 1 of 9 capture guards
- telemetry recording the alias rather than the effective model
- `leerie_commit` in 1 of 2 state-init branches
- `leerie_commit` in 1 of 2 launch blocks — caught by a reviewer, not the suite

I then wrote the derivation *twice*. **Two copies of a rule drift exactly the way two copies of a list do**: change the launcher's heredoc structure and one copy gets fixed while the other keeps passing.

## The fix

`tests/launcher_blocks.py` owns it — a neutral module rather than a cross-test import (both are idiomatic here; `tests/ec2_stub.py` is the precedent for the shape). The two consumers are unrelated concerns and neither should own it. It reads the launcher itself, so callers holding a `str` or a `Path` are equally served.

`tests/test_no_duplicate_launcher_splitters.py` makes a third copy impossible to add quietly, with two anti-vacuity controls — a scan matching nothing would certify "no duplicates" forever:

- the marker must be found **inside** the owner
- at least two other files must actually import `launch_env_blocks` (a single owner nobody imports is dead code, not deduplication)

## Verification

No behaviour change, so importability proves nothing. What proves equivalence is that **#183's falsifications still fail identically through the shared helper**:

| revert | result |
|---|---|
| remove the ec2 forward | fails naming `['ec2']` |
| stray `${...}` in the ec2 heredoc body | fails naming `ec2` |
| backtick in the ec2 heredoc body | fails naming `ec2` |
| **break the shared splitter** | guards in **both** consuming files fail |

That last one is the load-bearing check: it proves the two files genuinely *share* the derivation rather than merely importing something.

64 tests green across `test_leerie_commit`, `test_bedrock_bearer_token`, `test_no_duplicate_launcher_splitters`, `test_launcher_env_forwarding`, `test_state_fields`. The launcher is untouched by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
