### PR TITLE
test(launcher): detect the bash -n call structurally, not by co-occurrence

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2726,10 +2726,20 @@ have removed the launcher's only validation silently. It is now named and
 owned, with a derived guard (`_files_checking_launcher_syntax`) asserting some
 file still runs `bash -n` against the launcher — scanning `tests/` rather than
 naming itself, so moving the check again is fine and deleting it is not. The
-scan requires the invocation shape *and* a launcher reference in the same file,
-since `container-entry.sh` is `bash -n`-checked elsewhere and must not be
-mistaken for launcher coverage; an anti-vacuity test requires the scan to find
-its own file, so a broken scan fails as a broken scan.
+scan is **structural**: it walks each test file's AST for a `run(...)` call
+whose argv list literal contains both `bash` and `-n` *and* references the
+launcher, matching what this repo reaches for when the shape of a call is the
+assertion (`test_state_fields`'s write sweep, `test_claude_p_call_sites`, the
+`args.resume` branch walk). A text scan for those facts appearing *anywhere in
+the same file* is not equivalent and was the first version: co-occurrence is
+not connection, and `container-entry.sh` is `bash -n`-checked in
+`test_container_entry_run_id.py`. Falsified — with the real check gutted and a
+decoy file that runs `bash -n` on something else while mentioning `LAUNCHER`,
+the text predicate matched both files and passed while coverage was gone; the
+AST predicate fires. An anti-vacuity test requires the scan to find its own
+file, so a broken scan fails as a broken scan. The parse suppresses warnings:
+reading every test file surfaces other files' `SyntaxWarning`s, at least one
+deliberate and documented as not-to-be-fixed (`test_ec2_seed_repo.py`'s `\/`).
 **Known shortfall, deliberately not papered over:** `bash -n` does not catch
 the backtick class — a balanced pair inside what reads as a comment is parsed
 as command substitution, silently dropping that text from the script sent to a

--- a/tests/test_launcher_integrity.py
+++ b/tests/test_launcher_integrity.py
@@ -30,19 +30,18 @@ pre-existing findings first, which is why it is not attempted here.
 """
 from __future__ import annotations
 
-import re
+import ast
 import subprocess
+import warnings
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 LAUNCHER = REPO_ROOT / "leerie"
 TESTS_DIR = Path(__file__).resolve().parent
 
-# What a launcher syntax check looks like, whoever writes it. Matched against
-# test sources so the guard below finds the check wherever it lives rather than
-# hard-coding this file's name — the same derive-don't-enumerate discipline as
-# `tests/launcher_blocks.py`.
-_BASH_N = re.compile(r'"bash",\s*"-n"')
+# Names that, appearing inside the SAME argv list as `bash -n`, identify the
+# launcher as the thing being checked.
+_LAUNCHER_REFS = ("LAUNCHER", "leerie")
 
 
 def test_launcher_parses() -> None:
@@ -52,19 +51,56 @@ def test_launcher_parses() -> None:
     assert r.returncode == 0, f"leerie does not parse:\n{r.stderr}"
 
 
+def _checks_launcher_syntax(argv: ast.expr) -> bool:
+    """True when `argv` is a list literal running `bash -n` on the launcher.
+
+    Both facts must hold *within the same list*. An earlier version tested for
+    `bash -n` and a launcher reference anywhere in the same file, which is not
+    evidence the two are connected: a file running `bash -n` against something
+    else while separately mentioning `LAUNCHER` would have counted as coverage,
+    letting the guard below pass while the real check was gone — precisely the
+    failure it exists to catch. `container-entry.sh` is `bash -n`-checked in
+    `test_container_entry_run_id.py` and must not be mistaken for the launcher.
+    """
+    if not isinstance(argv, ast.List):
+        return False
+    literals = {e.value for e in argv.elts
+                if isinstance(e, ast.Constant) and isinstance(e.value, str)}
+    if not {"bash", "-n"} <= literals:
+        return False
+    return any(ref in ast.unparse(argv) for ref in _LAUNCHER_REFS)
+
+
 def _files_checking_launcher_syntax() -> list[str]:
     """Test files that run `bash -n` against the launcher specifically.
 
-    Requires both the invocation shape and a reference to the launcher path in
-    the same file — `container-entry.sh` is also `bash -n`-checked elsewhere,
-    and that must not be mistaken for coverage of the launcher.
+    Structural rather than textual, matching what this repo reaches for when
+    the *shape* of a call is the thing being asserted (`test_state_fields`'s
+    `st.data` write sweep, `test_claude_p_call_sites`, the `args.resume` branch
+    walk in `test_leerie_commit.py`).
     """
     out: list[str] = []
     for path in sorted(TESTS_DIR.rglob("*.py")):
-        text = path.read_text(errors="replace")
-        if _BASH_N.search(text) and 'LAUNCHER' in text or (
-                _BASH_N.search(text) and '"leerie"' in text):
-            out.append(path.name)
+        try:
+            # Warnings suppressed: parsing every test file surfaces other
+            # files' SyntaxWarnings, at least one of which is deliberate and
+            # documented as not-to-be-fixed (test_ec2_seed_repo.py's `\/`,
+            # where the surrounding bash relies on Python collapsing the
+            # escape). CI's syntax.yml already parses them all; this guard
+            # should not re-report someone else's intentional choice.
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                tree = ast.parse(path.read_text(errors="replace"),
+                                 filename=str(path))
+        except SyntaxError:  # not ours to police; syntax.yml covers it
+            continue
+        for node in ast.walk(tree):
+            if (isinstance(node, ast.Call) and node.args
+                    and getattr(node.func, "attr", getattr(node.func, "id", None))
+                    == "run"
+                    and _checks_launcher_syntax(node.args[0])):
+                out.append(path.name)
+                break
     return out
 
 


### PR DESCRIPTION
**No live defect — a latent one, fixed for consistency.** The sibling guard got this exact treatment one commit earlier; leaving one loose and one tight is the real problem.

## The weakness

`_files_checking_launcher_syntax` decided a file covered the launcher if `bash -n` appeared *anywhere* in it **and** `LAUNCHER` appeared *anywhere* in it:

```python
if _BASH_N.search(text) and 'LAUNCHER' in text or (
        _BASH_N.search(text) and '"leerie"' in text):
```

Two independent facts sharing a file is not evidence they're connected. A file running `bash -n` against something else while separately mentioning `LAUNCHER` counted as coverage — so the not-silently-dropped guard could pass while the real check was gone, which is precisely the failure it exists to catch. (`container-entry.sh` *is* `bash -n`-checked in `test_container_entry_run_id.py`.)

The expression also read like a precedence bug. It's correct under Python's rules, but a reader had to verify that before trusting the guard.

## Why fix a latent risk

`test_no_duplicate_launcher_splitters.py` had the identical weakness one commit earlier — matching the plain substring `child_env = dict`, which would have flagged a file that merely *documented* the derivation — and was tightened to the escaped-regex form so only a real implementation matches. The launcher scan didn't get the same treatment.

## The fix

An AST walk: a `run(...)` call whose first argument is a list literal containing both `"bash"` and `"-n"` **and** referencing the launcher. Both facts must hold *within the same list*. This is what the repo reaches for when the shape of a call is the assertion — `test_state_fields`'s `st.data` write sweep, `test_claude_p_call_sites`, the `args.resume` branch walk.

## Falsification — the third one is the point

| revert | old text predicate | new AST predicate |
|---|---|---|
| stray `fi` appended to `leerie` | fails ✅ | fails ✅ |
| check body removed | fails ✅ | fails ✅ |
| **check gutted + decoy file present** | matched `['test_launcher_integrity.py', 'test_zz_decoy.py']` → **PASSES while coverage is gone** | **fires** ✅ |

The decoy runs `bash -n` on `host-finalize.sh` and separately assigns `LAUNCHER` — exactly the shape the old predicate couldn't distinguish.

## One side effect handled

Parsing every test file surfaced other files' `SyntaxWarning`s, including one that is **deliberate and documented as not-to-be-fixed** — `test_ec2_seed_repo.py`'s `\/`, where the surrounding bash relies on Python collapsing the escape. The scan suppresses warnings rather than re-reporting someone else's intentional choice; CI's `syntax.yml` already parses them all.

63 tests green across `test_launcher_integrity`, `test_leerie_commit`, `test_no_duplicate_launcher_splitters`, `test_bedrock_bearer_token`, `test_launcher_env_forwarding`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
