### PR TITLE
fix: make forced constrained decoding reach every worker, and unbreak the rebaser

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -5547,6 +5547,27 @@ networking, and the container boundary reaps it if the run dies abnormally. The
 port is chosen by binding to `0` and reading back what the OS assigned, so
 concurrent leerie runs on one host never collide and no port scan is needed.
 
+The guarantee is per-*call*, not per-orchestrator-process. Three entrypoints
+invoke workers without ever reaching `_orchestrate()`, so each opens its own
+proxy around its own calls rather than sharing the main run's:
+
+- `run_rebaser` and `run_recapture_deps` — host-seam entrypoints (§6
+  *Finalization*, §6½) that run in their own separate, short-lived `python3`
+  process. They cannot re-derive the flag from CLI args, which never cross
+  that process boundary, so they read the value `_orchestrate()` already
+  resolved and persisted onto the run's own state.
+- `--phase heal` — returns before `_orchestrate()` is reached, so the replays
+  its heal loop drives would otherwise be unconstrained. It runs inside
+  `main()`, where the resolved flag is already in hand.
+
+Before this, all three silently ran unconstrained regardless of the flag: the
+guarantee held for every worker `_orchestrate()` itself drove, and for none
+of the workers reached any other way. Because these three are best-effort
+paths — none may block a push, abort a multi-run loop, or fail a heal — their
+proxies fail *soft* rather than following §7's fail-closed startup rule
+below: a listener that cannot bind costs the guarantee for that call, not the
+call itself.
+
 The proxy rewrites exactly one thing: on a request carrying a single tool named
 `StructuredOutput`, it sets `strict: true` and normalises the schema to the
 subset grammar compilation accepts — `additionalProperties: false` on every

--- a/docs/IMPLEMENTATION.md
+++ b/docs/IMPLEMENTATION.md
@@ -3649,6 +3649,65 @@ reach it via `ANTHROPIC_BASE_URL` injected into `worker_env`. The orchestrator
 is PID 1 in the container and workers are its children, so loopback needs no
 port mapping.
 
