### PR TITLE
fix: stage the worker prompt to a file; accept a blocked subtask by registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,7 +387,7 @@ below for full details and modifier flags.
 | `re-seed <run-id> [--force]` | Mid-run host→machine re-rsync of dirty delta. `--force` bypasses the safety check that refuses to clobber machine-side uncommitted edits. |
 | `status <run-id\|chain-id\|group-id>` | Render run/chain/group state from `run.json`. |
 | `attach <run-id\|chain-id>` | Poll `run.json` files every 5s. |
-| `accept-blocked <run-id> <subtask-id>` | Accept a blocked subtask so `resume` skips it. |
+| `accept-blocked <run-id> <subtask-id> [--force]` | Accept a blocked subtask so `resume` skips it. `--force` also settles one abandoned mid-flight (e.g. after a crash), where neither status field records it as blocked. |
 | `accept-integration <run-id> <subtask-id>` | Accept a recorded `integration_judge` finding for a subtask so `resume` stops re-invoking the judge for it. |
 | `chain [--chain-id <uuid>] --wave <files> [--wave <files>] ...` | Submit or resume a multi-run chain. `status`/`kill`/`resume`/`finalize`/`attach <chain-id>` and `list --chains` also operate on chains (see `docs/IMPLEMENTATION.md` "Chain verbs"). |
 | `group --repo <path> "<prompt>" [--repo ...] [--brief <file>] [--group-id <uuid>]` | Fan-out launcher for N single-repo runs sharing a `group_id`. `status`/`kill`/`resume`/`finalize <group-id>` and `list --groups` also operate on groups (see `docs/IMPLEMENTATION.md` "Run-group verbs"). |

--- a/docs/IMPLEMENTATION.md
+++ b/docs/IMPLEMENTATION.md
@@ -3816,10 +3816,15 @@ negative case, which is truthy and would otherwise reach
 `build()` emits `["claude", "-p", ...]` with **no positional argument
 after `-p`** — the user prompt (task + subtask_views + any retry note)
 is fed to the child's stdin instead, via `_invoke()`'s `stdin_data`
-param and a concurrent `_feed_stdin` task that writes the payload and
-closes stdin so the CLI sees EOF. `_invoke()` passes `stdin=PIPE` when
-`stdin_data` is given and `stdin=DEVNULL` otherwise (callers with no
-prompt to feed, e.g. the preflight smoke test, are unaffected).
+param. `_invoke()` writes that payload to a temp file **before** the
+spawn and hands the child that file as its stdin; the file reaches EOF
+on its own once read, which is the end-of-input the CLI needs to start
+processing. `stdin=DEVNULL` otherwise (callers with no prompt to feed,
+e.g. the preflight smoke test, are unaffected). The file is closed and
+unlinked from `_invoke`'s `finally`, so a timed-out or crashed worker
+cannot leak it, and it is created per call — so `claude_p`'s 2-attempt
+retry, which appends a retry note, stages a fresh file rather than
+replaying the first payload.
 
 This exists because a single argv element cannot exceed Linux's
 `MAX_ARG_STRLEN` (131,071 bytes, `PAGE_SIZE * 32`, not raisable) —
@@ -3831,13 +3836,16 @@ over stdin with no error, so it must be absent, not merely supplemented.
 Pinned by `tests/test_prompt_over_stdin.py`: the argv-length property (no
 `build()`-constructed argv element exceeds `MAX_ARG_STRLEN` for a 150KB+
 prompt), the absent positional, the retry path routing `retry_note`
