### PR TITLE
fix: correct a false claim in #207, and stop duplicating the args harness

### DIFF
--- a/.github/workflows/syntax.yml
+++ b/.github/workflows/syntax.yml
@@ -13,14 +13,24 @@ on:
   push:
     branches: [main]
     paths:
+      # chain/ and scripts/ are here because the undefined-name scan reads
+      # them; a filter narrower than the check it gates lets a PR touching
+      # only those paths skip the fast job (test.yml still runs the suite).
       - 'orchestrator/**/*.py'
       - 'tests/**/*.py'
+      - 'chain/**/*.py'
+      - 'scripts/**/*.py'
       - '.github/workflows/syntax.yml'
   pull_request:
     branches: [main]
     paths:
+      # chain/ and scripts/ are here because the undefined-name scan reads
+      # them; a filter narrower than the check it gates lets a PR touching
+      # only those paths skip the fast job (test.yml still runs the suite).
       - 'orchestrator/**/*.py'
       - 'tests/**/*.py'
+      - 'chain/**/*.py'
+      - 'scripts/**/*.py'
       - '.github/workflows/syntax.yml'
 
 concurrency:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3081,11 +3081,15 @@ walks the AST of `_run_phases`, because the obvious
 **The fresh-run branch of `_run_phases` had no execution coverage at all**
 until `tests/test_run_phases_fresh_init.py`, and v0.20.0 shipped a
 `NameError` in it that killed every non-resume run. Two structural reasons,
-both worth remembering when adding a guard here. First, only
+both worth remembering when adding a guard here. First, **every path that
+executed `_run_phases` did so with `resume=True`** — `resume=False` appeared
+nowhere under `tests/`, and no test executes `_orchestrate` either, so the
+branch that every real run takes was never run. Count the callers through the
+shared harness, not by grepping for the call: only
 `test_resume_planning_reentry.py` and `test_resume_planning_regression.py`
-execute `_run_phases`, and **both hardcode `resume=True`** — `resume=False`
-appeared nowhere under `tests/`, and no test executes `_orchestrate` either,
-so the branch that every real run takes was never run. Note
+contain one, but `test_checkpoint_aliasing.py` and `test_wiring_gate_resume.py`
+execute it too, via the `_drive` they import from the former — four files, one
+`resume` value. Note
 `test_wiring_gate_resume.py::test_fresh_run_invokes_the_gate` reuses that same
 `_args()`: "fresh" there means fresh *state*, not a fresh run, which is how
 the gap reads as covered. Second, the guard that did exist —
@@ -3105,9 +3109,16 @@ module scope nor `builtins` — ruff's F821 rule without the dependency, since
 pytest is the sole dev dependency here. Two traps are pinned by its own
 parametrized false-positive table, both of which a naive scan gets wrong: a
 `global X` + assignment **inside a function** binds the module name even when
-`X` never appears at module scope (leerie.py does this for `_STRICT_PROXY` and
-`_last_parse_error`), so the collector needs a pre-pass over every scope; and
-`__file__`/`__name__` are interpreter-injected, never assigned in source. The
+`X` appears at module scope nowhere else, so the collector needs a pre-pass
+over every scope; and `__file__`/`__name__` are interpreter-injected, never
+assigned in source. That pre-pass is **provably inert on this tree** — the scan
+returns `[]` with and without it — because every global leerie.py mutates under
+`global` is also bound at module scope (`_last_parse_error`, `_STRICT_PROXY`,
+both annotated assignments); it is kept because the rule must be right, and its
+own parametrized case is the only thing that fails without it. An earlier
+revision of this paragraph and of the file's own comment cited those two
+symbols as *evidence* the pre-pass was load-bearing, which is exactly
+backwards, and neither was re-derived before being written down. The
 positive control beside that table is mandatory — a scan returning `[]`
 unconditionally passes every negative case. Anti-vacuity is a canary injected
 into the **real** module rather than a synthetic snippet, so a refactor that

