### PR TITLE
fix: feed the worker's prompt before anything can block the event loop

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2106,6 +2106,36 @@ single pipe buffer and the single-argv ceiling this fix routes around.
 were updated in the same change to assert against `stdin_data` instead of
 an argv element, since both stub `_invoke` to inspect what `claude_p`
 constructs.
+Routing the prompt over stdin then created a **deadline** the argv form
+never had, and `tests/test_stdin_feeder_ordering.py` guards it. `claude -p`
+waits a hard-coded 3 s for its first stdin byte (`KJr(process.stdin, 3000)`
+in the CLI bundle — no env var), then drops its own `data` listener, so a
+late write is DISCARDED and the worker exits 1 on `Input must be provided`.
+leerie made two SYNCHRONOUS broker round-trips between the spawn and the
+first write, each bounded by `_cgroup_request`'s 5 s timeout — an accepted
+stall larger than the deadline in front of it, i.e. the failure was
+permitted by construction, while the comment at that site called the stall
+"negligible". Measured across every run on one host: **218 workers lost,
+12.4% of all invocations in the affected runs**, retried up to 4x each with
+every attempt charged to `max_total_workers`, spanning v0.9.95–v0.16.0.
+`_cgroup_enroll`'s docstring had already recorded the pair in a different
+run as "two apparently-unconnected events" — they are one event.
+**Both halves of the fix are load-bearing**, which is what the file mostly
+exists to pin: a reproduction harness scored all four combinations and only
+`create_task` at the spawn AND `to_thread` on both broker calls delivers the
+prompt — hoisting alone fails because the blocked loop never schedules the
+task, and `to_thread` alone fails because the write lands after the child is
+already gone. A future edit keeping one and dropping the other silently
+reopens a 12% budget leak, so `test_only_both_halves_deliver_the_prompt_in_time`
+drives all four combinations behaviourally rather than trusting the source
+order. Two harness traps here, both hit on the first draft and both the
+comment-matching class this file documents elsewhere: the region is dense
+with comments that necessarily name `_feed_stdin`, `await` and
+`_cgroup_enroll` while explaining the ordering, so `_invoke_src` strips
+comments via `tokenize` (not a `#` heuristic — a `#` inside a string
+literal would corrupt the result); and `async def _feed_stdin():` contains
+`_feed_stdin()` as a substring, so a bare `.count()` reports two calls for
+correct code and the call-site scan has to exclude the definition.
 The appended system prompt (docs/IMPLEMENTATION.md §3 "Appended system
 prompt transport — file, with a probe + inline fallback" — the second
 large argv element that compounds with the user prompt toward the same

--- a/docs/IMPLEMENTATION.md
+++ b/docs/IMPLEMENTATION.md
@@ -3826,6 +3826,25 @@ through stdin too, `_invoke`'s PIPE-vs-DEVNULL branch, and a real
 subprocess/real-pipe round trip for a 150,063-byte payload proving no
 deadlock between the concurrent feeder and the stdout/stderr readers.
 
+**The feeder must be queued before anything can block the event loop, and
+nothing on that path may block it.** `claude -p` waits a hard-coded **3 s**
+for its first stdin byte (`KJr(process.stdin, 3000)` in the CLI bundle; no
+env var), then removes its own `data` listener and proceeds without it — a
+late write is **discarded**, not buffered, and the worker exits 1 with
+`Input must be provided either through stdin or as a prompt argument`.
+leerie previously made two *synchronous* broker round-trips
+(`_cgroup_create`, `_cgroup_enroll`) between the spawn and the first write,
+each bounded by `_cgroup_request`'s **5 s** timeout — an accepted stall
+larger than the deadline in front of it, so the failure was permitted by
+construction. Measured before the fix: **218 workers lost this way, 12.4% of
+all invocations in the affected runs**, retried up to 4× each with every
+attempt charged to `max_total_workers`, on versions 0.9.95 through 0.16.0.
+`asyncio.create_task(_feed_stdin())` now runs immediately after the spawn
+and both broker calls go through `asyncio.to_thread` (matching
+`_cgroup_destroy`, which already did). **Both halves are required** — with
+either alone the prompt still misses the deadline, verified against a
+reproduction harness and pinned in `tests/test_stdin_feeder_ordering.py`.
+
 #### Appended system prompt transport — file, with a probe + inline fallback
 
 The appended system prompt (`system_prompt`, e.g. `reconciler.md` at

--- a/orchestrator/leerie.py
+++ b/orchestrator/leerie.py
@@ -14045,6 +14045,42 @@ async def _invoke(cmd: list[str], cwd: str, timeout: int,
         cap_mb = max(worker_memory_max_bytes // (1024 * 1024) - reserve_mb, 256)
         worker_env["NODE_OPTIONS"] = f"--max-old-space-size={cap_mb}"
 
+    # Defined BEFORE the spawn so it can be started as a task the instant
+    # `proc` exists — see the ordering comment at the `create_task` below.
+    # It closes over `proc` and `stdin_data` only, both of which are bound
+    # by the time the task first runs.
+    async def _feed_stdin():
+        # Writes `stdin_data` to the child's stdin, then closes it so the
+        # CLI sees EOF and starts processing rather than blocking for
+        # more input. Runs concurrently with `_read_stream`/`_drain_stderr`
+        # rather than write-then-await — the incident's live measurement
+        # showed a 150KB write completing at t=0.26s with the child's
+        # first stdout event at t=0.69s (write-then-read is safe on that
+        # CLI version), but a concurrent feeder costs nothing and removes
+        # the dependency on that ordering holding on future CLI versions.
+        # No-op (proc.stdin is None) when `stdin_data` is None — the
+        # DEVNULL branch below never gives the child a writable stdin.
+        if stdin_data is None or proc.stdin is None:
+            return
+        try:
+            proc.stdin.write(stdin_data.encode())
+            await proc.stdin.drain()
+        except (BrokenPipeError, ConnectionResetError):
+            # The child closed its read end before consuming the whole
+            # payload (e.g. it exited early, or errored before reading
+            # stdin at all). That is a fact about the worker's exit, not
+            # this feeder's — `_read_stream`/`proc.wait()` already
+            # surface the worker's actual outcome, so swallow rather
+            # than let this coroutine's exception blow up the gather and
+            # mask that outcome.
+            #
+            # NOTE this swallow is why the stdin-starvation failure below
+            # left no leerie-side trace: the worker's own stderr said what
+            # happened, but leerie's causal role in it did not.
+            pass
+        finally:
+            proc.stdin.close()
+
     proc = await asyncio.create_subprocess_exec(
         *cmd,
         cwd=cwd,
@@ -14080,17 +14116,35 @@ async def _invoke(cmd: list[str], cwd: str, timeout: int,
     # operational chatter and stays gated.
     if verbosity != "quiet":
         log(f"  [{sid}] spawned (pid={proc.pid})")
+    # Start feeding the prompt IMMEDIATELY — before the broker round-trips
+    # below. The CLI waits a hard-coded 3 s for its first stdin byte
+    # (`KJr(process.stdin, 3000)` in the bundle), then removes its own
+    # `data` listener and proceeds without it, so a late write is DISCARDED
+    # and the worker dies with "Input must be provided either through stdin
+    # or as a prompt argument". Measured across every run on one host: 218
+    # workers lost this way, 12.4% of all invocations in the affected runs,
+    # retried up to 4x each and every attempt charged to `max_total_workers`.
+    #
+    # Both halves of this fix are load-bearing and each was verified alone
+    # against a reproduction harness. Creating the task here but leaving the
+    # broker calls synchronous still fails (the blocked loop never schedules
+    # it); making the broker calls async but creating the task afterwards
+    # also still fails (the write lands after the child is already gone).
+    feeder = asyncio.create_task(_feed_stdin())
     # cgroup containment: ask the cgroup broker to create the worker cgroup
     # and enroll the worker (and every descendant it forks — the kernel
-    # propagates cgroup membership down the process tree). These are
-    # synchronous socket round-trips to the broker made directly in this
-    # coroutine (not via asyncio.to_thread): they briefly block the event
-    # loop, but the broker's replies are tiny/fast and bounded by
-    # `_cgroup_request`'s 5 s timeout, so the stall is negligible and no
-    # deadlock is possible (the broker never calls back into leerie).
-    # `destroy` is the one exception and IS dispatched via to_thread in the
+    # propagates cgroup membership down the process tree). Dispatched via
+    # `asyncio.to_thread` because they are synchronous socket round-trips:
+    # run inline they block the WHOLE event loop, including every sibling
+    # worker's feeder, for up to `_cgroup_request`'s 5 s timeout apiece.
+    # That bound is larger than the CLI's 3 s stdin patience, so the old
+    # inline form permitted the starvation above BY CONSTRUCTION — the
+    # comment that used to sit here called the stall "negligible", which is
+    # the assumption the incident falsified. No deadlock is possible either
+    # way (the broker never calls back into leerie).
+    # `destroy` is the same shape and IS dispatched via to_thread in the
     # finally below — it blocks for the broker's whole drain (seconds, not
-    # milliseconds), which is a different order of stall entirely.
+    # milliseconds), which is a larger stall of the same kind.
     # Containment enforcement itself was already gated at run start
     # (_enforce_and_record_cgroup_containment); here a per-worker failure
     # returns None / False and the worker runs without its own sub-cgroup
@@ -14111,11 +14165,12 @@ async def _invoke(cmd: list[str], cwd: str, timeout: int,
     cgroup_enroll_failure: str | None = None
     if (worker_memory_max_bytes is not None
             and worker_pids_max is not None):
-        cgroup_sid = _cgroup_create(_cgroup_worker_sid(run_id, sid),
-                                    worker_memory_max_bytes,
-                                    worker_pids_max)
+        cgroup_sid = await asyncio.to_thread(
+            _cgroup_create, _cgroup_worker_sid(run_id, sid),
+            worker_memory_max_bytes, worker_pids_max)
         if cgroup_sid is not None:
-            cgroup_enroll_failure = _cgroup_enroll(cgroup_sid, proc.pid)
+            cgroup_enroll_failure = await asyncio.to_thread(
+                _cgroup_enroll, cgroup_sid, proc.pid)
     # Track every descendant PID that ever appears under this worker. Claude
     # Code's Bash tool uses `run_in_background: true` to fire-and-forget
     # long-running commands (test runners, builds, dev servers); those
@@ -14400,34 +14455,6 @@ async def _invoke(cmd: list[str], cwd: str, timeout: int,
                     "claude -p stderr emitted a line exceeding the "
                     f"10 MiB buffer limit: {e}") from e
 
-    async def _feed_stdin():
-        # Writes `stdin_data` to the child's stdin, then closes it so the
-        # CLI sees EOF and starts processing rather than blocking for
-        # more input. Runs concurrently with `_read_stream`/`_drain_stderr`
-        # rather than write-then-await — the incident's live measurement
-        # showed a 150KB write completing at t=0.26s with the child's
-        # first stdout event at t=0.69s (write-then-read is safe on that
-        # CLI version), but a concurrent feeder costs nothing and removes
-        # the dependency on that ordering holding on future CLI versions.
-        # No-op (proc.stdin is None) when `stdin_data` is None — the
-        # DEVNULL branch above never gives the child a writable stdin.
-        if stdin_data is None or proc.stdin is None:
-            return
-        try:
-            proc.stdin.write(stdin_data.encode())
-            await proc.stdin.drain()
-        except (BrokenPipeError, ConnectionResetError):
-            # The child closed its read end before consuming the whole
-            # payload (e.g. it exited early, or errored before reading
-            # stdin at all). That is a fact about the worker's exit, not
-            # this feeder's — `_read_stream`/`proc.wait()` already
-            # surface the worker's actual outcome, so swallow rather
-            # than let this coroutine's exception blow up the gather and
-            # mask that outcome.
-            pass
-        finally:
-            proc.stdin.close()
-
     async def _idle_watchdog():
         # Observation-only stall detector. Wakes every `warn_sec` seconds
         # and warns if the worker has emitted no stdout bytes for that
@@ -14480,8 +14507,12 @@ async def _invoke(cmd: list[str], cwd: str, timeout: int,
         _ASYNCIO_MANAGED_PIDS.add(proc.pid)
         try:
             await asyncio.wait_for(
+                # `feeder` is the task started right after the spawn, NOT a
+                # fresh `_feed_stdin()` call — awaiting it here is what keeps
+                # its exceptions surfaced and its lifetime bounded by the
+                # same timeout as the rest.
                 asyncio.gather(_read_stream(), _drain_stderr(),
-                               _feed_stdin(), proc.wait()),
+                               feeder, proc.wait()),
                 timeout=timeout)
         except asyncio.TimeoutError:
             # Cancel the watchdog BEFORE the termination awaits so it

--- a/orchestrator/leerie.py
+++ b/orchestrator/leerie.py
@@ -14130,6 +14130,16 @@ async def _invoke(cmd: list[str], cwd: str, timeout: int,
     # broker calls synchronous still fails (the blocked loop never schedules
     # it); making the broker calls async but creating the task afterwards
     # also still fails (the write lands after the child is already gone).
+    #
+    # This task is created OUTSIDE the try/finally below, so an exception
+    # before the gather would leave it pending with stdin unclosed. Accepted
+    # rather than guarded: everything between here and that try is either a
+    # plain assignment or a call whose helper swallows OSError itself
+    # (`_cgroup_create` / `_cgroup_enroll`), and `_DescendantTracker.start`
+    # is a bare `create_task`. More to the point, `proc` is spawned outside
+    # that try too — so any exception in this window already leaks a live
+    # worker process, which is strictly worse than a pending feeder and is
+    # the pre-existing shape this does not change.
     feeder = asyncio.create_task(_feed_stdin())
     # cgroup containment: ask the cgroup broker to create the worker cgroup
     # and enroll the worker (and every descendant it forks — the kernel

--- a/tests/test_stdin_feeder_ordering.py
+++ b/tests/test_stdin_feeder_ordering.py
@@ -167,47 +167,71 @@ def test_only_both_halves_deliver_the_prompt_in_time(hoisted, threaded,
                                                      expect_delivered):
     """Behavioural proof that neither half alone suffices.
 
-    Models the CLI faithfully in the one respect that matters: a consumer
-    that gives up on stdin after a deadline and never looks again. Uses a
-    plain `asyncio.Event` deadline rather than a real subprocess so the test
-    is fast and platform-independent — the failure being reproduced is one
-    of *scheduling*, not of process semantics.
+    Uses a REAL child process, which is the whole point. An earlier draft
+    modelled the deadline with an in-process `asyncio.Event` + `wait_for`
+    and was wrong in the one way that mattered: a blocked event loop also
+    freezes the model's own timer, so whether the deadline or the write won
+    came down to ready-queue ordering — which differs across CPython
+    versions. It passed on 3.12+ and reported `GOT` for the two blocking
+    variants on 3.10/3.11. The real CLI is a separate process whose 3 s
+    clock runs regardless of what leerie's loop is doing; only a real
+    subprocess reproduces that, and it does so identically on every version.
+
+    Scaled down 10x from the real 3 s deadline to keep the test quick.
     """
     import asyncio
+    import sys
     import time
 
-    DEADLINE = 0.30          # stands in for the CLI's 3 s
-    BLOCK = 0.45             # stands in for a slow broker round-trip
+    DEADLINE = 0.30          # stands in for the CLI's hard-coded 3 s
+    BLOCK = 0.90             # stands in for a slow broker round-trip
+
+    # Mirrors the CLI: wait for the first stdin byte until a deadline, then
+    # stop listening. `select` gives the child its own OS-level clock.
+    #
+    # It announces READY before arming that clock, and the parent waits for
+    # it, so interpreter startup cannot eat into the margin. Without that
+    # handshake a slow runner shifts the child's deadline later than the
+    # parent's block and the two TIMEOUT variants flip to GOT — the same
+    # class of environment-dependence that made the previous draft of this
+    # test fail on 3.10/3.11 while passing locally.
+    CHILD = (
+        "import sys, select\n"
+        "print('READY', flush=True)\n"
+        f"r, _, _ = select.select([sys.stdin], [], [], {DEADLINE})\n"
+        "print('GOT' if r else 'TIMEOUT', flush=True)\n"
+    )
 
     async def scenario():
-        delivered = asyncio.Event()
-        started = time.monotonic()
-
-        async def child():
-            try:
-                await asyncio.wait_for(delivered.wait(), DEADLINE)
-                return "GOT"
-            except asyncio.TimeoutError:
-                return "TIMEOUT"          # gives up, stops listening
+        proc = await asyncio.create_subprocess_exec(
+            sys.executable, "-c", CHILD,
+            stdin=asyncio.subprocess.PIPE, stdout=asyncio.subprocess.PIPE)
+        ready = await asyncio.wait_for(proc.stdout.readline(), 30)
+        assert ready.strip() == b"READY", ready
 
         async def feed():
-            delivered.set()
-
-        child_task = asyncio.create_task(child())
-        await asyncio.sleep(0)            # let the child start waiting
+            try:
+                proc.stdin.write(b"x" * 1024)
+                await proc.stdin.drain()
+            except (BrokenPipeError, ConnectionResetError):
+                pass                      # child already gone — the D case
+            finally:
+                try:
+                    proc.stdin.close()
+                except Exception:
+                    pass
 
         feeder = asyncio.create_task(feed()) if hoisted else None
         if threaded:
             await asyncio.to_thread(time.sleep, BLOCK)
         else:
-            time.sleep(BLOCK)             # blocks the whole loop
+            time.sleep(BLOCK)             # blocks the whole event loop
         if feeder is None:
             feeder = asyncio.create_task(feed())
 
-        result = await child_task
-        await feeder
-        assert time.monotonic() - started >= BLOCK
-        return result
+        out, _ = await asyncio.gather(proc.stdout.read(), feeder)
+        await proc.wait()
+        return out.decode().strip()
 
     got = asyncio.run(scenario())
     assert got == ("GOT" if expect_delivered else "TIMEOUT"), (

--- a/tests/test_stdin_feeder_ordering.py
+++ b/tests/test_stdin_feeder_ordering.py
@@ -1,0 +1,214 @@
+"""The worker's prompt must reach its stdin before anything can block the
+event loop (DESIGN §6 *User prompt transport*).
+
+`claude -p` waits a hard-coded **3 s** for its first stdin byte
+(`KJr(process.stdin, 3000)` in the CLI bundle), then removes its own `data`
+listener and proceeds without it — so a late write is DISCARDED, not buffered,
+and the worker dies with `Input must be provided either through stdin or as a
+prompt argument`. leerie used to make two synchronous broker round-trips
+between the spawn and the first write, each bounded by `_cgroup_request`'s
+**5 s** timeout. An accepted 5 s stall in front of a 3 s deadline permits the
+failure by construction, and the comment at that site called it "negligible".
+
+Measured across every run on one host before the fix: **218 workers lost this
+way — 12.4% of all invocations in the affected runs** — retried up to 4x each,
+every attempt charged to `max_total_workers`. It spans v0.9.95 through v0.16.0.
+`_cgroup_enroll`'s own docstring records the same pair in a different run
+(`870cf82c…`) as "two apparently-unconnected events"; they are one event.
+
+**Both halves of the fix are load-bearing**, which is the point of this file.
+A reproduction harness scored all four combinations against a child that
+mimics the CLI's 3 s wait:
+
+| variant | child saw |
+|---|---|
+| blocking call before the feeder (the old code) | TIMEOUT |
+| feeder task created first, call still synchronous | **TIMEOUT** — the blocked loop never schedules it |
+| call in a thread, feeder created afterwards | **TIMEOUT** — write lands after the child is gone |
+| feeder task first AND call in a thread | GOT |
+
+So neither half alone is a fix, and a future edit that keeps one while
+dropping the other silently reopens a 12% budget leak.
+"""
+from __future__ import annotations
+
+import ast
+import inspect
+
+import pytest
+
+
+def _invoke_src(leerie) -> str:
+    """`_invoke`'s source with COMMENTS REMOVED.
+
+    Every scan in this file is about where statements sit relative to one
+    another, and the region under test is heavily commented — with comments
+    that necessarily name `_feed_stdin`, `await`, and `_cgroup_enroll` while
+    explaining the ordering. A raw substring scan matches that prose and
+    reports the ordering broken on correct code (it did, on the first draft
+    of this file). Stripped via `tokenize` rather than a `#` heuristic so a
+    `#` inside a string literal cannot corrupt the result.
+    """
+    import io
+    import tokenize
+    src = inspect.getsource(leerie._invoke)
+    out, last_line, last_col = [], 1, 0
+    for tok in tokenize.generate_tokens(io.StringIO(src).readline):
+        if tok.start[0] > last_line:
+            out.append("\n" * (tok.start[0] - last_line))
+            last_col = 0
+        if tok.type == tokenize.COMMENT:
+            last_line, last_col = tok.end
+            continue
+        if tok.start[1] > last_col:
+            out.append(" " * (tok.start[1] - last_col))
+        out.append(tok.string)
+        last_line, last_col = tok.end
+    return "".join(out)
+
+
+# ---- ordering: the write is queued before the broker round-trips ----------
+
+def test_feeder_task_is_created_before_the_cgroup_calls(leerie):
+    """Source-ordered, because the real path needs a spawned child, a live
+    broker socket and a 3-second race to observe behaviourally."""
+    src = _invoke_src(leerie)
+    i_feeder = src.index("asyncio.create_task(_feed_stdin())")
+    i_create = src.index("_cgroup_create")
+    i_enroll = src.index("_cgroup_enroll")
+    assert i_feeder < i_create, "the feeder must be queued before `create`"
+    assert i_feeder < i_enroll, "the feeder must be queued before `enroll`"
+
+
+def test_feeder_is_created_immediately_after_the_spawn(leerie):
+    """Nothing awaitable may sit between the spawn and the feeder.
+
+    An `await` there yields the loop to whatever else is runnable — which in
+    a wave of `max_parallel` workers is a sibling's broker round-trip — and
+    the 3 s clock is already running on a child that exists.
+    """
+    src = _invoke_src(leerie)
+    spawn = src.index("proc = await asyncio.create_subprocess_exec(")
+    feeder = src.index("asyncio.create_task(_feed_stdin())")
+    between = src[spawn:feeder]
+    # The spawn's own `await` is the one on the first line of the slice.
+    assert between.count("await ") == 1, (
+        "an extra await sits between the spawn and the feeder:\n"
+        + "\n".join(ln for ln in between.splitlines() if "await " in ln))
+
+
+def test_cgroup_calls_do_not_block_the_event_loop(leerie):
+    """`_cgroup_create` / `_cgroup_enroll` are synchronous socket
+    round-trips; run inline they stall the WHOLE loop — every sibling
+    worker's feeder included — for up to 5 s apiece."""
+    src = _invoke_src(leerie)
+    for fn in ("_cgroup_create", "_cgroup_enroll"):
+        # Every CALL of it, not the first mention: `_cgroup_enroll` is also
+        # named in a comment (stripped above) and assigned to a variable
+        # (`cgroup_enroll_failure`), so anchor on the call syntax.
+        calls = [i for i in range(len(src))
+                 if src.startswith(fn + ",", i) or src.startswith(fn + "(", i)]
+        assert calls, f"no call site found for {fn}"
+        for i in calls:
+            window = src[max(0, i - 80):i]
+            assert "to_thread" in window, (
+                f"{fn} is called inline and will block the event loop: "
+                f"{src[max(0, i - 80):i + len(fn) + 40]!r}")
+
+
+def test_gather_awaits_the_existing_task_not_a_second_call(leerie):
+    """Calling `_feed_stdin()` again in the gather would spawn a SECOND
+    writer against a stdin the first one already closed, and would leave the
+    real feeder unawaited."""
+    src = _invoke_src(leerie)
+    assert "feeder, proc.wait()" in src
+    assert "_feed_stdin(), proc.wait()" not in src
+    # Count CALLS, not the definition: `async def _feed_stdin():` contains
+    # `_feed_stdin()` as a substring, so a bare count reports 2 for correct
+    # code (it did, on the first draft).
+    calls = [i for i in range(len(src))
+             if src.startswith("_feed_stdin()", i)
+             and not src[:i].rstrip().endswith("def")]
+    assert len(calls) == 1, \
+        f"_feed_stdin() should be invoked exactly once, found {len(calls)}"
+    assert src[:calls[0]].rstrip().endswith("asyncio.create_task("), \
+        "the single invocation must be the create_task at the spawn"
+
+
+def test_feed_stdin_is_defined_before_the_spawn(leerie):
+    """It has to be, to be startable at the spawn — and it may close over
+    nothing that is bound later. `proc` and `stdin_data` are the only two,
+    and both are bound before the task first runs."""
+    src = _invoke_src(leerie)
+    assert src.index("async def _feed_stdin") < \
+        src.index("proc = await asyncio.create_subprocess_exec(")
+
+    # `_invoke` is module-level, so its source parses as-is — no dedent.
+    tree = ast.parse(inspect.getsource(leerie._invoke))
+    fn = next((n for n in ast.walk(tree)
+               if isinstance(n, ast.AsyncFunctionDef)
+               and n.name == "_feed_stdin"), None)
+    assert fn is not None
+    free = {n.id for n in ast.walk(fn) if isinstance(n, ast.Name)}
+    assert free <= {"proc", "stdin_data", "BrokenPipeError",
+                    "ConnectionResetError"}, \
+        f"_feed_stdin closes over something new: {free}"
+
+
+# ---- the property the ordering exists to protect --------------------------
+
+@pytest.mark.parametrize("hoisted,threaded,expect_delivered", [
+    (False, False, False),   # the old code
+    (True,  False, False),   # hoist alone — blocked loop never runs the task
+    (False, True,  False),   # to_thread alone — write lands too late
+    (True,  True,  True),    # both
+])
+def test_only_both_halves_deliver_the_prompt_in_time(hoisted, threaded,
+                                                     expect_delivered):
+    """Behavioural proof that neither half alone suffices.
+
+    Models the CLI faithfully in the one respect that matters: a consumer
+    that gives up on stdin after a deadline and never looks again. Uses a
+    plain `asyncio.Event` deadline rather than a real subprocess so the test
+    is fast and platform-independent — the failure being reproduced is one
+    of *scheduling*, not of process semantics.
+    """
+    import asyncio
+    import time
+
+    DEADLINE = 0.30          # stands in for the CLI's 3 s
+    BLOCK = 0.45             # stands in for a slow broker round-trip
+
+    async def scenario():
+        delivered = asyncio.Event()
+        started = time.monotonic()
+
+        async def child():
+            try:
+                await asyncio.wait_for(delivered.wait(), DEADLINE)
+                return "GOT"
+            except asyncio.TimeoutError:
+                return "TIMEOUT"          # gives up, stops listening
+
+        async def feed():
+            delivered.set()
+
+        child_task = asyncio.create_task(child())
+        await asyncio.sleep(0)            # let the child start waiting
+
+        feeder = asyncio.create_task(feed()) if hoisted else None
+        if threaded:
+            await asyncio.to_thread(time.sleep, BLOCK)
+        else:
+            time.sleep(BLOCK)             # blocks the whole loop
+        if feeder is None:
+            feeder = asyncio.create_task(feed())
+
+        result = await child_task
+        await feeder
+        assert time.monotonic() - started >= BLOCK
+        return result
+
+    got = asyncio.run(scenario())
+    assert got == ("GOT" if expect_delivered else "TIMEOUT"), (
+        f"hoisted={hoisted} threaded={threaded} -> {got}")


### PR DESCRIPTION
`claude -p` waits a **hard-coded 3 s** for its first stdin byte
(`KJr(process.stdin, 3000)` in the CLI bundle — no env var), then removes its
own `data` listener and proceeds without it. **A late write is discarded, not
buffered**, and the worker exits 1 with `Input must be provided either through
stdin or as a prompt argument`.

leerie made two **synchronous** broker round-trips between the spawn and the
first write — `_cgroup_create` and `_cgroup_enroll`, each bounded by
`_cgroup_request`'s **5 s** timeout. An accepted 5 s stall in front of a 3 s
deadline permits the failure *by construction*; the comment at that site called
it "negligible". And because they are synchronous, they block the **whole event
loop** — one worker's broker call starves every sibling's feeder too.

## Impact — measured, not estimated

| run | version | failures | distinct sids | max retries | workers | wasted |
|---|---|---|---|---|---|---|
| d1207301 | 0.9.100 | 90 | 48 | **4** | 557 | **16%** |
| a3c6cc1a | 0.12.2 | 57 | 37 | 2 | 369 | 15% |
| 7263cac2 | 0.9.95 | 34 | 21 | 2 | 293 | 12% |
| 9751c048 | **0.16.0** | 22 | 22 | 1 | 209 | 11% |

**218 workers lost / 1,759 invocations = 12.4%**, v0.9.95 → v0.16.0, still
firing on the current release. Failures are **retried** — observed directly,
same sid respawning up to 4×:

```
21:02:33 spawned (pid=1079763)  →  21:02:36 Warning + Error
21:03:04 spawned (pid=1080114)  →  21:03:06 Warning + Error
```

Every attempt is charged to `max_total_workers`, which makes this a **verified
contributor to the budget exhaustion behind N3/N4**, not a cosmetic transport
bug. `_cgroup_enroll`'s own docstring had already recorded a cgroup-enroll
failure and *"the CLI's own 3s-stdin-timeout crash"* in the same worker's
stream as "two apparently-unconnected events". They are one event.

## Both halves are required

Verified against a reproduction harness driving a child that mimics the CLI's
deadline:

| variant | child saw |
|---|---|
| blocking call before the feeder (old code) | `TIMEOUT` |
| feeder hoisted to a task, call still synchronous | **`TIMEOUT`** — blocked loop never schedules it |
| call in a thread, feeder created afterwards | **`TIMEOUT`** — write lands after the child is gone |
| **both** | **`GOT`** |

`to_thread` here matches `_cgroup_destroy`, already dispatched that way for the
same reason.

## Tests

`tests/test_stdin_feeder_ordering.py` pins the ordering structurally **and**
drives all four combinations behaviourally, so an edit keeping one half and
dropping the other cannot silently reopen a 12% budget leak.

Falsified live: reverting the hoist fails 3 tests; reverting `to_thread` fails 1.

Two harness traps, both hit on the first draft and both the comment-matching
class CLAUDE.md documents elsewhere: the region is dense with comments that
necessarily name `_feed_stdin`, `await` and `_cgroup_enroll` while explaining
the ordering, so the source is stripped of comments via `tokenize` (not a `#`
heuristic — a `#` inside a string literal would corrupt it); and
`async def _feed_stdin():` contains `_feed_stdin()` as a substring, so a bare
`.count()` reports two calls on correct code.

162 tests pass across the affected suites.

**Independent of #197** — branched from `main`, different code paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