-through stdin too, `_invoke`'s PIPE-vs-DEVNULL branch, and a real
-subprocess/real-pipe round trip for a 150,063-byte payload proving no
-deadlock between the concurrent feeder and the stdout/stderr readers.
+through stdin too, `_invoke`'s file-vs-DEVNULL branch, the whole payload
+being readable *at spawn time* (asserted inside the spawn, since checking
+afterwards cannot distinguish "written before exec" from "written during
+the run"), the staged file being unlinked, and a real subprocess round
+trip for a 150,063-byte payload proving no deadlock with the
+stdout/stderr readers.
 
-**The feeder must be queued before anything can block the event loop, and
-nothing on that path may block it.** `claude -p` waits a hard-coded **3 s**
-for its first stdin byte (`KJr(process.stdin, 3000)` in the CLI bundle; no
+**The prompt must be readable at `exec`, not delivered afterwards.**
+`claude -p` waits a hard-coded **3 s**
+for its first stdin byte (`r6r(process.stdin,3000)` in the CLI bundle; no
 env var), then removes its own `data` listener and proceeds without it — a
 late write is **discarded**, not buffered, and the worker exits 1 with
 `Input must be provided either through stdin or as a prompt argument`.
@@ -3848,11 +3856,28 @@ larger than the deadline in front of it, so the failure was permitted by
 construction. Measured before the fix: **218 workers lost this way, 12.4% of
 all invocations in the affected runs**, retried up to 4× each with every
 attempt charged to `max_total_workers`, on versions 0.9.95 through 0.16.0.
-`asyncio.create_task(_feed_stdin())` now runs immediately after the spawn
-and both broker calls go through `asyncio.to_thread` (matching
-`_cgroup_destroy`, which already did). **Both halves are required** — with
-either alone the prompt still misses the deadline, verified against a
-reproduction harness and pinned in `tests/test_stdin_feeder_ordering.py`.
+
+A first fix hoisted the write into `asyncio.create_task(_feed_stdin())`
+immediately after the spawn and moved both broker calls to
+`asyncio.to_thread`. That **narrowed the window without closing it**:
+delivery still depended on the event loop *scheduling* the feeder within
+3 s, and 0.17.0 lost 5 subtasks in one run to exactly that. Measured A/B,
+identical parent, only the transport varying, with synchronous bursts on
+the parent loop (the shape `_read_stream` produces when parsing several
+workers' JSON at once): **pipe+feeder lost 20/20 prompts at both 400 ms
+and 900 ms bursts; a staged file lost 0/20**, and 0/20 again under 10×
+CPU oversubscription (load 97). Raw CPU contention alone never reproduced
+it — 96 hogs on 32 cores cost 0/40 on *both* transports — so the mechanism
+is loop-blocking, not a busy host.
+
+The transport is therefore a **file**, which has no writer to schedule and
+so no deadline to lose. The broker calls stay on `asyncio.to_thread`
+regardless: stdin no longer depends on it, but every other coroutine still
+does. Pinned in `tests/test_stdin_feeder_ordering.py`, which asserts the
+property negatively — no writer task, no `proc.stdin.write`, stdin never a
+PIPE — because that is the form a regression takes, plus a behavioural pair
+showing a pipe losing and a file winning against a real child under a
+blocked loop.
 
 #### Appended system prompt transport — file, with a probe + inline fallback
 
@@ -5413,7 +5438,7 @@ DESIGN.md §8 for the full rationale and the incident this replaced).
 | `_is_same_document(path, text_len, text)` | True when `path` holds exactly `text` modulo surrounding whitespace. Keeps a task file out of its own reference list: the planner already has the task verbatim, so listing the file asks it to re-read content it holds — ~71K tokens of duplication on the measured incident (185,565 B at the measured 2.6 B/token). `resolve_task_argument` returns stripped contents and discards the path, so identity is re-established by content rather than by threading the path through every caller. A size pre-check (±8 bytes) means only a same-length candidate is ever opened; `text_len` is the task's encoded length, passed in rather than recomputed because this runs once per candidate and the task can be hundreds of KB. |
 | `_repo_rel(path, repo_root)` | Repo-relative string for a path, falling back to its basename when it resolves outside the repo. Pure path arithmetic. |
 | `_format_task_file_references(files, repo_root)` | Names the files the task references so the planner reads them itself. A list of paths and nothing else — it must not open them. `None` when the task names no files. |
-| `_unreachable_task_references(task)` | Advisory sibling of `_glob_task_references` — never touches its return value or candidate filtering. Scans the same de-emphasized, `has_ext`-or-`has_sep`-and-alnum-filtered tokens, but flags only tokens starting with `/` or `~` (absolute paths and home-relative references, both of which `_glob_task_references` silently drops as candidates — pathlib never expands `~`, so a `~`-prefixed token never even reaches that guard) that resolve to zero files. `phase_plan` logs a single warning line when non-empty; the check never gates. |
+| `_unreachable_task_references(task)` | Advisory sibling of `_glob_task_references` — never touches its return value or candidate filtering. Scans the same de-emphasized, `has_ext`-or-`has_sep`-and-alnum-filtered tokens, but flags only tokens starting with `/` or `~` (absolute paths and home-relative references, both of which `_glob_task_references` silently drops as candidates — pathlib never expands `~`, so a `~`-prefixed token never even reaches that guard) that resolve to zero files. Trailing sentence punctuation is `rstrip`ped (`` ` ``, `.`, `,`, `;`, `:`, `!`, `?`, `)`, `]`, `}`, quotes) so a reference ending a sentence, or backticked inside one, does not reach the operator as ``​`~/plans/x.md`.`` — the mangled form they would then go looking for. The two pre-existing `strip` calls cannot do it: they run in a fixed order, leaving the backtick in `` `x.md`. `` unreachable behind the period. **`rstrip`, never `strip`** — a LEADING dot is meaningful (`.env`, `.github/workflows/ci.yml`) and a leading `./`/`../` is a real relative path; a two-sided strip mangles all three, measured on the sibling `_parse_touched_file_line` defect. `phase_plan` logs a single warning line when non-empty; the check never gates. |
 
 **Freeze guard (2026-07-19 incident, root cause A) — resolved by deletion.**
 A single incidental dotted token (e.g. `CLAUDE.md` mentioned once in a
@@ -7929,12 +7954,32 @@ blocks again indefinitely. The `accept-blocked` verb lets the
 operator acknowledge the external block so `resume` skips that
 subtask.
 
-- **`leerie accept-blocked <run-id> <subtask-id> [--runtime fly|local|ec2]`**
+- **`leerie accept-blocked <run-id> <subtask-id> [--runtime fly|local|ec2] [--force]`**
   — sets `subtask_status[sid]` to `"complete"` in state.json and removes
   the sid from the `blocked` dict (if present). On `resume`,
   `phase_execute`'s wave-skip filters subtasks whose `subtask_status` is
-  `"complete"`, so the accepted subtask never re-dispatches. Without an
-  explicit `--runtime`, the verb auto-detects via the shared
+  `"complete"`, so the accepted subtask never re-dispatches.
+
+  The gate resolves the `blocked` registry **before** testing
+  `subtask_status`, because that registry — not the status string — is the
+  authoritative record, and the two disagree by **absence** as well as by
+  value. Measured across the run corpus, the single real disagreement was
+  precisely the absent-key shape: a sid in `blocked` with no
+  `subtask_status` entry at all, because its checkpoint was rejected before
+  a status was written. Resolving the registry after a `cur is None`
+  early-exit made that one real case unacceptable while admitting only the
+  value-mismatch case, which never occurred.
+
+  `--force` settles a subtask abandoned **mid-flight** — `in_progress` with
+  no registry entry, what a hard crash (ENOSPC, SIGKILL) leaves behind and
+  which neither field can express as blocked. It bypasses both status
+  checks, so it validates the sid against the scheduled set (`waves`) to
+  stop a typo minting a bogus `subtask_status` entry. The default stays
+  strict, keeping `--force` a deliberate operator act. Pinned in
+  `tests/test_accept_blocked.py` (absent-key accepted, neither-field still
+  refused, forced-abandoned accepted, forced-typo refused).
+
+  Without an explicit `--runtime`, the verb auto-detects via the shared
   `_auto_detect_run_runtime` helper (which probes `fly-machine.json`
   then `ec2-instance.json` — the same sidecar-probe order `stop`
   uses), falling back to `local` only when neither sidecar is present.

--- a/leerie
+++ b/leerie
@@ -1605,10 +1605,12 @@ PY
     _ab_run_id=""
     _ab_sid=""
     _ab_runtime=""
+    _ab_force=""
     while [ "$#" -gt 0 ]; do
       case "$1" in
         --runtime) _ab_runtime="${2:-}"; shift 2 ;;
         --runtime=*) _ab_runtime="${1#--runtime=}"; shift ;;
+        --force) _ab_force="--force"; shift ;;
         --*) remote_log "unknown accept-blocked flag: $1"; exit 1 ;;
         *)
           if [ -z "$_ab_run_id" ]; then _ab_run_id="$1"; shift
@@ -1658,14 +1660,15 @@ PY
     fi
     _ab_state_file="$_ab_state_dir/state.json"
     # Python program that validates and atomically mutates state.json.
-    # Reads (state_path, sid) from argv. Prints exactly one sentinel line
-    # prefixed ACCEPTED: / NOOP: / ERROR: so callers (esp. the Fly path,
+    # Reads (state_path, sid, force) from argv. Prints exactly one sentinel
+    # line prefixed ACCEPTED: / NOOP: / ERROR: so callers (esp. the Fly path,
     # which pipes this over `flyctl ssh console -C "python3 -"` and cannot
     # rely on the process exit code surviving flyctl's rc-flattening) can
     # grep the outcome. Exit code is still set for the local path.
     _ab_mutate='
 import json, os, sys, tempfile
 path, sid = sys.argv[1], sys.argv[2]
+force = len(sys.argv) > 3 and sys.argv[3] == "--force"
 try:
     with open(path) as f:
         st = json.load(f)
@@ -1674,15 +1677,32 @@ except FileNotFoundError:
     sys.exit(1)
 ss = st.get("subtask_status", {})
 cur = ss.get(sid)
-if cur is None:
+# The blocked registry is resolved FIRST, because it — not subtask_status —
+# is the authoritative record of a blocked subtask, and the two can disagree
+# by ABSENCE as well as by value. Measured across the run corpus, the single
+# real disagreement was exactly that shape: a subtask present in `blocked`
+# with no subtask_status entry at all (its checkpoint was rejected before a
+# status was ever written). Resolving the registry after a `cur is None`
+# early-exit made that case unacceptable — the one case that actually
+# occurred — while accepting only the value-mismatch case, which never did.
+bl = st.get("blocked", {})
+in_registry = isinstance(bl, dict) and sid in bl
+# --force settles a subtask abandoned mid-flight: `in_progress` with no
+# registry entry, which is what a hard crash (ENOSPC, SIGKILL) leaves behind
+# and which neither field can express as "blocked". Validated against the
+# scheduled sid set, so a typo cannot mint a bogus status entry.
+if force:
+    known = {s for wave in (st.get("waves") or []) for s in wave}
+    if known and sid not in known:
+        print(f"ERROR: subtask {sid!r} is not in the plan for this run", file=sys.stderr)
+        sys.exit(1)
+if cur is None and not (in_registry or force):
     print(f"ERROR: subtask {sid!r} not found in subtask_status", file=sys.stderr)
     sys.exit(1)
 if cur == "complete":
     print(f"NOOP: subtask {sid!r} is already complete")
     sys.exit(0)
-bl = st.get("blocked", {})
-in_registry = isinstance(bl, dict) and sid in bl
-if not in_registry and cur not in ("blocked", "failed"):
+if not force and not in_registry and cur not in ("blocked", "failed"):
     print(f"ERROR: subtask {sid!r} has status {cur!r} (expected blocked or failed)", file=sys.stderr)
     sys.exit(1)
 ss[sid] = "complete"
@@ -1753,7 +1773,7 @@ print(f"ACCEPTED: {sid!r} status changed from {cur!r} to complete")
       }
       _ab_remote_state="/work/.leerie/runs/$_ab_run_id/state.json"
       _ab_out="$(printf '%s' "$_ab_mutate" \
-        | ec2_remote_exec "$LEERIE_EC2_INSTANCE_ID" "python3 - '$_ab_remote_state' '$_ab_sid'" 2>&1 || true)"
+        | ec2_remote_exec "$LEERIE_EC2_INSTANCE_ID" "python3 - '$_ab_remote_state' '$_ab_sid' $_ab_force" 2>&1 || true)"
       _ab_sentinel="$(printf '%s\n' "$_ab_out" | tr -d '\r' \
                       | grep -E '^(ACCEPTED|NOOP|ERROR):' | tail -1 || true)"
       case "$_ab_sentinel" in
@@ -1771,7 +1791,7 @@ print(f"ACCEPTED: {sid!r} status changed from {cur!r} to complete")
       # consistent (best-effort; host copy is optional — EC2 state.json
       # normally lives only on the instance until fetch-back).
       if [ -f "$_ab_state_file" ]; then
-        python3 -c "$_ab_mutate" "$_ab_state_file" "$_ab_sid" >/dev/null 2>&1 || true
+        python3 -c "$_ab_mutate" "$_ab_state_file" "$_ab_sid" $_ab_force >/dev/null 2>&1 || true
       fi
       _ab_teardown_ec2
       remote_log "accept-blocked: done. Resume via: leerie resume $_ab_run_id"
@@ -1858,7 +1878,7 @@ print(f"ACCEPTED: {sid!r} status changed from {cur!r} to complete")
       # flattens the remote exit code.
       _ab_out="$(printf '%s' "$_ab_mutate" \
         | flyctl ssh console --app "$FLY_APP" --machine "$LEERIE_MACHINE_ID" \
-            --pty=false -C "python3 - '$_ab_remote_state' '$_ab_sid'" 2>&1 || true)"
+            --pty=false -C "python3 - '$_ab_remote_state' '$_ab_sid' $_ab_force" 2>&1 || true)"
       _ab_sentinel="$(printf '%s\n' "$_ab_out" | tr -d '\r' \
                       | grep -E '^(ACCEPTED|NOOP|ERROR):' | tail -1 || true)"
       case "$_ab_sentinel" in
@@ -1875,7 +1895,7 @@ print(f"ACCEPTED: {sid!r} status changed from {cur!r} to complete")
       # Mirror the mutation onto the host copy so list / audits stay
       # consistent (best-effort; host copy is optional).
       if [ -f "$_ab_state_file" ]; then
-        python3 -c "$_ab_mutate" "$_ab_state_file" "$_ab_sid" >/dev/null 2>&1 || true
+        python3 -c "$_ab_mutate" "$_ab_state_file" "$_ab_sid" $_ab_force >/dev/null 2>&1 || true
       fi
       _ab_teardown
       remote_log "accept-blocked: done. Resume via: leerie resume $_ab_run_id"
@@ -1885,7 +1905,7 @@ print(f"ACCEPTED: {sid!r} status changed from {cur!r} to complete")
         remote_log "accept-blocked: no state.json at $_ab_state_file"
         exit 1
       fi
-      python3 -c "$_ab_mutate" "$_ab_state_file" "$_ab_sid"
+      python3 -c "$_ab_mutate" "$_ab_state_file" "$_ab_sid" $_ab_force
       remote_log "accept-blocked: done. Resume via: leerie resume $_ab_run_id"
     fi
     exit 0

--- a/orchestrator/leerie.py
+++ b/orchestrator/leerie.py
@@ -8597,6 +8597,18 @@ def _unreachable_task_references(task: str) -> list[str]:
     tokens: list[str] = []
     for token in task.split():
         token = token.strip("\"'(),;:").strip("*_`")