+**Three entrypoints get their own instance, not `_orchestrate()`'s.** The
+module-level `_STRICT_PROXY` global is what `_invoke` actually gates on
+(`if _STRICT_PROXY is not None` — never `caps["force_strict_output"]`, which
+only `_orchestrate` and `main`'s collision guards read). Any path that
+invokes a worker without `_orchestrate` having run therefore sees no proxy:
+
+| entrypoint | why it misses `_orchestrate` | where the flag comes from |
+|---|---|---|
+| `run_rebaser` | separate `python3` process (`scripts/host-finalize.sh`'s heredoc, §6) | `st.data["dangerously_force_strict_output"]` |
+| `run_recapture_deps` | separate `python3` process (`./leerie config --recapture`'s seam, §6½) | same, re-read per `target_run_dir` |
+| `main()`'s `--phase heal` branch | `return`s before `_orchestrate()` is called | `caps` — already resolved in `main()` |
+
+All three wrap their worker call in the shared
+`_strict_output_proxy(caps, label)` async context manager (defined beside
+`_StrictOutputProxy`), which constructs, starts, and tears down one
+short-lived instance scoped to that call. The two host-seam entrypoints
+cannot call `resolve_dangerously_force_strict_output` meaningfully — the CLI
+flag never crosses the process boundary, only `state.json` does — so they
+read the value `_orchestrate()` already persisted for that exact run
+(§ *State fields*), falling back to a CLI-blind resolve only for a
+`state.json` predating that field. The heal branch needs no such read: it is
+still inside `main()`, which resolved the flag (and passed `main()`'s
+`ANTHROPIC_BASE_URL`/Bedrock collision guards) before the branch runs.
+`_replay_capture`, which the heal loop drives, deliberately needs **no**
+wiring of its own: it inherits whatever proxy is ambient, which is why
+rebuilding its `caps` from `DEFAULT_CAPS` is harmless here.
+
+The helper fails **soft in both directions**, deliberately departing from
+`_orchestrate`'s fail-closed startup rule (DESIGN §7) because all three
+callers are best-effort paths that must never block a push (`run_rebaser`'s
+own contract), abort multi-run consolidation, or fail a heal: a `start()`
+`OSError` logs and proceeds unconstrained, and a `stop()` failure is caught,
+logged, and swallowed rather than escaping the `finally` — where it would
+neither be caught by the caller's own `try` (a `finally`-raised exception
+bypasses its own handlers) nor leave an already-valid result intact. The
+global is reset unconditionally either way, which `run_recapture_deps`
+depends on per loop iteration: a stale non-`None` value would silently route
+the next target run through the previous run's closed proxy, even a run whose
+own state has the flag off. `run_recapture_deps` additionally keeps a broad
+guard *around* `asyncio.run` as well as inside it, since proxy construction
+sits outside the inner guard and a setup failure must not abort the whole
+consolidation.
+
+Before this wiring, all three built their own `caps` with no
+`force_strict_output` key, so every worker they invoked ran unconstrained no
+matter the flag. In production this surfaced as the rebaser's nullable
+`diagnosis` field (`SCHEMAS["rebaser"]`) reliably producing a bare,
+unparseable token instead of the literal `null` under unconstrained
+`--json-schema`, exhausting all 5 structured-output retries on effectively
+every rebase — non-fatal (finalize falls through to pushing `run_branch`
+un-rebased), but the intended rebase-onto-latest-base step silently never
+ran. `SCHEMAS["rebaser"]["diagnosis"]` was also independently narrowed from
+`["string", "null"]` to plain `"string"` (the prompt's own convention is
+already "empty string" for "nothing to diagnose") — the schema fix and the
+proxy-wiring fix are independent and compose; either alone closes this
+specific failure, together they also protect any other nullable field these
+entrypoints' schemas may gain later. `tests/test_strict_output_proxy.py`'s
+`TestStrictOutputReachesEveryEntrypoint` pins all three, structurally.
+
 **Upstream read timeout.** `_StrictOutputProxy(max_parallel, verbosity,
 upstream_timeout_sec)`, applied to the `urlopen` that forwards each request
 and floored at the module constant `_STRICT_PROXY_TIMEOUT_SEC`.
@@ -8920,7 +8979,7 @@ written somewhere in `orchestrator/leerie.py`. The coupling test in
 | `source_of_truth_pref` | str | resolved preference (`codebase` / `research` / `both`) |
 | `clarify` | bool | whether asking the user is allowed for this run (resolved from `--clarify` / `LEERIE_CLARIFY` / `leerie.toml` / default `False`) |
 | `dangerously_skip_permissions` | bool | whether every `claude -p` worker — including the judgment workers running in the real repo cwd — is invoked with `--dangerously-skip-permissions`. Resolved from `--dangerously-skip-permissions` / `LEERIE_DANGEROUSLY_SKIP_PERMISSIONS` / `leerie.toml` / default `False`. When `True`, waives the DESIGN §12 mechanical read-only enforcement on the classifier / planner / reconciler / plan_overlap_judge / provision workers; trust shifts onto their prompts. Re-resolved fresh on every run, including `resume`, so the user can flip it without editing state |
-| `dangerously_force_strict_output` | bool | whether this run forced constrained decoding via the per-run loopback proxy (`--dangerously-force-strict-output` / `LEERIE_DANGEROUSLY_FORCE_STRICT_OUTPUT` / `dangerously_force_strict_output` in leerie.toml). Mirrored from `caps["force_strict_output"]`. Recorded because the flag changes worker behaviour invisibly — it owns `ANTHROPIC_BASE_URL`, which makes the CLI treat the session as gateway-routed and apply a conservative client-side context ceiling instead of the model's native window (see `_model_arg`). Without this field a run's failure cannot be attributed to the flag after the fact. |
+| `dangerously_force_strict_output` | bool | whether this run forced constrained decoding via the per-run loopback proxy (`--dangerously-force-strict-output` / `LEERIE_DANGEROUSLY_FORCE_STRICT_OUTPUT` / `dangerously_force_strict_output` in leerie.toml). Mirrored from `caps["force_strict_output"]`. Recorded because the flag changes worker behaviour invisibly — it owns `ANTHROPIC_BASE_URL`, which makes the CLI treat the session as gateway-routed and apply a conservative client-side context ceiling instead of the model's native window (see `_model_arg`). Originally attribution-only ("without this field a run's failure cannot be attributed to the flag after the fact"); now also load-bearing — `run_rebaser` and `run_recapture_deps` read it back from `st.data` to decide whether to wire their own per-call proxy instance, since they run in a separate process the original CLI flag never reaches (§ *Forced constrained decoding*). |
 | `skip_overlap_judge` | bool | whether the phase 2¾ `plan_overlap_judge` worker is suppressed even on multi-planner runs (DESIGN §5 *Cross-domain surface overlap*). Resolved from `--skip-overlap-judge` / `LEERIE_SKIP_OVERLAP_JUDGE` / `leerie.toml` / default `False`. The cheap-skip on single-planner / <2-subtask runs is automatic and not gated by this field — this flag only affects runs where the worker would otherwise fire. Re-resolved fresh on every run, including `resume`, so the user can flip it without editing state |
 | `skip_adherence_check` | bool | whether the instruction-adherence gate (the deterministic prescribed-command-coverage floor + the `adherence_judge` worker in the planner check loop) is suppressed. Resolved from `--skip-adherence-check` / `LEERIE_SKIP_ADHERENCE_CHECK` / `skip_adherence_check` in `leerie.toml` / default `False`. When True, a plan that diverges from an explicitly prescribed procedure is not caught before `phase_execute` spends. Re-resolved fresh on every run, including `resume`, so the user can flip it without editing state |
 | `skip_coverage_check` | bool | whether the phase 2⅞½ task-coverage gate (a single advisory `task_coverage_judge` invocation since 2026-08-04; the deterministic `check_required_items_coverage` floor it used to compose with was deleted) is suppressed. Resolved from `--skip-coverage-check` / `LEERIE_SKIP_COVERAGE_CHECK` / `skip_coverage_check` in `leerie.toml` / default `False`. When True, the review does not run at all — no gap is surfaced before `phase_execute` spends. Since the gate is advisory, this suppresses the report and its worker call, not a block. Added after run 488c42e5, where the judge counted a task item the task itself deferred as `missing_work` — unsatisfiable by any planner, with no operator override, unlike every sibling gate. Re-resolved fresh on every run, including `resume` |
@@ -9485,7 +9544,7 @@ enforcement functions:
 | `test_dockerfile_bake_from_capture.py` | Bake-from-persisted-installs path (distinct from `test_dockerfile_autogen.py`): launcher emits apt layer from `setup_packages` plus a `COPY`+`RUN` layer per `language_installs` entry with embedded `copy-input-shas` comment; `p.exists()` guard silently drops hallucinated `copy_input` paths from COPY while always emitting the RUN; all copy_inputs absent → RUN emitted, no COPY; multi-manager (pnpm+pip) → two COPY+RUN layers each with their own sha comment; pip install with only `requirements.txt` (no lockfile) → baked via persisted path, not lockfile fallback; identical regen → bit-identical Dockerfile (sha stable, no needless rebuild); changing `copy_input` file content → sha comment changes; committed `.leerie/Dockerfile` left untouched even when `language_installs` present; **node-ancillary augmentation on the persisted path — a pnpm entry whose `copy_inputs` omit `patches/` still emits `COPY patches/ ./patches/` (its own path-preserving line, never flattened into `./`) with the patch sha folded into the rebuild comment; a workspace child `packages/a/package.json` is COPYed to `./packages/a/package.json` (no basename clobber); a non-node (poetry) install ignores a `patches/` dir; the apt layer has no trailing `USER leerie`**; coupling tests that `persisted_installs`, `.exists()`, `copy-input-shas`, and `language_installs` sentinel strings exist in extracted launcher block |
 | `test_base_dockerfile_chromium.py` | Base image `./Dockerfile` (not the per-repo autogen one): asserts `chromium` and `chromium-driver` are installed and the three container flags (`--no-sandbox`, `--disable-setuid-sandbox`, `--disable-dev-shm-usage`) are baked into `/etc/chromium.d/leerie-container-flags` after the chromium install (ordering guard) — see *Browser-based testing* above |
 | `test_config_verb.py` | `leerie config` verb (Phase 3 bash-harness tests): `--init` creates `.leerie/config.toml` with auto-detected BLT values (uncommented) and a commented `setup_packages` example, prints the path, suggests `git add .leerie/`, and does NOT invoke `nerdctl run`; bare mode prints each axis with provenance (`[config]` vs `[inference]`) and shows `leerie.toml` keys when present; `--chat` invokes `claude --system-prompt-file prompts/config_chat.md --add-dir <USER_REPO>` (NOT `claude -p`) without `nerdctl run`; `--recapture` exits 1 with diagnostic when no runs directory or no finished run found, and dispatches to the python3 seam (`run_recapture_deps`) when a finished run exists; `--recapture --force` triggers wholesale replace; content assertions on `prompts/config_chat.md` (exists, mentions `build`/`lint`/`test`/`setup_packages` keys, `ARG BASE_IMAGE`, `config.toml`, `Dockerfile`; instructs ending at `USER root` and does NOT instruct a trailing `USER leerie`) and a parallel guard that `docs/USAGE.md`'s hand-authored `.leerie/Dockerfile` example likewise has no trailing `USER leerie`; coupling tests that verify the `config)` arm exists in the live launcher and exits before `nerdctl run`. Also covers the Dockerfile language-layer bake-from-persisted-installs logic (extracted Python heredoc invoked directly): persisted `language_installs` → COPY+RUN emitted per manager; hallucinated copy_inputs silently dropped while RUN always emitted; all copy_inputs missing → RUN without COPY; multi-manager → multiple COPY+RUN layers; no persisted installs → lockfile-detection fallback; empty `language_installs` list → lockfile fallback; no lockfile and no persisted installs → empty output; identical inputs → identical output (hash stability). |
-| `test_config_recapture.py` | `leerie config --recapture` LLM-seam dispatch and multi-run consolidation: launcher `--recapture` arm dispatches to the python3 seam; exits 1 with diagnostic when no runs directory or no finished run found; `--force` flag passed to the seam; python3 failure exits 1; no `nerdctl` invoked; `--recapture` arm within extraction boundary; `run_recapture_deps` consolidates across ≥2 finished runs (all captured, not just newest); `--force` drops sentinel on each run (wholesale replace semantics); without `--force` already-captured runs are skipped (never-clobber union); Dockerfile survivor tests (committed and generated) |
+| `test_config_recapture.py` | `leerie config --recapture` LLM-seam dispatch and multi-run consolidation: launcher `--recapture` arm dispatches to the python3 seam; exits 1 with diagnostic when no runs directory or no finished run found; `--force` flag passed to the seam; python3 failure exits 1; no `nerdctl` invoked; `--recapture` arm within extraction boundary; `run_recapture_deps` consolidates across ≥2 finished runs (all captured, not just newest); `--force` drops sentinel on each run (wholesale replace semantics); without `--force` already-captured runs are skipped (never-clobber union); Dockerfile survivor tests (committed and generated); per-run `dangerously_force_strict_output` in `state.json` wires (and, when unset, correctly skips) `run_recapture_deps`'s own `_StrictOutputProxy` instance around that run's `capture_repo_deps()` call; a raising `stop()` still resets the global so the next target run in the loop cannot inherit a closed proxy; a proxy *construction* failure is logged and skipped rather than aborting the whole consolidation |
 | `test_replay_capture.py` | `_replay_capture()` — args reconstructed from capture record, `override_system_prompt` plumbed through, no `calls.ndjson` written during replay, return-value shape `(envelope, structured_output)` |
 | `test_phase_judge.py` | `phase_judge()` / `_judge_capture()` — 3 verdicts written for 3-record NDJSON, INDEX.json content, schema validation, max_parallel semaphore bound, call_type filtering, empty/missing NDJSON edge cases |
 | `test_heal_loop.py` | `HealState` save/load round-trip + atomic write; `_heal_baseline()` — state.json + 6 verdict files for 2 samples n=3; `_heal_apply_patch()` — patched prompts written per sample under iter-1/; `_heal_replay_patched()` — history + best_so_far updated in state.json |

--- a/orchestrator/leerie.py
+++ b/orchestrator/leerie.py
@@ -46,7 +46,7 @@ import urllib.request
 import uuid
 import weakref
 from collections import deque
-from collections.abc import Awaitable, Callable, Iterator
+from collections.abc import AsyncIterator, Awaitable, Callable, Iterator
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import TextIO
@@ -11860,19 +11860,54 @@ def run_recapture_deps(
             continue
         target_st.load()  # non-fatal if state.json is missing (older runs)
 
+        # Same host-seam wiring gap as run_rebaser (see there): this
+        # entrypoint runs in its own process, never through
+        # _orchestrate()'s CLI-arg resolution or _STRICT_PROXY setup, so
+        # capture_repo_deps's claude_p() call always ran unconstrained
+        # regardless of the flag. Read the per-run value _orchestrate()
+        # already resolved and persisted into THIS run's own state (each
+        # target_run_dir may have been run with a different setting).
+        run_caps = dict(caps)
+        run_caps["force_strict_output"] = (
+            target_st.data["dangerously_force_strict_output"]
+            if "dangerously_force_strict_output" in target_st.data
+            else resolve_dangerously_force_strict_output(repo_root, False))
+
+        async def _capture_with_strict_output() -> bool:
+            async with _strict_output_proxy(run_caps, "recapture"):
+                try:
+                    await capture_repo_deps(
+                        repo_root, target_st,
+                        caps=run_caps, models=models, efforts=efforts,
+                        replace=force,
+                    )
+                    return True
+                # See the backstop guard above: TerminalAuthFailure /
+                # RateLimitedExit are BaseException subclasses that a bare
+                # `except Exception` misses. This must stay the innermost try
+                # DIRECTLY wrapping capture_repo_deps() —
+                # tests/test_capture_swallows_exit_signals.py AST-scans for
+                # exactly that shape and fails loudly if the guard and the
+                # call it guards ever drift apart.
+                except (Exception, TerminalAuthFailure, RateLimitedExit,
+                        ContextOverflow, DiskLowSpace) as exc:
+                    log(f"recapture: error during dep_capture for "
+                        f"{target_run_dir.name}: {exc}")
+                    return False
+
         log(f"recapture: scanning {target_run_dir / 'logs'} ...")
+        # The guard inside the coroutine covers the capture call itself; this
+        # one covers everything around it (proxy construction, a non-OSError
+        # from start(), asyncio.run itself). Without it a setup failure would
+        # abort the whole multi-run consolidation, breaking this function's
+        # "per-run errors are logged and skipped" contract.
         try:
-            asyncio.run(capture_repo_deps(
-                repo_root, target_st,
-                caps=caps, models=models, efforts=efforts,
-                replace=force,
-            ))
-            ran_any = True
-        # See the backstop guard above: TerminalAuthFailure / RateLimitedExit
-        # are BaseException subclasses that a bare `except Exception` misses.
+            if asyncio.run(_capture_with_strict_output()):
+                ran_any = True
         except (Exception, TerminalAuthFailure, RateLimitedExit,
                 ContextOverflow, DiskLowSpace) as exc:
-            log(f"recapture: error during dep_capture for {target_run_dir.name}: {exc}")
+            log(f"recapture: error during dep_capture for "
+                f"{target_run_dir.name}: {exc}")
 
     if not ran_any and not force:
         log("recapture: all eligible runs already captured (use --force to re-run)")
@@ -11950,6 +11985,19 @@ def run_rebaser(
         }
     st.load()
 
+    # This entrypoint runs in its own fresh python3 process
+    # (host-finalize.sh's heredoc), so it never goes through
+    # _orchestrate()'s CLI-arg resolution or _STRICT_PROXY setup — without
+    # this, claude_p() below always ran unconstrained regardless of the
+    # flag. Read the value _orchestrate() already resolved and persisted
+    # into this run's own state as the source of truth (the CLI flag
+    # itself never reaches this process); fall back to a fresh resolve
+    # only for old state.json files that predate this field.
+    caps["force_strict_output"] = (
+        st.data["dangerously_force_strict_output"]
+        if "dangerously_force_strict_output" in st.data
+        else resolve_dangerously_force_strict_output(repo_root, False))
+
     # Worker-budget pre-check (mirrors capture_repo_deps's identical guard
     # above): the run has already spent its budget across the whole
     # _orchestrate loop by the time finalize runs, so a rebaser call must
@@ -11988,22 +12036,27 @@ def run_rebaser(
         f"{working_branch}..{run_branch} — onto the fresh tip of "
         f"{pr_base_branch}. Do not touch any other branch."
     )
+
+    async def _call_with_strict_output() -> dict:
+        async with _strict_output_proxy(caps, "rebaser"):
+            return await claude_p(
+                user_prompt=user_prompt,
+                system_prompt=sys_prompt,
+                schema_key="rebaser",
+                cwd=str(worktree),
+                allowed_tools=ACT_TOOLS,
+                max_turns=60,
+                autonomous=True,
+                caps=caps,
+                st=st,
+                model=models.get("rebaser", MODEL_DEFAULT),
+                effort=efforts.get("rebaser"),
+                sid=f"rebaser-{run_id}",
+            )
+
     try:
         st.bump_workers(caps)
-        result = asyncio.run(claude_p(
-            user_prompt=user_prompt,
-            system_prompt=sys_prompt,
-            schema_key="rebaser",
-            cwd=str(worktree),
-            allowed_tools=ACT_TOOLS,
-            max_turns=60,
-            autonomous=True,
-            caps=caps,
-            st=st,
-            model=models.get("rebaser", MODEL_DEFAULT),
-            effort=efforts.get("rebaser"),
-            sid=f"rebaser-{run_id}",
-        ))
+        result = asyncio.run(_call_with_strict_output())
     # See run_recapture_deps's identical guard above: TerminalAuthFailure /
     # RateLimitedExit are BaseException subclasses a bare `except Exception`
     # would miss, and this call must never propagate past host-finalize.sh's
@@ -14104,6 +14157,80 @@ class _StrictOutputProxy:
             self._writers.discard(writer)
             with contextlib.suppress(Exception):
                 writer.close()
+
+
+@contextlib.asynccontextmanager
+async def _strict_output_proxy(caps: dict, label: str) -> AsyncIterator[None]:
+    """Run the enclosed block with `_STRICT_PROXY` live iff the flag is set.
+
+    `_orchestrate()` starts one proxy per run before its first worker and
+    closes it in its own `finally` (DESIGN §7). Three entrypoints never
+    reach that code and so need their own short-lived instance, or the flag
+    is silently inert for every worker they invoke: `run_rebaser` and
+    `run_recapture_deps` (each a separate host-seam `python3` process, where
+    the module-level global starts fresh at `None` regardless of config) and
+    `main()`'s `--phase heal` branch (which returns before `_orchestrate` is
+    called). `_invoke` gates purely on this global being non-None, so a
+    caller needs nothing beyond wrapping its own worker call in this.
+
+    Fails soft in BOTH directions, because all three callers are best-effort
+    paths that must never block a push or abort a multi-run loop: a `start()`
+    `OSError` logs and proceeds unconstrained (the guarantee is lost, not the
+    run — DESIGN §7 *It fails open*), and a `stop()` failure is logged and
+    swallowed rather than propagated out of the `finally`, where it would
+    escape past an already-successful result and be misreported as a worker
+    failure. The global is reset unconditionally either way, which
+    `run_recapture_deps` relies on per loop iteration: a stale non-None value
+    would silently route the NEXT target run through this run's closed proxy,
+    even a run whose own state has the flag off.
+
+    `label` names the calling path in log lines only — the proxy itself is
+    identical for all three.
+
+    Deliberately NOT reused by `_orchestrate`: that one is scoped to a whole
+    run rather than a single call, reports four aggregate counters at
+    shutdown, and dies rather than continuing when its listener cannot bind
+    (DESIGN §7 *It fails closed at startup*) — the opposite of the fail-soft
+    contract these three need.
+    """
+    global _STRICT_PROXY
+    started = False
+    if caps.get("force_strict_output"):
+        proxy = _StrictOutputProxy(
+            caps["max_parallel"], VERBOSITY_DEFAULT,
+            caps.get("worker_timeout_sec",
+                     DEFAULT_CAPS["worker_timeout_sec"]))
+        try:
+            port = await proxy.start()
+        except OSError as e:
+            log(f"strict output: could not start local proxy for {label} "
+                f"({e}); continuing without constrained decoding")
+        else:
+            # Publish to the global only after a successful bind. Assigning
+            # it first would leave a never-started proxy visible to `_invoke`
+            # whenever `start()` raised anything but OSError: that escapes
+            # before the `finally` below is even entered, so nothing resets
+            # it, and `__init__` leaves `port` at 0 — pointing every later
+            # worker in the process at `127.0.0.1:0`. That is a hard failure
+            # rather than the lost guarantee this is supposed to degrade to,
+            # and in run_recapture_deps's loop it would hit the NEXT run.
+            _STRICT_PROXY = proxy
+            started = True
+            log(f"strict output: rewriting worker API requests via "
+                f"127.0.0.1:{port} — `strict: true` forced on the "
+                f"StructuredOutput tool "
+                f"(--dangerously-force-strict-output, {label})")
+    try:
+        yield
+    finally:
+        if started:
+            try:
+                await _STRICT_PROXY.stop()
+            except Exception as e:  # noqa: BLE001 - see fail-soft note above
+                log(f"strict output: error stopping local proxy for "
+                    f"{label} ({e}); continuing")
+            finally:
+                _STRICT_PROXY = None
 
 
 # Substrings that identify a *schema* rejection of a structured submission, as
@@ -32316,9 +32443,21 @@ See README.md "Launcher verbs" for full details and sub-flags.""")
                     "max_iterations": args.heal_max_rounds,
                     "success_threshold": args.heal_success_threshold,
                 }
-                asyncio.run(phase_heal(call_type, failing_records, heal_out_dir,
-                                       caps, phase_st, models, efforts,
-                                       config=config))
+
+                # This branch returns without ever reaching _orchestrate(),
+                # which is where the run-scoped proxy is started — so the
+                # heal loop's own replays (via _replay_capture) would run
+                # unconstrained no matter the flag. `caps` already carries
+                # the resolved value from main() above, and _invoke gates on
+                # the global alone, so wrapping here is the whole fix:
+                # neither phase_heal nor _replay_capture needs to change.
+                async def _heal_with_strict_output() -> None:
+                    async with _strict_output_proxy(caps, "heal"):
+                        await phase_heal(
+                            call_type, failing_records, heal_out_dir,
+                            caps, phase_st, models, efforts, config=config)
+
+                asyncio.run(_heal_with_strict_output())
         return
 
     # The fail-closed cgroup containment gate (DESIGN §6 *Memory

--- a/orchestrator/leerie.py
+++ b/orchestrator/leerie.py
@@ -2033,7 +2033,13 @@ SCHEMAS: dict[str, dict] = {
             },
             "final_branch_state": {"type": "string"},
             "resolution_summary": {"type": "string"},
-            "diagnosis": {"type": ["string", "null"]},
+            # Plain string (not ["string", "null"]): unconstrained
+            # `claude -p --json-schema` reliably emitted a bare, unparseable
+            # empty token for this field's value on a clean rebase instead
+            # of the literal `null`, causing structured_output_retry_exhausted
+            # on every single rebaser call in production. "" means nothing to
+            # diagnose, per the rebaser prompt's own convention.
+            "diagnosis": {"type": "string"},
             "confidence": _confidence_schema(["resolution"]),
         },
     },

--- a/tests/test_config_recapture.py
+++ b/tests/test_config_recapture.py
@@ -487,6 +487,282 @@ class TestRunRecaptureMultiRun:
                 f"{run_dir.name} not captured; captured={captured}"
             )
 
+    def test_wires_strict_output_proxy_when_flag_is_set_on_run_state(
+            self, leerie, tmp_path, monkeypatch):
+        """Regression test for the host-seam strict-output wiring gap
+        (same class of bug as run_rebaser's): when a run's own state has
+        dangerously_force_strict_output=True, run_recapture_deps must
+        start the proxy around that run's capture_repo_deps() call."""
+        state_dir = tmp_path / "state"
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _make_finished_run(state_dir, "run-001", "2026-01-01T10:00:00",
+                           commands=["pip install flask"])
+
+        monkeypatch.delenv("LEERIE_CAPTURE_DEPS", raising=False)
+        calls = {"started": False, "stopped": False}
+
+        class _FakeProxy:
+            def __init__(self, max_parallel, verbosity, timeout_sec):
+                pass
+
+            async def start(self):
+                calls["started"] = True
+                return 12345
+
+            async def stop(self):
+                calls["stopped"] = True
+
+        async def fake_capture(repo_root, st, **kwargs):
+            assert leerie._STRICT_PROXY is not None, (
+                "capture_repo_deps must run while the proxy is active")
+
+        with patch.object(leerie, "capture_repo_deps", new=fake_capture), \
+             patch.object(leerie, "_StrictOutputProxy", _FakeProxy), \
+             patch.object(leerie, "State") as mock_state_cls:
+            def _make_fake_st(leerie_root, run_id, repo_root=None):
+                class _St:
+                    pass
+                s = _St()
+                s.run_dir = leerie_root / "runs" / run_id
+                s.data = {"dangerously_force_strict_output": True}
+                s.bump_workers = lambda c: None
+                s.load = lambda: None
+                return s
+            mock_state_cls.side_effect = _make_fake_st
+
+            leerie.run_recapture_deps(state_dir, repo)
+
+        assert calls["started"] is True
+        assert calls["stopped"] is True
+        assert leerie._STRICT_PROXY is None
+
+    def test_skips_strict_output_proxy_when_flag_is_unset_on_run_state(
+            self, leerie, tmp_path, monkeypatch):
+        """When the flag is false/absent on a run's state, no proxy should
+        be instantiated for its capture_repo_deps() call — guards against
+        an always-on regression of the fix above."""
+        state_dir = tmp_path / "state"
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _make_finished_run(state_dir, "run-001", "2026-01-01T10:00:00",
+                           commands=["pip install flask"])
+
+        monkeypatch.delenv("LEERIE_CAPTURE_DEPS", raising=False)
+        instantiated = {"count": 0}
+
+        class _FakeProxy:
+            def __init__(self, *a, **kw):
+                instantiated["count"] += 1
+
+            async def start(self):
+                return 1
+
+            async def stop(self):
+                pass
+
+        async def fake_capture(repo_root, st, **kwargs):
+            pass
+
+        with patch.object(leerie, "capture_repo_deps", new=fake_capture), \
+             patch.object(leerie, "_StrictOutputProxy", _FakeProxy), \
+             patch.object(leerie, "State") as mock_state_cls:
+            def _make_fake_st(leerie_root, run_id, repo_root=None):
+                class _St:
+                    pass
+                s = _St()
+                s.run_dir = leerie_root / "runs" / run_id
+                s.data = {"dangerously_force_strict_output": False}
+                s.bump_workers = lambda c: None
+                s.load = lambda: None
+                return s
+            mock_state_cls.side_effect = _make_fake_st
+
+            leerie.run_recapture_deps(state_dir, repo)
+
+        assert instantiated["count"] == 0
+
+    def test_proxy_global_is_reset_even_when_stop_raises_across_runs(
+            self, leerie, tmp_path, monkeypatch):
+        """run_recapture_deps consolidates across MULTIPLE finished runs,
+        reusing the same module-level _STRICT_PROXY global each iteration
+        (unlike _orchestrate's single-shot use of it). If proxy.stop()
+        itself raised and the reset were skipped, the run AFTER it would
+        silently inherit a stale/closed proxy — even one whose own state
+        has the flag off. Assert the second run's capture never sees a
+        proxy at all, regardless of what happened to the first run's."""
+        state_dir = tmp_path / "state"
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _make_finished_run(state_dir, "run-001", "2026-01-01T10:00:00",
+                           commands=["pip install flask"])
+        _make_finished_run(state_dir, "run-002", "2026-01-02T10:00:00",
+                           commands=["pip install django"])
+
+        monkeypatch.delenv("LEERIE_CAPTURE_DEPS", raising=False)
+        seen_proxy_during_run: dict[str, bool] = {}
+
+        class _FakeProxy:
+            def __init__(self, *a, **kw):
+                pass
+
+            async def start(self):
+                return 1
+
+            async def stop(self):
+                raise RuntimeError("simulated teardown failure")
+
+        async def fake_capture(repo_root, st, **kwargs):
+            run_name = Path(getattr(st, "run_dir", "")).name
+            seen_proxy_during_run[run_name] = leerie._STRICT_PROXY is not None
+
+        with patch.object(leerie, "capture_repo_deps", new=fake_capture), \
+             patch.object(leerie, "_StrictOutputProxy", _FakeProxy), \
+             patch.object(leerie, "State") as mock_state_cls:
+            def _make_fake_st(leerie_root, run_id, repo_root=None):
+                class _St:
+                    pass
+                s = _St()
+                s.run_dir = leerie_root / "runs" / run_id
+                # target_dirs is processed newest-first (run-002, then
+                # run-001). Only run-002 has the flag on and a stop() that
+                # raises; run-001 (flag off) is processed second and must
+                # not see a proxy leaked from run-002's failed teardown.
+                s.data = {"dangerously_force_strict_output":
+                          run_id == "run-002"}
+                s.bump_workers = lambda c: None
+                s.load = lambda: None
+                return s
+            mock_state_cls.side_effect = _make_fake_st
+
+            leerie.run_recapture_deps(state_dir, repo)
+
+        assert seen_proxy_during_run.get("run-002") is True
+        assert seen_proxy_during_run.get("run-001") is False
+        assert leerie._STRICT_PROXY is None, (
+            "a raising stop() must not leave a stale proxy on the module "
+            "global after run_recapture_deps returns")
+
+    def test_proxy_setup_failure_does_not_abort_the_whole_consolidation(
+            self, leerie, tmp_path, monkeypatch):
+        """Per-run errors are logged and skipped — that contract covers proxy
+        SETUP too, not just the capture call.
+
+        The proxy is constructed and started outside the guard that wraps
+        `capture_repo_deps` itself, so a constructor failure (or any
+        non-`OSError` out of `start()`) escapes that inner guard. Unguarded,
+        it would propagate out of `asyncio.run` and abort the entire
+        multi-run loop — killing consolidation for every remaining run over
+        one run's setup problem."""
+        state_dir = tmp_path / "state"
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _make_finished_run(state_dir, "run-001", "2026-01-01T10:00:00",
+                           commands=["pip install flask"])
+        _make_finished_run(state_dir, "run-002", "2026-01-02T10:00:00",
+                           commands=["pip install django"])
+
+        monkeypatch.delenv("LEERIE_CAPTURE_DEPS", raising=False)
+        captured: list[str] = []
+
+        class _ExplodingProxy:
+            def __init__(self, *a, **kw):
+                # Not an OSError: the start() guard deliberately catches only
+                # OSError, so this models the escape route that guard misses.
+                raise RuntimeError("simulated proxy construction failure")
+
+        async def fake_capture(repo_root, st, **kwargs):
+            captured.append(Path(getattr(st, "run_dir", "")).name)
+
+        with patch.object(leerie, "capture_repo_deps", new=fake_capture), \
+             patch.object(leerie, "_StrictOutputProxy", _ExplodingProxy), \
+             patch.object(leerie, "State") as mock_state_cls:
+            def _make_fake_st(leerie_root, run_id, repo_root=None):
+                class _St:
+                    pass
+                s = _St()
+                s.run_dir = leerie_root / "runs" / run_id
+                # run-002 is processed first (newest-first) and blows up in
+                # proxy setup; run-001 has the flag off and must still run.
+                s.data = {"dangerously_force_strict_output":
+                          run_id == "run-002"}
+                s.bump_workers = lambda c: None
+                s.load = lambda: None
+                return s
+            mock_state_cls.side_effect = _make_fake_st
+
+            # Must not raise.
+            leerie.run_recapture_deps(state_dir, repo)
+
+        assert "run-001" in captured, (
+            "a proxy setup failure on one run aborted the whole "
+            f"consolidation; captured={captured}")
+        assert leerie._STRICT_PROXY is None
+
+    def test_non_oserror_from_start_does_not_leak_a_dead_proxy(
+            self, leerie, tmp_path, monkeypatch):
+        """`start()` failing with anything but `OSError` must not leave the
+        proxy published on the module global.
+
+        The `except OSError` arm is the only one that resets it, and an
+        exception raised before the context manager's `yield` escapes without
+        entering the `finally` that would otherwise clean up. A proxy left
+        behind that way never bound, so `__init__`'s `port = 0` stands — and
+        `_invoke` gates on the global being non-None before reading `.port`,
+        so the NEXT run in this loop would send every worker to
+        `127.0.0.1:0`. That is a hard failure, not the lost guarantee this is
+        meant to degrade to."""
+        state_dir = tmp_path / "state"
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _make_finished_run(state_dir, "run-001", "2026-01-01T10:00:00",
+                           commands=["pip install flask"])
+        _make_finished_run(state_dir, "run-002", "2026-01-02T10:00:00",
+                           commands=["pip install django"])
+
+        monkeypatch.delenv("LEERIE_CAPTURE_DEPS", raising=False)
+        seen_proxy_during_run: dict[str, bool] = {}
+
+        class _FailingStartProxy:
+            def __init__(self, *a, **kw):
+                self.port = 0
+
+            async def start(self):
+                # Deliberately NOT an OSError — that arm is already covered
+                # and is the only one that resets the global.
+                raise RuntimeError("simulated non-OSError start failure")
+
+            async def stop(self):
+                pass
+
+        async def fake_capture(repo_root, st, **kwargs):
+            run_name = Path(getattr(st, "run_dir", "")).name
+            seen_proxy_during_run[run_name] = leerie._STRICT_PROXY is not None
+
+        with patch.object(leerie, "capture_repo_deps", new=fake_capture), \
+             patch.object(leerie, "_StrictOutputProxy", _FailingStartProxy), \
+             patch.object(leerie, "State") as mock_state_cls:
+            def _make_fake_st(leerie_root, run_id, repo_root=None):
+                class _St:
+                    pass
+                s = _St()
+                s.run_dir = leerie_root / "runs" / run_id
+                # run-002 is processed first and fails to start its proxy;
+                # run-001 (flag off) follows and must see no proxy at all.
+                s.data = {"dangerously_force_strict_output":
+                          run_id == "run-002"}
+                s.bump_workers = lambda c: None
+                s.load = lambda: None
+                return s
+            mock_state_cls.side_effect = _make_fake_st
+
+            leerie.run_recapture_deps(state_dir, repo)
+
+        assert seen_proxy_during_run.get("run-001") is False, (
+            "a failed start() leaked a never-bound proxy onto the global; "
+            "the next run's workers would be pointed at 127.0.0.1:0")
+        assert leerie._STRICT_PROXY is None
+
 
 # ---------------------------------------------------------------------------
 # End-to-end: real python3 seam with stubbed claude

--- a/tests/test_run_rebaser.py
+++ b/tests/test_run_rebaser.py
@@ -238,3 +238,149 @@ def test_run_rebaser_worker_exception_returns_failed_not_raised(leerie, tmp_path
 
     assert result["status"] == "failed"
     assert "simulated worker crash" in result["diagnosis"]
+
+
+def _seed_state(leerie_root: Path, run_id: str, **data) -> None:
+    run_dir = leerie_root / "runs" / run_id
+    run_dir.mkdir(parents=True, exist_ok=True)
+    (run_dir / "state.json").write_text(json.dumps(data))
+
+
+def test_run_rebaser_wires_strict_output_proxy_when_flag_is_set(
+        leerie, tmp_path, monkeypatch):
+    """Regression test for the host-seam strict-output wiring gap: when
+    the run's own state has dangerously_force_strict_output=True,
+    run_rebaser must start the proxy around its claude_p() call (so
+    ANTHROPIC_BASE_URL actually gets injected downstream) and stop it
+    afterward — not silently run unconstrained regardless of the flag."""
+    repo = _init_repo(tmp_path)
+    leerie_root = tmp_path / "leerie_root"
+    _seed_state(leerie_root, "run-strict-001",
+                dangerously_force_strict_output=True)
+
+    calls = {"started": False, "stopped": False, "init_args": None}
+
+    class _FakeProxy:
+        def __init__(self, max_parallel, verbosity, timeout_sec):
+            calls["init_args"] = (max_parallel, verbosity, timeout_sec)
+
+        async def start(self):
+            calls["started"] = True
+            return 12345
+
+        async def stop(self):
+            calls["stopped"] = True
+
+    monkeypatch.setattr(leerie, "_StrictOutputProxy", _FakeProxy)
+
+    async def fake_claude_p(*args, **kwargs):
+        assert leerie._STRICT_PROXY is not None, (
+            "claude_p must run while the proxy is active")
+        return {
+            "status": "rebased",
+            "final_branch_state": "clean",
+            "resolution_summary": "no conflicts",
+            "diagnosis": "",
+            "confidence": _full_confidence(9.5),
+        }
+
+    monkeypatch.setattr(leerie, "claude_p", fake_claude_p)
+
+    result = leerie.run_rebaser(
+        leerie_root, repo, "run-strict-001", repo,
+        "leerie/runs/run-strict-001", "main", "main")
+
+    assert result["status"] == "rebased"
+    assert calls["started"] is True
+    assert calls["stopped"] is True
+    assert leerie._STRICT_PROXY is None
+
+
+def test_run_rebaser_survives_proxy_teardown_failure(
+        leerie, tmp_path, monkeypatch):
+    """A stop() failure must not turn a successful rebase into a reported
+    'failed' result: a finally-raised exception isn't caught by this same
+    function's own try/except, so an unguarded stop() would propagate past
+    a completed, valid claude_p() return and get caught by the OUTER
+    except at this function's call site instead — discarding real,
+    successful work over a cleanup-only hiccup. Also confirms the global
+    is still reset even though teardown itself failed."""
+    repo = _init_repo(tmp_path)
+    leerie_root = tmp_path / "leerie_root"
+    _seed_state(leerie_root, "run-strict-003",
+                dangerously_force_strict_output=True)
+
+    class _FakeProxy:
+        def __init__(self, max_parallel, verbosity, timeout_sec):
+            pass
+
+        async def start(self):
+            return 12345
+
+        async def stop(self):
+            raise RuntimeError("simulated teardown failure")
+
+    monkeypatch.setattr(leerie, "_StrictOutputProxy", _FakeProxy)
+
+    async def fake_claude_p(*args, **kwargs):
+        return {
+            "status": "rebased",
+            "final_branch_state": "clean",
+            "resolution_summary": "no conflicts",
+            "diagnosis": "",
+            "confidence": _full_confidence(9.5),
+        }
+
+    monkeypatch.setattr(leerie, "claude_p", fake_claude_p)
+
+    result = leerie.run_rebaser(
+        leerie_root, repo, "run-strict-003", repo,
+        "leerie/runs/run-strict-003", "main", "main")
+
+    assert result["status"] == "rebased", (
+        f"a proxy teardown failure must not mask a successful rebase; "
+        f"got {result!r}")
+    assert leerie._STRICT_PROXY is None
+
+
+def test_run_rebaser_skips_strict_output_proxy_when_flag_is_unset(
+        leerie, tmp_path, monkeypatch):
+    """When the flag is false/absent, run_rebaser must NOT instantiate the
+    proxy at all — guards against an always-on regression of the fix
+    above."""
+    repo = _init_repo(tmp_path)
+    leerie_root = tmp_path / "leerie_root"
+    _seed_state(leerie_root, "run-strict-002",
+                dangerously_force_strict_output=False)
+
+    instantiated = {"count": 0}
+
+    class _FakeProxy:
+        def __init__(self, *a, **kw):
+            instantiated["count"] += 1
+
+        async def start(self):
+            return 1
+
+        async def stop(self):
+            pass
+
+    monkeypatch.setattr(leerie, "_StrictOutputProxy", _FakeProxy)
+
+    async def fake_claude_p(*args, **kwargs):
+        return {
+            "status": "rebased",
+            "final_branch_state": "clean",
+            "resolution_summary": "no conflicts",
+            "diagnosis": "",
+            "confidence": _full_confidence(9.5),
+        }
+
+    monkeypatch.setattr(leerie, "claude_p", fake_claude_p)
+
+    result = leerie.run_rebaser(
+        leerie_root, repo, "run-strict-002", repo,
+        "leerie/runs/run-strict-002", "main", "main")
+
+    assert result["status"] == "rebased"
+    assert instantiated["count"] == 0

--- a/tests/test_strict_output_proxy.py
+++ b/tests/test_strict_output_proxy.py
@@ -1988,3 +1988,105 @@ def test_no_proxied_requests_at_all_is_not_a_rename(leerie):
     """A run where the proxy saw nothing proves nothing about the tool — the
     warning must key on `passed_through`, not fire on an empty run."""
     assert "NOTHING was rewritten" not in _summary_for(leerie)
+
+
+# ---------------------------------------------------------------------------
+# The flag has to REACH the workers, not merely resolve.
+# ---------------------------------------------------------------------------
+
+class TestStrictOutputReachesEveryEntrypoint:
+    """A knob that resolves correctly but never reaches its consumers is
+    documented-but-inert.
+
+    `main()` resolves `caps["force_strict_output"]`, but the proxy that makes
+    it mean anything is started in `_orchestrate()`. Three entrypoints never
+    reach `_orchestrate`, so without their own instance every worker they
+    invoke runs unconstrained no matter the flag:
+
+      - `run_rebaser` and `run_recapture_deps` — each a separate host-seam
+        `python3` process, where the module-level `_STRICT_PROXY` starts
+        fresh at `None` regardless of config.
+      - `main()`'s `--phase heal` branch — returns before `_orchestrate` is
+        called, so its `_replay_capture` replays inherit no proxy.
+
+    This is the same defect class
+    `test_worker_duration_distribution.py::TestOverrideReachesEveryConsumer`
+    pins for the worker-timeout knob — and it caught these very entrypoints
+    missing that one. Shipped consequence here: the rebaser's nullable
+    `diagnosis` field produced unparseable output on every single call,
+    exhausting all structured-output retries and silently skipping the
+    rebase on every finalize.
+    """
+
+    def test_host_seam_entrypoints_wrap_their_worker_call(self, leerie):
+        """The two separate-process seams must open the proxy themselves."""
+        import inspect
+        for fn in (leerie.run_rebaser, leerie.run_recapture_deps):
+            src = inspect.getsource(fn)
+            assert "_strict_output_proxy(" in src, (
+                f"{fn.__name__} never opens a strict-output proxy, so "
+                "--dangerously-force-strict-output is inert for its worker")
+
+    def test_host_seam_entrypoints_read_the_flag_off_run_state(self, leerie):
+        """The CLI flag never reaches these separate processes — only
+        `state.json` crosses the boundary — so re-resolving from argv alone
+        would miss a run launched with the bare CLI flag."""
+        import inspect
+        for fn in (leerie.run_rebaser, leerie.run_recapture_deps):
+            src = inspect.getsource(fn)
+            assert "dangerously_force_strict_output" in src, (
+                f"{fn.__name__} never reads the resolved per-run value, so a "
+                "CLI-flag-only run silently runs unconstrained there")
+
+    def test_heal_branch_wraps_phase_heal(self, leerie):
+        """`--phase heal` returns before `_orchestrate`, so its replays need
+        the proxy opened in the branch itself.
+
+        Structural (not a substring match): the `phase_heal` call must sit
+        lexically inside an `async with _strict_output_proxy(...)` block, so
+        merely mentioning the helper somewhere in `main()` cannot satisfy it.
+        """
+        import ast
+        import inspect
+        import textwrap
+
+        tree = ast.parse(textwrap.dedent(inspect.getsource(leerie.main)))
+
+        def opens_strict_proxy(node: ast.AsyncWith) -> bool:
+            for item in node.items:
+                call = item.context_expr
+                if (isinstance(call, ast.Call)
+                        and isinstance(call.func, ast.Name)
+                        and call.func.id == "_strict_output_proxy"):
+                    return True
+            return False
+
+        guarded = any(
+            isinstance(inner, ast.Call)
+            and isinstance(inner.func, ast.Name)
+            and inner.func.id == "phase_heal"
+            for node in ast.walk(tree)
+            if isinstance(node, ast.AsyncWith) and opens_strict_proxy(node)
+            for inner in ast.walk(node)
+        )
+        assert guarded, (
+            "main()'s --phase heal branch calls phase_heal outside any "
+            "async with _strict_output_proxy(...) — the heal loop's replays "
+            "run unconstrained even when the flag is set")
+
+    def test_replay_capture_needs_no_proxy_of_its_own(self, leerie):
+        """Pins WHY `_replay_capture` is deliberately untouched: `_invoke`
+        gates on the module-level global alone, never on
+        `caps["force_strict_output"]`. So a caller that opens the proxy is
+        sufficient, and `_replay_capture` rebuilding its own caps from
+        `DEFAULT_CAPS` is harmless. If that gating ever moved to `caps`, this
+        assumption would break silently and `_replay_capture` would need its
+        own wiring — hence the guard."""
+        import inspect
+        invoke_src = inspect.getsource(leerie._invoke)
+        assert "_STRICT_PROXY is not None" in invoke_src, (
+            "_invoke no longer gates on the global; _replay_capture (and any "
+            "other caller relying on an ambient proxy) may now be inert")
+        assert "force_strict_output" not in invoke_src, (
+            "_invoke now reads force_strict_output off caps — _replay_capture "
+            "builds its own caps from DEFAULT_CAPS and would silently lose it")


### PR DESCRIPTION
Two independently-revertable fixes for one observed failure: every rebaser invocation on 0.21.0 ending in `structured_output_retry_exhausted`. Separate commits, per CONTRIBUTING's one-logical-change rule.

**Layers touched** (three-layer rule): DESIGN → IMPLEMENTATION → code → tests. Propagated top-down; DESIGN §7 *Forcing constrained decoding* changed first, since the architectural claim "one per run, started by the orchestrator" was incomplete rather than merely under-documented.

## 1. `fix: narrow the rebaser's diagnosis to a plain string`

`SCHEMAS["rebaser"]["diagnosis"]` was `["string", "null"]`. `--json-schema` is validated, not constrained, and the worker reliably emitted a bare unparseable token where `null` belonged on the clean-rebase path. Every retry reproduced it. Measured against one repo's state directory: of the 14 runs on 0.21.0 that reached the rebaser, all 28 rebaser result events failed this way.

Non-fatal in practice — `host-finalize.sh` falls through to pushing the run branch as-is — so it surfaced as PRs that were simply never rebased onto the latest base.

Matches what `prompts/rebaser.md` already asks for ("Otherwise empty string"); `host-finalize.sh` already reads `.diagnosis // ""`. Neither side needed changing.

## 2. `fix: make forced constrained decoding reach the three entrypoints that bypass _orchestrate`

The more general gap underneath. `--dangerously-force-strict-output` resolves in `main()`, but the proxy is started in `_orchestrate()` and `_invoke` gates on the `_STRICT_PROXY` global alone — so any path invoking a worker without `_orchestrate` having run was silently unconstrained:

| entrypoint | why it misses `_orchestrate` |
|---|---|
| `run_rebaser` | own `python3` process (`host-finalize.sh`) |
| `run_recapture_deps` | own `python3` process (`config --recapture`) |
| `main()`'s `--phase heal` | returns before `_orchestrate` is called |

`TestOverrideReachesEveryConsumer` already pins this defect class for the worker-timeout knob and found the first two of these inert for it. Its third is `_replay_capture`, not the heal branch — and the difference is the useful part. The timeout is read off `caps`, so that fix had to land *inside* `_replay_capture`, which builds its own. This one is gated on the global, so it lands one level up, in the `--phase heal` branch that drives `_replay_capture`; `_replay_capture` itself needs no change, inheriting whatever proxy is ambient.

Each of the three now wraps its worker call in a new `_strict_output_proxy(caps, label)` asynccontextmanager. The two host-seam entrypoints read the resolved value back off the run's own `state.json`, since the CLI flag never crosses a process boundary.

The helper fails soft in both directions, departing from §7's fail-closed startup rule because all three callers must never block a push, abort a multi-run loop, or fail a heal. It closes three teardown hazards that each cost real behaviour when written inline first — most notably publishing the global only after a successful bind, since assigning it first left a never-started proxy (`port` 0) visible to `_invoke` whenever `start()` raised anything but `OSError`, pointing every later worker at `127.0.0.1:0`.

`run_recapture_deps` also regained a broad guard around its `asyncio.run`: proxy construction sits outside the guard wrapping `capture_repo_deps`, so a setup failure would have aborted the whole consolidation rather than being logged and skipped.

## Verification

- `python3 -c "import ast; ast.parse(open('orchestrator/leerie.py').read())"` — OK
- `pytest tests/test_no_undefined_names.py` — 13 passed
- `pytest tests/test_run_rebaser.py tests/test_config_recapture.py tests/test_strict_output_proxy.py tests/test_capture_swallows_exit_signals.py` — 171 passed
- 12 new tests across 3 files. Every fix above was validated by reverting it and confirming the corresponding test failed, then restoring it — 7 of the 12 have that property; the other five are negative controls (the two flag-unset cases) and invariant pins, which by design do not fail on a revert.
- `TestStrictOutputReachesEveryEntrypoint` pins all three entrypoints; the heal branch structurally via AST, so merely naming the helper somewhere in `main()` cannot satisfy it.

**Not run:** a full `pytest tests/` against the final commit. The last complete run (7231 passed, 0 failed) predates the final publish-after-bind fix and its test, both covered by the 171-test run above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
