### PR TITLE
docs: fix two sentences that contradicted the things they pointed at

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3097,7 +3097,9 @@ the gap reads as covered. Second, the guard that did exist —
 `test_orchestrator_owns_blt.py::test_subtask_tests_is_seeded_on_both_run_init_branches`
 — is a key-presence AST walk, and **it passed against the broken code**: the
 key was in the dict literal, only its value expression was unevaluatable.
-Presence is not evaluation, and no AST walk of a literal can be. The new file
+Presence is not evaluation: a walk that checks a key exists says nothing about
+whether that key's value resolves, which takes either execution or scope
+resolution (the symtable scan below does the latter statically). The new file
 executes the branch, stopping at a sentinel on
 `_enforce_and_record_cgroup_containment` (the first call after the seed's
 `st.save()`, so no other stub is needed), and carries the guard-the-guard test

--- a/tests/test_no_undefined_names.py
+++ b/tests/test_no_undefined_names.py
@@ -1,8 +1,9 @@
 """No name in this repo's Python may be undefined at the point it is read.
 
-`ast.parse` — CLAUDE.md's task-completion static check, and the whole of
+`ast.parse` — CLAUDE.md's task-completion static check, and the first step of
 `.github/workflows/syntax.yml` — cannot see this class: an undefined name is
-syntactically perfect and fails only when the line executes. v0.20.0 shipped
+syntactically perfect and fails only when the line executes. That workflow's
+second step is this file, for exactly that reason. v0.20.0 shipped
 `NameError: name 'repo_root' is not defined` in the fresh-run branch of
 `_run_phases`, which the suite could not catch either (no test executed that
 branch; see `tests/test_run_phases_fresh_init.py`), and which a one-second

--- a/tests/test_run_phases_fresh_init.py
+++ b/tests/test_run_phases_fresh_init.py
@@ -22,7 +22,11 @@ Nothing in the suite could see it, for two independent reasons:
    `test_orchestrator_owns_blt.py::test_subtask_tests_is_seeded_on_both_run_init_branches`
    asserts the *key* appears in both branches. It passed on the broken code:
    the key was there, only the expression was unevaluatable. Presence is not
-   evaluation, and no AST walk can be.
+   evaluation: a walk that checks a key exists says nothing about whether that
+   key's value resolves. Establishing *that* takes either execution — this
+   file — or scope resolution, which is what the companion below does
+   statically. A walk over the dict literal supplies neither, which is why it
+   passed while the branch it certified was dead.
 
 So this file exists to *run* the branch. The sentinel goes on
 `_enforce_and_record_cgroup_containment`, which is the first call after the
@@ -57,7 +61,8 @@ import pytest
 #
 # No key counts in either sentence on purpose: those are properties of the
 # current tree and rot silently, unlike a measurement of a past event. The
-# figures live in this change's commit message, where they describe a moment.
+# figures live in the commit that removed them (#209), where they describe a
+# moment rather than a claim about the tree you are reading.
 #
 # `resume=False` is passed at each call site rather than defaulted here, so
 # the branch under test is stated where it is exercised. The keys this file's


### PR DESCRIPTION
Fourth audit pass over the #207 → #209 chain. **Prose only** — nothing under `orchestrator/` changes, so v0.20.1 stands. Two of these are false statements, not wording, and one survived three prior audits.

## `ast.parse` was called "the whole of `syntax.yml`"

That workflow has had **two** steps since #207: the AST parse, and `pytest tests/test_no_undefined_names.py`. The docstring said the workflow consists entirely of a check that cannot catch this class — while the workflow runs *that very file* to catch it.

False on arrival: `git log -S"the whole of"` dates it to `09edc37`, the same commit that added the second step.

## "no AST walk can be" was refuted by the next paragraph

Eight lines below it, the file points at its companion — a symtable scan that catches exactly this defect **without executing anything**. CLAUDE.md's copy sat in a paragraph describing that same scan.

Static analysis *can* catch it. What can't is a walk over the dict literal checking a key is present: that says nothing about whether the key's value resolves, which needs either execution (the fresh-init test) or scope resolution (the companion). Both documents now state the narrow version, and both moved together.

## A reference that decayed on merge

"The figures live in **this change's** commit message" named nothing once merged; now names #209. Same failure mode as the present-tense enumeration fixed in round three.

## Closed outside the tree

#208's description still showed the two figures its successor corrected. The commit message is the record under squash-merge, but the PR page is what people read — edited via the REST endpoint (`gh pr edit` fails against the deprecated Projects API) with a note stating what was wrong and pointing at #209.

## Verification

18 tests over exactly the two touched files; `test_claude_md_ordinals.py` 3 passed (run explicitly, since this edits CLAUDE.md prose); full suite **6769 passed, 84 skipped, 0 failed** serial. Both edited paragraphs re-read in place rather than as a diff — both defects were only visible in context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)