+        # Sentence punctuation trailing a reference, stripped from the RIGHT
+        # only. A reference ending a sentence, or wrapped in backticks inside
+        # one, otherwise reaches the operator warning as "`~/plans/x.md`." —
+        # the mangled form they then go looking for. The two strips above
+        # cannot do it: they run in a fixed order, so the backtick in
+        # "`x.md`." is unreachable behind the period.
+        #
+        # rstrip, never strip: a LEADING dot is meaningful (`.env`,
+        # `.github/workflows/ci.yml`) and a leading `./` or `../` is a real
+        # relative path. Measured on the sibling `_parse_touched_file_line`
+        # defect, a two-sided strip mangled all three.
+        token = token.rstrip("`.,;:!?)]}\"'")
         if not token:
             continue
         if not any(c.isalnum() for c in token):
@@ -14364,13 +14376,25 @@ async def _invoke(cmd: list[str], cwd: str, timeout: int,
                   active_token: str | None = None) -> dict:
     """Run a `claude -p` command, streaming events as they arrive.
 
-    `stdin_data`, when given, is fed to the child's stdin by a concurrent
-    feeder task and stdin is closed afterward — this is how `claude_p`
-    hands the worker its (potentially 100KB+) prompt without putting it
+    `stdin_data`, when given, is written to a temp file that becomes the
+    child's stdin — this is how `claude_p` hands the worker its
+    (potentially 100KB+) prompt without putting it
     on argv, where a single element over Linux's MAX_ARG_STRLEN (131,071
     bytes, not raisable) raises `OSError: [Errno 7] Argument list too
-    long` at exec time. When `stdin_data` is None (e.g. the smoke-test
-    caller, whose prompt is a fixed short string), stdin is closed
+    long` at exec time. A file rather than a pipe because the CLI waits a
+    hard-coded 3 s for its FIRST stdin byte (`r6r(process.stdin,3000)` in
+    the bundle, surfaced as "no stdin data received in 3s") and then drops
+    its own `data` listener, discarding a late write. A pipe makes that
+    deadline a race against the orchestrator's event loop; a file has the
+    first byte readable at exec, so there is no deadline to lose. Measured
+    A/B under synchronous bursts on the parent loop (the shape
+    `_read_stream` produces when parsing several workers' JSON at once):
+    pipe+feeder lost 20/20 prompts at both 400 ms and 900 ms bursts, file
+    lost 0/20, and file stayed at 0/20 under 10x CPU oversubscription
+    (load 97). Note raw CPU contention alone never reproduced it — 3x
+    oversubscription cost 0/40 on BOTH transports — so the mechanism is
+    loop-blocking, not a busy host. When `stdin_data` is None (e.g. the
+    smoke-test caller, whose prompt is a fixed short string), stdin is closed
     immediately via DEVNULL — unchanged from the prior behavior.
 
     The CLI is invoked with `--output-format stream-json --verbose`; each
@@ -14478,65 +14502,80 @@ async def _invoke(cmd: list[str], cwd: str, timeout: int,
         cap_mb = max(worker_memory_max_bytes // (1024 * 1024) - reserve_mb, 256)
         worker_env["NODE_OPTIONS"] = f"--max-old-space-size={cap_mb}"
 
-    # Defined BEFORE the spawn so it can be started as a task the instant
-    # `proc` exists — see the ordering comment at the `create_task` below.
-    # It closes over `proc` and `stdin_data` only, both of which are bound
-    # by the time the task first runs.
-    async def _feed_stdin():
-        # Writes `stdin_data` to the child's stdin, then closes it so the
-        # CLI sees EOF and starts processing rather than blocking for
-        # more input. Runs concurrently with `_read_stream`/`_drain_stderr`
-        # rather than write-then-await — the incident's live measurement
-        # showed a 150KB write completing at t=0.26s with the child's
-        # first stdout event at t=0.69s (write-then-read is safe on that
-        # CLI version), but a concurrent feeder costs nothing and removes
-        # the dependency on that ordering holding on future CLI versions.
-        # No-op (proc.stdin is None) when `stdin_data` is None — the
-        # DEVNULL branch below never gives the child a writable stdin.
-        if stdin_data is None or proc.stdin is None:
-            return
-        try:
-            proc.stdin.write(stdin_data.encode())
-            await proc.stdin.drain()
-        except (BrokenPipeError, ConnectionResetError):
-            # The child closed its read end before consuming the whole
-            # payload (e.g. it exited early, or errored before reading
-            # stdin at all). That is a fact about the worker's exit, not
-            # this feeder's — `_read_stream`/`proc.wait()` already
-            # surface the worker's actual outcome, so swallow rather
-            # than let this coroutine's exception blow up the gather and
-            # mask that outcome.
-            #
-            # NOTE this swallow is why the stdin-starvation failure below
-            # left no leerie-side trace: the worker's own stderr said what
-            # happened, but leerie's causal role in it did not.
-            pass
-        finally:
-            proc.stdin.close()
+    # The prompt is staged to a temp file BEFORE the spawn, and that file —
+    # already positioned at byte 0 with the whole payload on disk — becomes
+    # the child's stdin. The CLI's 3 s first-byte deadline is therefore
+    # satisfied by construction: there is no writer left to be scheduled
+    # late, because there is no writer at all. This replaces a concurrent
+    # feeder task, which made delivery a race against the orchestrator's
+    # event loop and lost that race 20/20 times under 400 ms loop bursts
+    # (see this function's docstring for the full A/B).
+    #
+    # Closed and unlinked in the `finally` below, on every exit path, the
+    # same lifecycle `_append_system_prompt_file_supported`'s temp file
+    # already uses. Created per `_invoke` call, so `claude_p`'s 2-attempt
+    # retry — which appends a retry note to `stdin_data` — gets a fresh
+    # file for the second attempt rather than replaying the first payload.
+    stdin_file = None
+    stdin_path = None
+    if stdin_data is not None:
+        import tempfile  # noqa: PLC0415
+        stdin_fd, stdin_path = tempfile.mkstemp(prefix="leerie-prompt-")
+        # fdopen rather than a bare os.write: os.write returns a count and
+        # is permitted to short-write, so writing a 150KB prompt with it
+        # would deliver a TRUNCATED payload on the day it ever did — the
+        # worker would then run on a silently incomplete prompt instead of
+        # failing visibly, which is strictly worse than the bug this
+        # transport replaced. The buffered writer loops internally.
+        with os.fdopen(stdin_fd, "wb") as staged:
+            staged.write(stdin_data.encode())
+        # Opened for reading and handed to the child as its stdin. The
+        # child inherits a dup of this descriptor, so closing ours in the
+        # `finally` does not disturb a still-running worker.
+        stdin_file = open(stdin_path, "rb")
 
-    proc = await asyncio.create_subprocess_exec(
-        *cmd,
-        cwd=cwd,
-        # stdin=PIPE when the caller has a prompt to feed (the normal
-        # `claude_p` path — the user prompt no longer travels on argv,
-        # see `build()`'s comment); DEVNULL otherwise. Either way the
-        # worker never inherits the orchestrator's stdin, which inside a
-        # `nerdctl run -it` container is /dev/pts/0 — a real TTY. A CLI
-        # that branches on isatty() (e.g. to prompt for permission)
-        # would hang invisibly waiting for input that never arrives.
-        # The PIPE is fed by `_feed_stdin` below and closed once the
-        # write completes, so it is just as terminal-free as DEVNULL —
-        # the worker still never sees a live TTY.
-        stdin=(asyncio.subprocess.PIPE if stdin_data is not None
-               else asyncio.subprocess.DEVNULL),
-        stdout=asyncio.subprocess.PIPE,
-        stderr=asyncio.subprocess.PIPE,
-        limit=10 * 1024 * 1024,
-        # Session/PG leader so `_terminate_proc_tree` can reap the tool-call
-        # grandchildren `claude -p` spawns (vitest, dev servers, etc.).
-        start_new_session=True,
-        env=worker_env,
-    )
+    # The spawn is guarded because the staged file is created BEFORE the
+    # try/finally that normally reaps it, and `create_subprocess_exec` is a
+    # fork: under the `pids.max` exhaustion this codebase already handles
+    # elsewhere it raises, and every retry would then strand another
+    # ~150KB file. Disk exhaustion is not hypothetical here either — it has
+    # killed runs (hence the `_disk_free_ratio` preflight) — so a leak on
+    # the failure path feeds the very condition that produced the failure.
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            *cmd,
+            cwd=cwd,
+            # The staged prompt file when the caller has a prompt to feed (the
+            # normal `claude_p` path — the user prompt no longer travels on
+            # argv, see `build()`'s comment); DEVNULL otherwise. Either way the
+            # worker never inherits the orchestrator's stdin, which inside a
+            # `nerdctl run -it` container is /dev/pts/0 — a real TTY. A CLI
+            # that branches on isatty() (e.g. to prompt for permission)
+            # would hang invisibly waiting for input that never arrives.
+            # A regular file is not a TTY either, and it reaches EOF on its own
+            # once read, so the CLI still sees the end-of-input it needs to
+            # start processing — the close the old feeder had to perform.
+            stdin=(stdin_file if stdin_file is not None
+                   else asyncio.subprocess.DEVNULL),
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            limit=10 * 1024 * 1024,
+            # Session/PG leader so `_terminate_proc_tree` can reap the
+            # tool-call grandchildren `claude -p` spawns (vitest, dev
+            # servers, etc.).
+            start_new_session=True,
+            env=worker_env,
+        )
+    except BaseException:
+        # Reap the staged file, then let the original failure propagate
+        # unchanged — this must not mask why the spawn failed.
+        if stdin_file is not None:
+            with contextlib.suppress(OSError):
+                stdin_file.close()
+        if stdin_path is not None:
+            with contextlib.suppress(OSError):
+                os.unlink(stdin_path)
+        raise
     # Spawn heartbeat: surfaces *that* the worker was launched before the
     # await blocks on its first event. Without this line, the user sees
     # the phase header and then silence until the first stream-json event
@@ -14549,41 +14588,38 @@ async def _invoke(cmd: list[str], cwd: str, timeout: int,
     # operational chatter and stays gated.
     if verbosity != "quiet":
         log(f"  [{sid}] spawned (pid={proc.pid})")
-    # Start feeding the prompt IMMEDIATELY — before the broker round-trips
-    # below. The CLI waits a hard-coded 3 s for its first stdin byte
-    # (`KJr(process.stdin, 3000)` in the bundle), then removes its own
-    # `data` listener and proceeds without it, so a late write is DISCARDED
-    # and the worker dies with "Input must be provided either through stdin
-    # or as a prompt argument". Measured across every run on one host: 218
-    # workers lost this way, 12.4% of all invocations in the affected runs,
-    # retried up to 4x each and every attempt charged to `max_total_workers`.
+    # The prompt is ALREADY on the child's stdin at this point — it was
+    # staged to a file before the spawn, so nothing below can delay its
+    # delivery. That ordering used to be load-bearing and fragile: the CLI
+    # waits a hard-coded 3 s for its first stdin byte
+    # (`r6r(process.stdin,3000)` in the bundle, surfaced as "no stdin data
+    # received in 3s"), then removes its own `data` listener and proceeds
+    # without it, so a late write was DISCARDED and the worker died with
+    # "Input must be provided either through stdin or as a prompt
+    # argument". Measured across every run on one host: 218 workers lost
+    # that way, 12.4% of all invocations in the affected runs, retried up
+    # to 4x each and every attempt charged to `max_total_workers`.
     #
-    # Both halves of this fix are load-bearing and each was verified alone
-    # against a reproduction harness. Creating the task here but leaving the
-    # broker calls synchronous still fails (the blocked loop never schedules
-    # it); making the broker calls async but creating the task afterwards
-    # also still fails (the write lands after the child is already gone).
-    #
-    # This task is created OUTSIDE the try/finally below, so an exception
-    # before the gather would leave it pending with stdin unclosed. Accepted
-    # rather than guarded: everything between here and that try is either a
-    # plain assignment or a call whose helper swallows OSError itself
-    # (`_cgroup_create` / `_cgroup_enroll`), and `_DescendantTracker.start`
-    # is a bare `create_task`. More to the point, `proc` is spawned outside
-    # that try too — so any exception in this window already leaks a live
-    # worker process, which is strictly worse than a pending feeder and is
-    # the pre-existing shape this does not change.
-    feeder = asyncio.create_task(_feed_stdin())
+    # A concurrent feeder task (the previous fix) narrowed that window but
+    # could not close it: delivery still depended on the event loop
+    # scheduling the task within 3 s, and under bursts of synchronous work
+    # on the loop it lost 20/20 prompts. A file has no such dependency, so
+    # the broker round-trips below — and anything else that blocks the loop
+    # — are no longer able to starve a worker of its prompt.
     # cgroup containment: ask the cgroup broker to create the worker cgroup
     # and enroll the worker (and every descendant it forks — the kernel
     # propagates cgroup membership down the process tree). Dispatched via
     # `asyncio.to_thread` because they are synchronous socket round-trips:
-    # run inline they block the WHOLE event loop, including every sibling
-    # worker's feeder, for up to `_cgroup_request`'s 5 s timeout apiece.
-    # That bound is larger than the CLI's 3 s stdin patience, so the old
-    # inline form permitted the starvation above BY CONSTRUCTION — the
-    # comment that used to sit here called the stall "negligible", which is
-    # the assumption the incident falsified. No deadlock is possible either
+    # run inline they block the WHOLE event loop for up to
+    # `_cgroup_request`'s 5 s timeout apiece. The stdin deadline no longer
+    # depends on that (the prompt is already on disk), but every other
+    # coroutine still does — a sibling worker's `_read_stream`, the
+    # watchdog, `proc.wait()` — so keeping these off the loop remains
+    # correct. Historically this block was the direct cause of the stdin
+    # starvation: its 5 s bound is larger than the CLI's 3 s patience, so
+    # the old inline form permitted the failure BY CONSTRUCTION, and the
+    # comment that used to sit here called the stall "negligible" — the
+    # assumption the incident falsified. No deadlock is possible either
     # way (the broker never calls back into leerie).
     # `destroy` is the same shape and IS dispatched via to_thread in the
     # finally below — it blocks for the broker's whole drain (seconds, not
@@ -14950,12 +14986,11 @@ async def _invoke(cmd: list[str], cwd: str, timeout: int,
         _ASYNCIO_MANAGED_PIDS.add(proc.pid)
         try:
             await asyncio.wait_for(
-                # `feeder` is the task started right after the spawn, NOT a
-                # fresh `_feed_stdin()` call — awaiting it here is what keeps
-                # its exceptions surfaced and its lifetime bounded by the
-                # same timeout as the rest.
+                # No stdin task to await: the prompt was staged to a file
+                # before the spawn, so there is nothing left to deliver by
+                # the time this gather runs.
                 asyncio.gather(_read_stream(), _drain_stderr(),
-                               feeder, proc.wait()),
+                               proc.wait()),
                 timeout=timeout)
         except asyncio.TimeoutError:
             # Cancel the watchdog BEFORE the termination awaits so it
@@ -15038,6 +15073,20 @@ async def _invoke(cmd: list[str], cwd: str, timeout: int,
         # cancellable, but the worker thread completes the round-trip
         # regardless, so the broker still receives the destroy.
         await asyncio.to_thread(_cgroup_destroy, cgroup_sid)
+
+        # Drop the staged prompt file. The child holds its own dup of the
+        # descriptor, so this neither disturbs a still-running worker nor
+        # leaves the payload on disk after one exits. Best-effort for the
+        # same reason every other teardown step here is: a cleanup failure
+        # must not mask the worker's real outcome.
+        if stdin_file is not None:
+            try:
+                stdin_file.close()
+            except OSError:
+                pass
+        if stdin_path is not None:
+            with contextlib.suppress(OSError):
+                os.unlink(stdin_path)
 
     if envelope is None:
         stderr_txt = b"".join(stderr_chunks).decode(errors="replace").strip()

--- a/tests/test_accept_blocked.py
+++ b/tests/test_accept_blocked.py
@@ -20,14 +20,18 @@ import pytest
 REPO_ROOT = Path(__file__).resolve().parent.parent
 
 
-def _run_accept(state_path: Path, sid: str) -> subprocess.CompletedProcess:
+def _run_accept(state_path: Path, sid: str,
+                force: bool = False) -> subprocess.CompletedProcess:
     """Run the accept-blocked mutation via the launcher."""
     env = {k: v for k, v in os.environ.items()}
     env["LEERIE_STATE_DIR"] = str(state_path.parent.parent.parent)
     run_id = state_path.parent.name
+    argv = [str(REPO_ROOT / "leerie"), "accept-blocked", run_id, sid,
+            "--runtime", "local"]
+    if force:
+        argv.append("--force")
     return subprocess.run(
-        [str(REPO_ROOT / "leerie"), "accept-blocked", run_id, sid,
-         "--runtime", "local"],
+        argv,
         env=env,
         capture_output=True,
         text=True,
@@ -36,12 +40,15 @@ def _run_accept(state_path: Path, sid: str) -> subprocess.CompletedProcess:
 
 
 def _make_state(tmp_path: Path, subtask_status: dict,
-                blocked: dict | None = None) -> Path:
+                blocked: dict | None = None,
+                waves: list | None = None) -> Path:
     run_dir = tmp_path / "runs" / "test-run-001"
     run_dir.mkdir(parents=True)
     state = {"subtask_status": subtask_status}
     if blocked is not None:
         state["blocked"] = blocked
+    if waves is not None:
+        state["waves"] = waves
     state_file = run_dir / "state.json"
     state_file.write_text(json.dumps(state, indent=2))
     return state_file
@@ -321,3 +328,93 @@ def test_rejects_traversal_run_id(tmp_path):
     )
     assert r.returncode != 0
     assert "invalid run-id" in (r.stdout + r.stderr)
+
+
+# ---------------------------------------------------------------------------
+# The two fields can disagree by ABSENCE, not just by value (N21/N22).
+#
+# The pre-existing "registry disagrees" tests above both read that as *a
+# different status string*. Measured across the run corpus, the single real
+# disagreement was the other shape: a subtask in `blocked` with NO
+# subtask_status entry at all — its checkpoint was rejected (the N22
+# `## Files touched: None.` defect) before any status was written. The gate
+# resolved the registry only AFTER a `cur is None` early-exit, so the one
+# case that actually occurred was the one it refused.
+# ---------------------------------------------------------------------------
+
+def test_accepts_when_absent_from_subtask_status_but_in_registry(tmp_path):
+    """The measured incident: `_self/d1207301`'s refactor-013."""
+    sf = _make_state(
+        tmp_path, {"other-1": "complete"},
+        blocked={"refactor-013": "checkpoint invalid: `## Files touched` "
+                                 "lists 'None.' but the file does not exist"})
+    r = _run_accept(sf, "refactor-013")
+    assert r.returncode == 0, r.stderr
+    st = json.loads(sf.read_text())
+    assert st["subtask_status"]["refactor-013"] == "complete"
+    assert "refactor-013" not in st.get("blocked", {})
+
+
+def test_still_refuses_a_sid_in_neither_field(tmp_path):
+    """Anti-vacuity for the test above: the relaxation must not accept
+    everything. A sid in neither field is a typo, not a blocked subtask."""
+    sf = _make_state(tmp_path, {"s1": "blocked"}, blocked={"s1": "r"})
+    r = _run_accept(sf, "nonexistent-9")
+    assert r.returncode != 0
+    assert "not found in subtask_status" in r.stderr
+
+
+def test_force_settles_a_subtask_abandoned_mid_flight(tmp_path):
+    """`in_progress` with NO registry entry — what a hard crash (ENOSPC,
+    SIGKILL) leaves behind, and what neither field can express as blocked.
+    Observed on `9751c048`'s test-015. Without --force it must stay refused,
+    so the default gate keeps its meaning."""
+    sf = _make_state(tmp_path, {"test-015": "in_progress"}, blocked={},
+                     waves=[["test-015"]])
+    refused = _run_accept(sf, "test-015")
+    assert refused.returncode != 0
+    assert "expected blocked or failed" in refused.stderr
+
+    forced = _run_accept(sf, "test-015", force=True)
+    assert forced.returncode == 0, forced.stderr
+    st = json.loads(sf.read_text())
+    assert st["subtask_status"]["test-015"] == "complete"
+
+
+def test_force_still_rejects_a_sid_not_in_the_plan(tmp_path):
+    """--force bypasses both status fields, so without this it would mint a
+    bogus subtask_status entry from a typo."""
+    sf = _make_state(tmp_path, {"test-015": "in_progress"}, blocked={},
+                     waves=[["test-015"]])
+    r = _run_accept(sf, "test-999", force=True)
+    assert r.returncode != 0
+    assert "not in the plan" in r.stderr
+    st = json.loads(sf.read_text())
+    assert "test-999" not in st["subtask_status"]
+
+
+def test_force_reaches_every_transport(tmp_path):
+    """`--force` must be threaded through ALL of accept-blocked's transports.
+
+    The verb has five invocation sites — local, the Fly and EC2 remote
+    commands, and the two host-side state mirrors. Wiring only the local one
+    leaves `--force` silently ignored on Fly/EC2: the flag parses, the verb
+    reports success, and the mutation refuses on the far side. That is the
+    same partial-fix shape `tests/test_resolve_aws_launcher.py` documents
+    for `_resolve_ec2_knob`, where fixing one arm of a multi-arm dispatch
+    read as done.
+
+    Structural because the remote arms need a live machine to exercise: pin
+    that no invocation of the mutation program passes the sid WITHOUT the
+    force argument following it.
+    """
+    src = (REPO_ROOT / "leerie").read_text()
+    invocations = [ln.strip() for ln in src.splitlines()
+                   if '"$_ab_mutate" "$_ab_state_file" "$_ab_sid"' in ln
+                   or "'$_ab_remote_state' '$_ab_sid'" in ln]
+    assert invocations, "found no accept-blocked mutation invocations to check"
+    unwired = [ln for ln in invocations if "_ab_force" not in ln]
+    assert not unwired, (
+        "these accept-blocked invocations do not forward --force, so the "
+        "flag is silently ignored on that transport:\n  "
+        + "\n  ".join(unwired))

