### PR TITLE
fix: correct the --force validation claim; drop unreachable stdin mocks

### DIFF
--- a/docs/IMPLEMENTATION.md
+++ b/docs/IMPLEMENTATION.md
@@ -7974,8 +7974,12 @@ subtask.
   no registry entry, what a hard crash (ENOSPC, SIGKILL) leaves behind and
   which neither field can express as blocked. It bypasses both status
   checks, so it validates the sid against the scheduled set (`waves`) to
-  stop a typo minting a bogus `subtask_status` entry. The default stays
-  strict, keeping `--force` a deliberate operator act. Pinned in
+  stop a typo minting a bogus `subtask_status` entry — **when `waves` is
+  present**, which is every run where a subtask can be blocked or
+  abandoned, since `waves` is populated at scheduling and nothing can be
+  abandoned before then. Legacy or pre-scheduling state carries no `waves`
+  and degrades open rather than refusing a legitimate accept. The default
+  stays strict, keeping `--force` a deliberate operator act. Pinned in
   `tests/test_accept_blocked.py` (absent-key accepted, neither-field still
   refused, forced-abandoned accepted, forced-typo refused).
 

--- a/leerie
+++ b/leerie
@@ -1690,7 +1690,11 @@ in_registry = isinstance(bl, dict) and sid in bl
 # --force settles a subtask abandoned mid-flight: `in_progress` with no
 # registry entry, which is what a hard crash (ENOSPC, SIGKILL) leaves behind
 # and which neither field can express as "blocked". Validated against the
-# scheduled sid set, so a typo cannot mint a bogus status entry.
+# scheduled sid set (waves) WHEN PRESENT — which is every run where a
+# subtask can be blocked or abandoned, since waves is populated at
+# scheduling and nothing can be abandoned before then. Legacy or
+# pre-scheduling state carries no waves and degrades open rather than
+# refusing a legitimate accept.
 if force:
     known = {s for wave in (st.get("waves") or []) for s in wave}
     if known and sid not in known:

--- a/tests/test_argv_stdin_transport.py
+++ b/tests/test_argv_stdin_transport.py
@@ -258,28 +258,17 @@ class _MockStream:
         return line
 
 
-class _MockStdinWriter:
-    def __init__(self):
-        self.written = b""
-        self.closed = False
-
-    def write(self, data: bytes):
-        self.written += data
-
-    async def drain(self):
-        pass
-
-    def close(self):
-        self.closed = True
-
-
 class _MockProc:
     def __init__(self, stdout_lines, returncode: int = 0):
         self.stdout = _MockStream(stdout_lines)
         self.stderr = _MockStream([])
         self.returncode = returncode
         self.pid = 999_999_997
-        self.stdin = _MockStdinWriter()
+        # Always None: the prompt is staged to a file before the spawn, so
+        # the child is never handed a writable stdin. A mock that modelled
+        # one would imply `_invoke` still writes to the child after exec —
+        # the transport this suite exists to prove was replaced.
+        self.stdin = None
 
     def kill(self):
         pass

--- a/tests/test_prompt_over_stdin.py
+++ b/tests/test_prompt_over_stdin.py
@@ -237,29 +237,17 @@ class _MockStream:
         return line
 
 
-class _MockStdinWriter:
-    def __init__(self):
-        self.written = b""
-        self.closed = False
-
-    def write(self, data: bytes):
-        self.written += data
-
-    async def drain(self):
-        pass
-
-    def close(self):
-        self.closed = True
-
-
 class _MockProc:
-    def __init__(self, stdout_lines: list[str], returncode: int = 0,
-                 with_stdin: bool = False):
+    def __init__(self, stdout_lines: list[str], returncode: int = 0):
         self.stdout = _MockStream(stdout_lines)
         self.stderr = _MockStream([])
         self.returncode = returncode
         self.pid = _MOCK_PID_SENTINEL
-        self.stdin = _MockStdinWriter() if with_stdin else None
+        # Always None: the prompt is staged to a file before the spawn, so
+        # the child is never handed a writable stdin. A mock that modelled
+        # one would imply `_invoke` still writes to the child after exec —
+        # the transport this suite exists to prove was replaced.
+        self.stdin = None
 
     def kill(self):
         pass