--- a/tests/test_no_undefined_names.py
+++ b/tests/test_no_undefined_names.py
@@ -40,8 +40,16 @@ _INTERPRETER_GLOBALS = frozenset({
 
 def undefined_names(source: str, filename: str) -> list[tuple[str, str]]:
     """Return `(scope_path, name)` for every name that would raise
-    `NameError` when its line executes."""
-    top = symtable.symtable(source, filename, "exec")
+    `NameError` when its line executes.
+
+    A file that does not parse is reported as a `<syntaxerror>` scope rather
+    than raising: this runs over every `.py` in the repo, and an escaping
+    `SyntaxError` fails the whole scan as a bare traceback that names no file.
+    """
+    try:
+        top = symtable.symtable(source, filename, "exec")
+    except SyntaxError as e:
+        return [("<syntaxerror>", f"{e.msg} (line {e.lineno})")]
 
     bound = set(dir(builtins)) | set(_INTERPRETER_GLOBALS)
     for sym in top.get_symbols():
@@ -51,10 +59,19 @@ def undefined_names(source: str, filename: str) -> list[tuple[str, str]]:
             bound.add(sym.get_name())
 
     # A `global X` + assignment inside any function binds the module-level
-    # name too, and X need not appear at module scope at all — leerie.py
-    # mutates module state this way (`_STRICT_PROXY`, `_last_parse_error`).
+    # name even when X appears at module scope nowhere else, so a scan that
+    # collects only module-scope bindings false-positives on every read of it.
     # Collected in a pre-pass because the binding scope can be walked after
     # the reading scope.
+    #
+    # PROVABLY INERT ON THIS TREE, and deliberately kept: run the scan with
+    # and without this pre-pass and the real module yields [] both ways. Every
+    # module global leerie.py mutates under `global` is ALSO bound at module
+    # scope (`_last_parse_error` at :9093, `_STRICT_PROXY` at :13070, both
+    # annotated assignments), which is the ordinary shape. The pattern this
+    # guards is real Python that this repo simply does not contain today —
+    # `test_no_false_positives[global declared then assigned]` is the only
+    # thing exercising it, and that case fails without the pre-pass.
     def collect_globals(table: symtable.SymbolTable) -> None:
         for sym in table.get_symbols():
             if sym.is_global() and sym.is_assigned():
@@ -167,3 +184,12 @@ def test_a_genuinely_undefined_name_is_reported():
     it, a scan that returns `[]` unconditionally passes all of them."""
     assert undefined_names(
         "def f():\n    return nope\n", "x.py") == [("f", "nope")]
+
+
+def test_an_unparseable_file_is_reported_not_raised():
+    """Guards the failure *message*, not coverage: `ast.parse` in the same
+    workflow already fails on such a file, but an escaping SyntaxError here
+    would take down the whole-repo scan without naming the file."""
+    found = undefined_names("def f(:\n", "broken.py")
+    assert len(found) == 1
+    assert found[0][0] == "<syntaxerror>"

--- a/tests/test_run_phases_fresh_init.py
+++ b/tests/test_run_phases_fresh_init.py
@@ -34,47 +34,24 @@ from __future__ import annotations
 import asyncio
 import json
 import subprocess
-from pathlib import Path
-from types import SimpleNamespace
 
 import pytest
+
+# The single owner of the args/caps harness, imported in the same form as
+# tests/test_checkpoint_aliasing.py and tests/test_wiring_gate_resume.py.
+# A local copy would be a third one, which is the duplication class this repo
+# has been bitten by repeatedly (see the launcher-block and state-walk guards).
+# `resume=False` is passed at each call site rather than defaulted here, so
+# the branch under test is stated where it is exercised. The keys this file's
+# path additionally reads (subtask_tests, skip_coverage_check,
+# skip_completeness_check, skip_integration_check) are all `getattr(...,
+# default)` reads and need no entry in the shared dict.
+from tests.test_resume_planning_reentry import _args, _caps
 
 
 class _ReachedCgroupGate(Exception):
     """Raised by the stubbed containment gate — the first call after the
     fresh-run state seed has been evaluated and saved."""
-
-
-def _args(**overrides) -> SimpleNamespace:
-    base = dict(
-        resume=False,
-        task="a trivial task",
-        answers=None,
-        clarify=False,
-        dangerously_skip_permissions=False,
-        skip_overlap_judge=False,
-        skip_adherence_check=False,
-        skip_satisfied_check=False,
-        skip_budget_check=True,
-        skip_coverage_check=False,
-        skip_completeness_check=False,
-        skip_integration_check=False,
-        strict_conformer=False,
-        skip_base_baseline=False,
-        skip_repo_map=False,
-        dangerously_allow_uncapped=True,
-        skip_smoke=True,
-        no_push=False,
-        pr_template=None,
-        host_no_push=None,
-        pr_base_branch=None,
-        group_id=None,
-        inspect_dirs=[],
-        no_verify=False,
-        subtask_tests=None,
-    )
-    base.update(overrides)
-    return SimpleNamespace(**base)
 
 
 @pytest.fixture
@@ -109,10 +86,12 @@ def _drive(leerie, monkeypatch, fresh_repo, **arg_overrides):
     monkeypatch.setattr(
         leerie, "_enforce_and_record_cgroup_containment", _boom)
 
+    args = _args(resume=False, task="a trivial task", **arg_overrides)
+
     reached = False
     try:
         asyncio.run(leerie._run_phases(
-            _args(**arg_overrides), dict(leerie.DEFAULT_CAPS), leerie_root,
+            args, _caps(leerie), leerie_root,
             st, "both", "quiet", {}, {}))
     except _ReachedCgroupGate:
         reached = True
@@ -192,5 +171,5 @@ def test_fresh_branch_is_actually_the_one_under_test(leerie, monkeypatch,
 
     with pytest.raises(SystemExit):
         asyncio.run(leerie._run_phases(
-            _args(resume=True), dict(leerie.DEFAULT_CAPS), leerie_root, st,
+            _args(resume=True), _caps(leerie), leerie_root, st,
             "both", "quiet", {}, {}))


### PR DESCRIPTION
> **Correction (added after merge).** This description originally said *"duplicated 21 of its 24 keys"* and *"61 tests"*. Both were wrong: reentry's `_args` has **21** keys and my copy had **25**; the five files named collect **44** tests, and 61 was the output of a six-file invocation. Corrected in #209, which is where the permanent record lives — the body below is edited only so the page does not keep showing a number known to be false.

Post-merge audit of #207 (v0.20.1). **The fix it shipped is correct** — re-verified: `st.repo_root` is the value `main()` derives, the scan reports zero findings across 455 files, reverting the one word still fails the same 5 tests. These are defects in what surrounds it.

## A claim I wrote down was false

CLAUDE.md and the comment in `tests/test_no_undefined_names.py` both justified the collect-globals pre-pass with *"leerie.py mutates module state this way (`_STRICT_PROXY`, `_last_parse_error`)"*. Both are bound at module scope by ordinary annotated assignments (`:9093`, `:13070`) — cited as evidence for the opposite of what they show.

Measured both ways this time: with and without the pre-pass the real module yields `[]` identically (**provably inert on this tree**); disabling it fails exactly one test, its own parametrized case. The pre-pass stays — the pattern is real Python and the rule must be right — but it's now documented as inert here.

#207's commit message carries the original claim and can't be rewritten, so the correction is in *this* commit message, per CLAUDE.md's "commit messages are the permanent record".

## A third copy of `_args`

`test_resume_planning_reentry.py` is the single owner (imported by `test_checkpoint_aliasing.py` and `test_wiring_gate_resume.py`); my file duplicated all 21 of its keys and added 4 (my copy had 25). No guard covers `_args`, so nothing failed — which is the argument for the convention. Now imported like the other two consumers, with `resume=False` at each call site.

Since that rewrites the harness the regression depends on, **falsification was re-run against it**: same 5 failures, and the three existing consumers plus both new files pass together (44 tests).

## Two smaller corrections

- CLAUDE.md said only two files execute `_run_phases`; four did (two contain the call, two reach it via the imported `_drive`), and the present-tense sentence went stale the moment a fifth landed.
- `syntax.yml` triggered on `orchestrator/**` and `tests/**` while the scan it runs also reads `chain/**` and `scripts/**` (6 files). Never a hole — `test.yml` has no path filter — but the fast job now covers what its own check reads.
- The scan no longer lets a `SyntaxError` escape; an unparseable file is a named offender instead of a bare traceback.

## Verification

No orchestrator change, so **no release needed**. 18 tests across the two files; full suite **6769 passed, 84 skipped, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