--- a/tests/test_argv_stdin_transport.py
+++ b/tests/test_argv_stdin_transport.py
@@ -26,7 +26,7 @@ combined, end-to-end transport contract the incident write-up demands:
     exercised separately
   - the schema stays inline (`--json-schema`, never a `@file` form)
   - a stubbed spawn fed the full payload does not raise E2BIG and does
-    not deadlock (bounded via a concurrent feeder)
+    not deadlock (the payload is staged to a file before the spawn)
 
 Does not cover the coverage-gate (root cause A) or dep_capture budget
 sites — those are separate subtasks.
@@ -238,7 +238,7 @@ class TestIncidentShapedTransport:
 # ---------------------------------------------------------------------------
 # Stubbed spawn: the incident payload must not raise E2BIG and must not
 # deadlock, exercised through _invoke's real asyncio spawn + concurrent
-# feeder against a stubbed asyncio.create_subprocess_exec (no live
+# staging against a stubbed asyncio.create_subprocess_exec (no live
 # `claude` binary required).
 # ---------------------------------------------------------------------------
 
@@ -324,20 +324,27 @@ def test_stubbed_spawn_does_not_raise_e2big_at_incident_scale(
     assert envelope["is_error"] is False
 
 
-def test_stubbed_spawn_feeds_full_payload_without_deadlock(
+def test_stubbed_spawn_stages_full_payload_before_exec(
         leerie, leerie_dir, monkeypatch):
-    """The concurrent feeder writes the entire incident-scale payload
-    and closes stdin (EOF) rather than blocking on a write-then-read
-    ordering — asserted by inspecting the mock's captured stdin."""
+    """The entire incident-scale payload is readable on the child's stdin
+    at the moment of spawn.
+
+    Read inside the fake, before `_invoke` proceeds: the guarantee is that
+    the payload was already there, and checking afterwards cannot tell that
+    apart from a write that happened during the run. (The CLI drops its
+    stdin listener 3 s after spawn, so "during the run" is exactly the
+    failure mode — see tests/test_stdin_feeder_ordering.py.)
+    """
     user_prompt = _incident_shaped_user_prompt()
-    proc_holder: dict = {}
+    seen: dict = {}
 
     async def fake(*cmd, **kwargs):
+        handed = kwargs.get("stdin")
+        handed.seek(0)
+        seen["at_spawn"] = handed.read()
         events = [json.dumps({"type": "result", "subtype": "success",
                               "is_error": False, "result": "{}"})]
-        proc = _MockProc(events)
-        proc_holder["proc"] = proc
-        return proc
+        return _MockProc(events)
 
     monkeypatch.setattr("asyncio.create_subprocess_exec", fake)
 
@@ -346,9 +353,7 @@ def test_stubbed_spawn_feeds_full_payload_without_deadlock(
         sid="incident-feed", leerie_dir=leerie_dir, verbosity="quiet",
         stdin_data=user_prompt))
 
-    proc = proc_holder["proc"]
-    assert proc.stdin.written == user_prompt.encode()
-    assert proc.stdin.closed is True
+    assert seen["at_spawn"] == user_prompt.encode()
 
 
 def test_real_subprocess_incident_payload_no_deadlock(leerie, leerie_dir):
@@ -356,7 +361,7 @@ def test_real_subprocess_incident_payload_no_deadlock(leerie, leerie_dir):
     exact 150,063-byte incident payload is delivered and read back
     without hanging, bounded by _invoke's own asyncio.wait_for timeout
     rather than relying on pytest-level enforcement — if the concurrent
-    feeder/reader pairing deadlocked, this test would hang instead of
+    stdin/reader pairing deadlocked, this test would hang instead of
     failing cleanly."""
     import sys
 

--- a/tests/test_prompt_over_stdin.py
+++ b/tests/test_prompt_over_stdin.py
@@ -11,13 +11,17 @@ Covers:
   - `build()` never puts the user prompt on argv, at any payload size
     (the argv-length property: no element can exceed MAX_ARG_STRLEN
     for a 150KB+ payload, because none of them carry it at all).
-  - `_invoke` spawns with `stdin=PIPE` (not DEVNULL) when `stdin_data`
-    is given, and DEVNULL when it is not (smoke-test / direct-cmd
-    callers unaffected).
-  - The concurrent stdin feeder delivers the full payload to a REAL
-    child process over a REAL OS pipe with no deadlock, for a payload
-    well over the 131,071-byte single-argv ceiling this fix exists to
-    route around.
+  - `_invoke` spawns with an already-readable temp FILE as stdin when
+    `stdin_data` is given, and DEVNULL when it is not (smoke-test /
+    direct-cmd callers unaffected). A file rather than a pipe because the
+    CLI drops its stdin listener 3 s after spawn, which made a pipe a race
+    against the orchestrator's event loop — measured 20/20 prompts lost
+    under 400 ms bursts of synchronous work on that loop, 0/20 with a file
+    (and 0/20 for a file at 10x CPU oversubscription). The file is staged
+    before the spawn and unlinked after the call.
+  - The full payload reaches a REAL child process with no deadlock, for a
+    payload well over the 131,071-byte single-argv ceiling this fix exists
+    to route around.
   - `claude_p` end-to-end (via a stubbed `_invoke`) sends a 150KB+
     prompt through as `stdin_data`, not as part of `cmd`.
   - The reconciler's size-gate retry prompt (`_build_size_retry_prompt`,
@@ -30,6 +34,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import os
 import sys
 
 import pytest
@@ -271,25 +276,46 @@ def leerie_dir(tmp_path):
     return cd
 
 
-def test_invoke_uses_pipe_when_stdin_data_given(leerie, leerie_dir,
-                                                monkeypatch):
+def test_invoke_passes_a_readable_file_when_stdin_data_given(
+        leerie, leerie_dir, monkeypatch):
+    """The prompt must reach the child as an ALREADY-READABLE file, not a
+    pipe someone still has to write to.
+
+    The CLI drops its stdin listener 3 s after spawn
+    (`r6r(process.stdin,3000)`), so a pipe makes delivery a race against
+    the orchestrator's event loop — measured 20/20 prompts lost under
+    400 ms bursts of synchronous work on that loop. A regular file has the
+    payload on disk before the child exists, so there is no writer left to
+    schedule late and no deadline to lose.
+    """
     captured: dict = {}
 
     async def fake(*cmd, **kwargs):
-        captured.update(kwargs)
+        handed = kwargs.get("stdin")
+        captured["is_pipe"] = handed is asyncio.subprocess.PIPE
+        captured["readable"] = hasattr(handed, "read")
+        # Read it HERE, at spawn time. The payload must already be on disk
+        # and positioned at byte 0 — that is the whole guarantee, and it is
+        # only observable before `_invoke`'s cleanup closes the file.
+        if captured["readable"]:
+            handed.seek(0)
+            captured["content"] = handed.read()
         events = [json.dumps({"type": "result", "subtype": "success",
                               "is_error": False})]
-        return _MockProc(events, with_stdin=True)
+        return _MockProc(events, with_stdin=False)
 
     monkeypatch.setattr("asyncio.create_subprocess_exec", fake)
+    payload = "hello prompt"
     asyncio.run(leerie._invoke(
         ["claude", "-p"], cwd=str(leerie_dir.parent),
-        timeout=60, sid="t-pipe", leerie_dir=leerie_dir,
-        verbosity="quiet", stdin_data="hello prompt"))
+        timeout=60, sid="t-file", leerie_dir=leerie_dir,
+        verbosity="quiet", stdin_data=payload))
 
-    assert captured.get("stdin") == asyncio.subprocess.PIPE, (
-        "_invoke must pass stdin=PIPE when stdin_data is given, so the "
-        "feeder can write the prompt to the child")
+    assert not captured["is_pipe"], (
+        "_invoke must NOT hand the child a pipe — that reintroduces the "
+        "race the file transport exists to remove")
+    assert captured["readable"], "expected a readable file object as stdin"
+    assert captured["content"] == payload.encode()
 
 
 def test_invoke_still_uses_devnull_when_no_stdin_data(leerie, leerie_dir,
@@ -313,19 +339,25 @@ def test_invoke_still_uses_devnull_when_no_stdin_data(leerie, leerie_dir,
     assert captured.get("stdin") == asyncio.subprocess.DEVNULL
 
 
-def test_feeder_writes_full_payload_and_closes_stdin(leerie, leerie_dir,
-                                                      monkeypatch):
-    """The concurrent feeder writes the entire stdin_data payload and
-    closes the pipe afterward (EOF), so the child sees a complete,
-    terminated stream — not a hang waiting for more input."""
-    proc_holder: dict = {}
+def test_full_payload_is_on_disk_before_the_child_exists(
+        leerie, leerie_dir, monkeypatch):
+    """The ENTIRE payload must be readable at the moment of spawn.
+
+    A partial write would recreate the failure in a subtler form: the CLI
+    starts on an incomplete prompt instead of dying visibly. Asserting at
+    spawn time (inside the fake, before `_invoke` proceeds) is the point —
+    checking afterwards cannot distinguish "written before exec" from
+    "written during the run", which is the whole distinction here.
+    """
+    seen: dict = {}
 
     async def fake(*cmd, **kwargs):
+        handed = kwargs.get("stdin")
+        handed.seek(0)
+        seen["at_spawn"] = handed.read()
         events = [json.dumps({"type": "result", "subtype": "success",
                               "is_error": False})]
-        proc = _MockProc(events, with_stdin=True)
-        proc_holder["proc"] = proc
-        return proc
+        return _MockProc(events, with_stdin=False)
 
     monkeypatch.setattr("asyncio.create_subprocess_exec", fake)
     payload = "p" * 150_063  # the incident's exact overflow size
@@ -334,9 +366,28 @@ def test_feeder_writes_full_payload_and_closes_stdin(leerie, leerie_dir,
         timeout=60, sid="t-feed", leerie_dir=leerie_dir,
         verbosity="quiet", stdin_data=payload))
 
-    proc = proc_holder["proc"]
-    assert proc.stdin.written == payload.encode()
-    assert proc.stdin.closed is True
+    assert seen["at_spawn"] == payload.encode()
+
+
+def test_prompt_file_is_cleaned_up(leerie, leerie_dir, monkeypatch):
+    """The staged file must not outlive the call — a leak here would
+    accumulate one 100KB+ file per worker invocation across a run."""
+    paths: list = []
+
+    async def fake(*cmd, **kwargs):
+        paths.append(kwargs["stdin"].name)
+        events = [json.dumps({"type": "result", "subtype": "success",
+                              "is_error": False})]
+        return _MockProc(events, with_stdin=False)
+
+    monkeypatch.setattr("asyncio.create_subprocess_exec", fake)
+    asyncio.run(leerie._invoke(
+        ["claude", "-p"], cwd=str(leerie_dir.parent),
+        timeout=60, sid="t-clean", leerie_dir=leerie_dir,
+        verbosity="quiet", stdin_data="hello"))
+
+    assert paths and not os.path.exists(paths[0]), (
+        f"staged prompt file {paths[0]} survived the call")
 
 
 # ---------------------------------------------------------------------------
@@ -378,3 +429,34 @@ def test_real_subprocess_150kb_stdin_no_deadlock(leerie, leerie_dir):
     assert envelope["type"] == "result"
     assert envelope["is_error"] is False
     assert envelope["structured_output"]["nbytes"] == len(payload.encode())
+
+
+def test_no_staged_file_leaks_when_the_spawn_fails(leerie, leerie_dir,
+                                                    monkeypatch):
+    """A failed spawn must not strand the staged prompt.
+
+    The file is created BEFORE the try/finally that normally reaps it, and
+    `create_subprocess_exec` is a fork — under the `pids.max` exhaustion
+    this codebase handles elsewhere it raises EAGAIN, and every retry would
+    strand another ~150KB file. Disk exhaustion has killed runs here (hence
+    the `_disk_free_ratio` preflight), so leaking on the failure path feeds
+    the very condition that produced the failure.
+    """
+    import glob
+    import tempfile
+
+    pattern = os.path.join(tempfile.gettempdir(), "leerie-prompt-*")
+    before = set(glob.glob(pattern))
+
+    async def boom(*cmd, **kwargs):
+        raise OSError(11, "Resource temporarily unavailable")  # EAGAIN
+
+    monkeypatch.setattr("asyncio.create_subprocess_exec", boom)
+    with pytest.raises(OSError):
+        asyncio.run(leerie._invoke(
+            ["claude", "-p"], cwd=str(leerie_dir.parent),
+            timeout=60, sid="t-leak", leerie_dir=leerie_dir,
+            verbosity="quiet", stdin_data="x" * 150_000))
+
+    assert not (set(glob.glob(pattern)) - before), (
+        "a failed spawn stranded its staged prompt file")

--- a/tests/test_stdin_feeder_ordering.py
+++ b/tests/test_stdin_feeder_ordering.py
@@ -2,7 +2,8 @@
 event loop (DESIGN §6 *User prompt transport*).
 
 `claude -p` waits a hard-coded **3 s** for its first stdin byte
-(`KJr(process.stdin, 3000)` in the CLI bundle), then removes its own `data`
+(`r6r(process.stdin,3000)` in the CLI bundle, read out of the shipped
+binary), then removes its own `data`
 listener and proceeds without it — so a late write is DISCARDED, not buffered,
 and the worker dies with `Input must be provided either through stdin or as a
 prompt argument`. leerie used to make two synchronous broker round-trips
@@ -16,26 +17,58 @@ every attempt charged to `max_total_workers`. It spans v0.9.95 through v0.16.0.
 `_cgroup_enroll`'s own docstring records the same pair in a different run
 (`870cf82c…`) as "two apparently-unconnected events"; they are one event.
 
-**Both halves of the fix are load-bearing**, which is the point of this file.
-A reproduction harness scored all four combinations against a child that
-mimics the CLI's 3 s wait:
+**The feeder was never a complete fix, and this file now guards its
+replacement.** Hoisting the write into a task and moving the broker calls off
+the loop narrowed the window but could not close it: delivery still depended on
+the event loop *scheduling* that task within 3 s. Under bursts of synchronous
+work on the loop — the shape `_read_stream` produces when parsing several
+workers' JSON at once — it lost every time. Measured A/B, identical parent,
+only the transport varying:
 
-| variant | child saw |
-|---|---|
-| blocking call before the feeder (the old code) | TIMEOUT |
-| feeder task created first, call still synchronous | **TIMEOUT** — the blocked loop never schedules it |
-| call in a thread, feeder created afterwards | **TIMEOUT** — write lands after the child is gone |
-| feeder task first AND call in a thread | GOT |
+| parent loop burst | pipe + feeder | staged file |
+|---|---|---|
+| 400 ms | **20/20 prompts LOST** | 0/20 lost |
+| 900 ms | **20/20 prompts LOST** | 0/20 lost |
+| 900 ms + 320 CPU hogs (load 97) | — | 0/20 lost |
 
-So neither half alone is a fix, and a future edit that keeps one while
-dropping the other silently reopens a 12% budget leak.
+Raw CPU contention alone never reproduced it (96 hogs on 32 cores: 0/40 lost on
+*both* transports), so the mechanism is loop-blocking, not a busy host.
+
+The fix is to remove the deadline as a dependency rather than race it: the
+prompt is staged to a temp file before the spawn, so its first byte is readable
+at `exec` and there is no writer left to schedule. What this file pins is that
+property — a revert to any pipe-and-writer shape must fail here, because such a
+shape is a race whether or not its ordering happens to be correct today.
 """
 from __future__ import annotations
 
 import ast
+import asyncio
 import inspect
+import sys
+import time
 
 import pytest
+
+# The real-child rationale, retained: an earlier draft modelled the deadline
+# with an in-process `asyncio.Event` + `wait_for` and was wrong in the one way
+# that mattered — a blocked event loop also freezes the model's own timer, so
+# whether the deadline or the write won came down to ready-queue ordering,
+# which differs across CPython versions. It passed on 3.12+ and reported GOT
+# for the blocking variants on 3.10/3.11. The real CLI is a separate process
+# whose 3 s clock runs regardless of what leerie's loop is doing; only a real
+# subprocess reproduces that, and it does so identically on every version.
+#
+# The child announces READY before arming its clock and the parent waits for
+# it, so interpreter startup cannot eat into the margin. Without that
+# handshake a slow runner shifts the child's deadline past the parent's block
+# and the TIMEOUT variant flips to GOT.
+CHILD = (
+    "import sys, select\n"
+    "print('READY', flush=True)\n"
+    "r, _, _ = select.select([sys.stdin], [], [], 0.30)\n"
+    "print('GOT' if r else 'TIMEOUT', flush=True)\n"
+)
 
 
 def _invoke_src(leerie) -> str:
@@ -43,10 +76,11 @@ def _invoke_src(leerie) -> str:
 
     Every scan in this file is about where statements sit relative to one
     another, and the region under test is heavily commented — with comments
-    that necessarily name `_feed_stdin`, `await`, and `_cgroup_enroll` while
-    explaining the ordering. A raw substring scan matches that prose and
-    reports the ordering broken on correct code (it did, on the first draft
-    of this file). Stripped via `tokenize` rather than a `#` heuristic so a
+    that necessarily name the old feeder, `await`, and `_cgroup_enroll`
+    while explaining the history. A raw substring scan matches that prose —
+    and `test_no_writer_task_exists` below asserts a name is ABSENT, so an
+    unstripped comment mentioning it fails on correct code (it did, on the
+    first draft of this file). Stripped via `tokenize` rather than a `#` heuristic so a
     `#` inside a string literal cannot corrupt the result.
     """
     import io
@@ -67,34 +101,48 @@ def _invoke_src(leerie) -> str:
     return "".join(out)
 
 
-# ---- ordering: the write is queued before the broker round-trips ----------
+# ---- the payload is on disk before the child exists -----------------------
 
-def test_feeder_task_is_created_before_the_cgroup_calls(leerie):
-    """Source-ordered, because the real path needs a spawned child, a live
-    broker socket and a 3-second race to observe behaviourally."""
-    src = _invoke_src(leerie)
-    i_feeder = src.index("asyncio.create_task(_feed_stdin())")
-    i_create = src.index("_cgroup_create")
-    i_enroll = src.index("_cgroup_enroll")
-    assert i_feeder < i_create, "the feeder must be queued before `create`"
-    assert i_feeder < i_enroll, "the feeder must be queued before `enroll`"
+def test_prompt_is_staged_before_the_spawn(leerie):
+    """The write must complete BEFORE `create_subprocess_exec`.
 
-
-def test_feeder_is_created_immediately_after_the_spawn(leerie):
-    """Nothing awaitable may sit between the spawn and the feeder.
-
-    An `await` there yields the loop to whatever else is runnable — which in
-    a wave of `max_parallel` workers is a sibling's broker round-trip — and
-    the 3 s clock is already running on a child that exists.
+    Staging it afterwards would recreate the race in a new shape: the child
+    would exist, its 3 s clock running, while the parent still had work to do
+    before the first byte was readable.
     """
     src = _invoke_src(leerie)
+    i_stage = src.index("tempfile.mkstemp(")
+    i_spawn = src.index("proc = await asyncio.create_subprocess_exec(")
+    assert i_stage < i_spawn, (
+        "the prompt file must be staged before the spawn, not after")
+
+
+def test_no_writer_task_exists(leerie):
+    """No coroutine may be responsible for delivering the prompt.
+
+    This is the invariant, stated negatively because that is the form a
+    regression takes: any reintroduced writer — however well ordered — makes
+    delivery depend on the loop scheduling it inside the CLI's 3 s window,
+    which is exactly what the measured A/B in this module's docstring shows
+    losing 20/20.
+    """
+    src = _invoke_src(leerie)
+    assert "_feed_stdin" not in src, (
+        "a stdin feeder has been reintroduced; the prompt must be staged to "
+        "a file before the spawn instead")
+    assert "proc.stdin.write" not in src, (
+        "nothing may write to the child's stdin after the spawn")
+
+
+def test_stdin_is_never_a_pipe_when_a_prompt_is_given(leerie):
+    """A PIPE is the mechanism the race needs; a file is what removes it."""
+    src = _invoke_src(leerie)
     spawn = src.index("proc = await asyncio.create_subprocess_exec(")
-    feeder = src.index("asyncio.create_task(_feed_stdin())")
-    between = src[spawn:feeder]
-    # The spawn's own `await` is the one on the first line of the slice.
-    assert between.count("await ") == 1, (
-        "an extra await sits between the spawn and the feeder:\n"
-        + "\n".join(ln for ln in between.splitlines() if "await " in ln))
+    args = src[spawn:spawn + 1400]
+    assert "stdin=(stdin_file" in args, (
+        "the staged file must be handed to the child as its stdin")
+    assert "subprocess.PIPE if stdin_data" not in args, (
+        "stdin must not be a PIPE when a prompt is given")
 
 
 def test_cgroup_calls_do_not_block_the_event_loop(leerie):
@@ -116,93 +164,83 @@ def test_cgroup_calls_do_not_block_the_event_loop(leerie):
                 f"{src[max(0, i - 80):i + len(fn) + 40]!r}")
 
 