@@ -302,7 +290,7 @@ def test_invoke_passes_a_readable_file_when_stdin_data_given(
             captured["content"] = handed.read()
         events = [json.dumps({"type": "result", "subtype": "success",
                               "is_error": False})]
-        return _MockProc(events, with_stdin=False)
+        return _MockProc(events)
 
     monkeypatch.setattr("asyncio.create_subprocess_exec", fake)
     payload = "hello prompt"
@@ -328,7 +316,7 @@ def test_invoke_still_uses_devnull_when_no_stdin_data(leerie, leerie_dir,
         captured.update(kwargs)
         events = [json.dumps({"type": "result", "subtype": "success",
                               "is_error": False})]
-        return _MockProc(events, with_stdin=False)
+        return _MockProc(events)
 
     monkeypatch.setattr("asyncio.create_subprocess_exec", fake)
     asyncio.run(leerie._invoke(
@@ -357,7 +345,7 @@ def test_full_payload_is_on_disk_before_the_child_exists(
         seen["at_spawn"] = handed.read()
         events = [json.dumps({"type": "result", "subtype": "success",
                               "is_error": False})]
-        return _MockProc(events, with_stdin=False)
+        return _MockProc(events)
 
     monkeypatch.setattr("asyncio.create_subprocess_exec", fake)
     payload = "p" * 150_063  # the incident's exact overflow size
@@ -378,7 +366,7 @@ def test_prompt_file_is_cleaned_up(leerie, leerie_dir, monkeypatch):
         paths.append(kwargs["stdin"].name)
         events = [json.dumps({"type": "result", "subtype": "success",
                               "is_error": False})]
-        return _MockProc(events, with_stdin=False)
+        return _MockProc(events)
 
     monkeypatch.setattr("asyncio.create_subprocess_exec", fake)
     asyncio.run(leerie._invoke(


### PR DESCRIPTION
Two follow-ups to #200, both found by auditing it rather than by a failure.

## 1. A comment promised an invariant the code does not provide

The comment I added in #200 read:

> `# Validated against the scheduled sid set, so a typo cannot mint a bogus status entry.`

The guard is `if known and sid not in known`, so when `waves` is absent or empty the validation is **skipped**. "cannot" is too strong, and the same wording reached `docs/IMPLEMENTATION.md`.

**No behavioural impact.** `waves` is `[]` only before scheduling (`orchestrator/leerie.py:23931`) and populated at `:24433`; a subtask cannot be blocked or abandoned until it has been scheduled, so every run where `--force` is meaningful has it. Legacy state degrades open rather than refusing a legitimate accept — the behaviour we want.

Verified by driving the real `_ab_mutate` program extracted from the launcher: `waves` absent → accepted; `waves: []` → accepted; already-`complete` → `NOOP`; `waves` populated + typo → refused.

## 2. The file transport left its mocks behind

#200 removed the feeder, which removed every reader of the mock's stdin state — but `_MockStdinWriter` and the `with_stdin` parameter stayed:

| file | state before this PR |
|---|---|
| `tests/test_prompt_over_stdin.py` | unreachable outright — 0 call sites passed `with_stdin=True`, default `False` |
| `tests/test_argv_stdin_transport.py` | constructed on every mock, never inspected |

Now `self.stdin = None`, with a comment saying why. A mock that models a writable stdin asserts *structurally* that the code under test writes to the child after exec. It does not — so the next person adding a test reaches for `with_stdin=True`, models a transport that no longer exists, and gets a test that passes while proving nothing. That is the failure mode this suite's own notes catalogue repeatedly.

`tests/test_no_dead_functions.py` cannot catch it: it scans `orchestrator/leerie.py` for private module-level functions, not tests.

Deliberately untouched: `test_stdin_feeder_ordering.py`'s pipe branch, which models the losing transport on purpose against a real subprocess.

## Verification

Comment, doc, and dead-scaffolding removal only — no production logic changed. `bash -n leerie` clean; `test_accept_blocked.py` 20/20; `test_prompt_over_stdin.py` + `test_argv_stdin_transport.py` + `test_stdin_feeder_ordering.py` 27/27. Net −23 lines across two test files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