-def test_gather_awaits_the_existing_task_not_a_second_call(leerie):
-    """Calling `_feed_stdin()` again in the gather would spawn a SECOND
-    writer against a stdin the first one already closed, and would leave the
-    real feeder unawaited."""
+def test_gather_awaits_no_stdin_task(leerie):
+    """Nothing stdin-related may remain in the gather.
+
+    A leftover name there would be either a dangling reference (crash) or a
+    revived writer (the race). The gather's members are now exactly the three
+    that outlive the spawn.
+    """
     src = _invoke_src(leerie)
-    assert "feeder, proc.wait()" in src
-    assert "_feed_stdin(), proc.wait()" not in src
-    # Count CALLS, not the definition: `async def _feed_stdin():` contains
-    # `_feed_stdin()` as a substring, so a bare count reports 2 for correct
-    # code (it did, on the first draft).
-    calls = [i for i in range(len(src))
-             if src.startswith("_feed_stdin()", i)
-             and not src[:i].rstrip().endswith("def")]
-    assert len(calls) == 1, \
-        f"_feed_stdin() should be invoked exactly once, found {len(calls)}"
-    assert src[:calls[0]].rstrip().endswith("asyncio.create_task("), \
-        "the single invocation must be the create_task at the spawn"
+    assert "feeder, proc.wait()" not in src
+    assert "_read_stream(), _drain_stderr()," in src
+    assert "proc.wait()" in src
 
 
-def test_feed_stdin_is_defined_before_the_spawn(leerie):
-    """It has to be, to be startable at the spawn — and it may close over
-    nothing that is bound later. `proc` and `stdin_data` are the only two,
-    and both are bound before the task first runs."""
+def test_staged_file_is_cleaned_up(leerie):
+    """One 100KB+ file per worker invocation, so a leak is not academic — a
+    long run makes thousands. Pinned structurally because the real path needs
+    a spawned child to observe."""
     src = _invoke_src(leerie)
-    assert src.index("async def _feed_stdin") < \
-        src.index("proc = await asyncio.create_subprocess_exec(")
-
-    # `_invoke` is module-level, so its source parses as-is — no dedent.
+    assert "os.unlink(stdin_path)" in src, (
+        "the staged prompt file must be unlinked")
+    # It must sit in the teardown, not on the success path only: a worker that
+    # times out or crashes leaks the file otherwise.
     tree = ast.parse(inspect.getsource(leerie._invoke))
-    fn = next((n for n in ast.walk(tree)
-               if isinstance(n, ast.AsyncFunctionDef)
-               and n.name == "_feed_stdin"), None)
-    assert fn is not None
-    free = {n.id for n in ast.walk(fn) if isinstance(n, ast.Name)}
-    assert free <= {"proc", "stdin_data", "BrokenPipeError",
-                    "ConnectionResetError"}, \
-        f"_feed_stdin closes over something new: {free}"
+    in_finally = any(
+        "os.unlink(stdin_path)" in ast.unparse(h)
+        for n in ast.walk(tree) if isinstance(n, ast.Try) for h in [n.finalbody]
+        if h)
+    assert in_finally, (
+        "the unlink must run from a `finally`, so a timed-out or crashed "
+        "worker cannot leak its prompt file")
 
 
 # ---- the property the ordering exists to protect --------------------------
 
-@pytest.mark.parametrize("hoisted,threaded,expect_delivered", [
-    (False, False, False),   # the old code
-    (True,  False, False),   # hoist alone — blocked loop never runs the task
-    (False, True,  False),   # to_thread alone — write lands too late
-    (True,  True,  True),    # both
+@pytest.mark.parametrize("transport,expect_delivered", [
+    ("pipe", False),   # any writer loses when the loop is blocked
+    ("file", True),    # a staged file has nothing left to schedule
 ])
-def test_only_both_halves_deliver_the_prompt_in_time(hoisted, threaded,
-                                                     expect_delivered):
-    """Behavioural proof that neither half alone suffices.
+def test_only_a_staged_file_survives_a_blocked_event_loop(transport,
+                                                          expect_delivered):
+    """The property the whole transport exists for.
 
-    Uses a REAL child process, which is the whole point. An earlier draft
-    modelled the deadline with an in-process `asyncio.Event` + `wait_for`
-    and was wrong in the one way that mattered: a blocked event loop also
-    freezes the model's own timer, so whether the deadline or the write won
-    came down to ready-queue ordering — which differs across CPython
-    versions. It passed on 3.12+ and reported `GOT` for the two blocking
-    variants on 3.10/3.11. The real CLI is a separate process whose 3 s
-    clock runs regardless of what leerie's loop is doing; only a real
-    subprocess reproduces that, and it does so identically on every version.
+    A blocked parent loop is not hypothetical: `_read_stream` parses JSON
+    from up to `max_parallel` workers, and each burst of that work is time
+    the loop cannot schedule anything else. With a pipe, the prompt is still
+    undelivered during those bursts and the child's independent clock runs
+    out. With a file it was delivered before the child existed.
 
-    Scaled down 10x from the real 3 s deadline to keep the test quick.
+    Scaled down 10x from the real 3 s deadline to keep the test quick; the
+    full-scale A/B is in this module's docstring.
     """
-    import asyncio
-    import sys
-    import time
+    import os
+    import tempfile
 
     DEADLINE = 0.30          # stands in for the CLI's hard-coded 3 s
-    BLOCK = 0.90             # stands in for a slow broker round-trip
-
-    # Mirrors the CLI: wait for the first stdin byte until a deadline, then
-    # stop listening. `select` gives the child its own OS-level clock.
-    #
-    # It announces READY before arming that clock, and the parent waits for
-    # it, so interpreter startup cannot eat into the margin. Without that
-    # handshake a slow runner shifts the child's deadline later than the
-    # parent's block and the two TIMEOUT variants flip to GOT — the same
-    # class of environment-dependence that made the previous draft of this
-    # test fail on 3.10/3.11 while passing locally.
-    CHILD = (
-        "import sys, select\n"
-        "print('READY', flush=True)\n"
-        f"r, _, _ = select.select([sys.stdin], [], [], {DEADLINE})\n"
-        "print('GOT' if r else 'TIMEOUT', flush=True)\n"
-    )
+    BLOCK = 0.90             # stands in for a burst of loop-blocking work
 
     async def scenario():
+        if transport == "file":
+            fd, path = tempfile.mkstemp()
+            os.write(fd, b"x" * 1024)
+            os.close(fd)
+            f = open(path, "rb")
+            try:
+                proc = await asyncio.create_subprocess_exec(
+                    sys.executable, "-c", CHILD,
+                    stdin=f, stdout=asyncio.subprocess.PIPE)
+                ready = await asyncio.wait_for(proc.stdout.readline(), 30)
+                assert ready.strip() == b"READY", ready
+                time.sleep(BLOCK)          # blocks the whole event loop
+                out = await proc.stdout.read()
+                await proc.wait()
+            finally:
+                f.close()
+                os.unlink(path)
+            return out.decode().strip()
+
         proc = await asyncio.create_subprocess_exec(
             sys.executable, "-c", CHILD,
             stdin=asyncio.subprocess.PIPE, stdout=asyncio.subprocess.PIPE)
@@ -214,25 +252,21 @@ def test_only_both_halves_deliver_the_prompt_in_time(hoisted, threaded,
                 proc.stdin.write(b"x" * 1024)
                 await proc.stdin.drain()
             except (BrokenPipeError, ConnectionResetError):
-                pass                      # child already gone — the D case
+                pass                      # child already gone
             finally:
                 try:
                     proc.stdin.close()
                 except Exception:
                     pass
 
-        feeder = asyncio.create_task(feed()) if hoisted else None
-        if threaded:
-            await asyncio.to_thread(time.sleep, BLOCK)
-        else:
-            time.sleep(BLOCK)             # blocks the whole event loop
-        if feeder is None:
-            feeder = asyncio.create_task(feed())
-
+        # Hoisted feeder AND nothing else awaited first — i.e. the most
+        # favourable arrangement the pipe transport ever had. It still loses.
+        feeder = asyncio.create_task(feed())
+        time.sleep(BLOCK)
         out, _ = await asyncio.gather(proc.stdout.read(), feeder)
         await proc.wait()
         return out.decode().strip()
 
     got = asyncio.run(scenario())
     assert got == ("GOT" if expect_delivered else "TIMEOUT"), (
-        f"hoisted={hoisted} threaded={threaded} -> {got}")
+        f"transport={transport} -> {got}")

--- a/tests/test_task_file_globbing.py
+++ b/tests/test_task_file_globbing.py
@@ -172,3 +172,41 @@ class TestUnreachableTaskReferences:
         monkeypatch.setenv("HOME", str(home))
         assert leerie._unreachable_task_references(
             "see ~/plan.md for details") == []
+
+    # --- the reference must come back CLEAN (N33) ------------------------
+    #
+    # It is rendered straight into an operator warning, so trailing sentence
+    # punctuation makes them go looking for a path that was never written.
+    # Same class as `_parse_touched_file_line`'s `None.` defect: punctuation
+    # the tokenizer never stripped.
+
+    def test_reference_ending_a_sentence_has_no_trailing_period(self):
+        assert leerie._unreachable_task_references(
+            "See /etc/nonexistent-leerie-thing.conf.") == [
+                "/etc/nonexistent-leerie-thing.conf"]
+
+    def test_backticked_reference_keeps_no_backtick_or_period(self):
+        """The incident's exact shape: a backticked path ending a sentence.
+        The two pre-existing strips run in a fixed order, so the backtick is
+        unreachable behind the period unless it is rstripped."""
+        assert leerie._unreachable_task_references(
+            "Specs live in `~/.claude/plans/so-we-have-to-giggly-gray.md`."
+        ) == ["~/.claude/plans/so-we-have-to-giggly-gray.md"]
+
+    def test_parenthesised_reference_is_clean(self):
+        assert leerie._unreachable_task_references(
+            "(see ~/.claude/plans/nope-not-here.md)") == [
+                "~/.claude/plans/nope-not-here.md"]
+
+    def test_a_leading_dot_is_never_stripped(self, tmp_path, monkeypatch):
+        """rstrip, never strip. `.env`, `.github/...`, `./x` and `../x` are
+        all real paths whose LEADING dot is meaningful -- a two-sided strip
+        mangles every one of them, measured on the sibling defect.
+
+        Driven through an absolute path so the token actually reaches the
+        collector (only `/`- and `~`-prefixed tokens do), which is what makes
+        this observable rather than vacuous.
+        """
+        assert leerie._unreachable_task_references(
+            "check /nonexistent-leerie-root/.github/workflows/ci.yml.") == [
+                "/nonexistent-leerie-root/.github/workflows/ci.yml"]


### PR DESCRIPTION
Closes the three gaps left after #199, each measured on a real run.

## 1. The stdin race is not fixed by #198

`claude -p` drops its stdin listener 3 s after spawn — `r6r(process.stdin,3000)`, read out of the shipped bundle rather than taken from a comment. A late write is discarded and the worker dies `Input must be provided`.

#198 hoisted the write into a task and moved the broker calls off the loop. That **narrowed the window without closing it**: delivery still depended on the event loop *scheduling* that task within 3 s. Run `c5f16fe2`, started 18 h after 0.17.0 was tagged, hit it 22 times and lost 3 subtasks — then lost 5 more on resume.

Measured A/B, identical parent, only the transport varying, under synchronous bursts on the parent loop (the shape `_read_stream` produces parsing several workers' JSON at once):

| loop burst | pipe + feeder | staged file |
|---|---|---|
| 400 ms | **20/20 prompts LOST** | 0/20 |
| 900 ms | **20/20 prompts LOST** | 0/20 |
| 900 ms + 320 hogs (load 97) | — | 0/20 |

Raw CPU contention never reproduced it — 96 hogs on 32 cores cost 0/40 on **both** transports — so the mechanism is loop-blocking, not a busy host. That also corrects the framing in earlier notes.

`_invoke` now stages the prompt to a temp file before the spawn and hands the child that file: the first byte is readable at `exec`, so there is no writer to schedule and no deadline to lose. Two assumptions were checked rather than trusted — the deadline is real in the bundle, and the CLI **accepts a regular file** (it passes the stdin gate and fails on auth instead). The second matters: the CLI's own error text says *"a pipe or /dev/null"* and never mentions a file.

## 2. `accept-blocked` refused the one case that occurs

The gate resolved the `blocked` registry *after* a `cur is None` early-exit. So a subtask in that registry with **no** `subtask_status` entry — the single real disagreement across the run corpus, left by a checkpoint rejected before a status was ever written — was refused, while only the value-mismatch case, which never occurred, was accepted.

The registry is now resolved first. `--force` settles a subtask abandoned mid-flight (`in_progress`, no registry entry — what ENOSPC/SIGKILL leaves behind), validated against `waves` so a typo cannot mint a bogus entry.

## 3. Unreachable-reference warnings rendered mangled paths

`` `~/plans/x.md`. `` — the form an operator would then go looking for. Trailing sentence punctuation is now `rstrip`ped; never `strip`, which mangles `.env`, `./x` and `.github/…` (measured on the sibling `_parse_touched_file_line` defect).

## Found while auditing the above

- **`os.write` may short-write** — would have delivered a *truncated* prompt silently, worse than the bug being fixed. Now `os.fdopen(...).write()`.
- **A failed spawn stranded its staged file.** It is created before the try that reaps it, and `create_subprocess_exec` is a fork: under `pids.max` exhaustion it raises EAGAIN and every retry leaked ~150 KB into the disk exhaustion N30 exists to prevent.
- **`--force` reached only 3 of 5 invocation sites**, leaving it silently ignored on Fly and EC2 — the same partial-fix shape `test_resolve_aws_launcher.py` documents for `_resolve_ec2_knob`. Now wired everywhere, with a guard.

## Verification

362 targeted tests pass (1 pre-existing tree-sitter skip). Every guard is falsified, each confirmed to actually change the code first:

| sabotage | tests that fire |
|---|---|
| revert stdin to PIPE | 5 |
| restore the gate ordering | 1 (the incident case) |
| remove the rstrip | 3 |
| un-wire one transport | 1 |

`tests/test_stdin_feeder_ordering.py` is repointed rather than deleted — it now asserts the property *negatively* (no writer task, no `proc.stdin.write`, stdin never a PIPE), because that is the form a regression takes.

Full suite left to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)