### PR TITLE
leerie: Add unit tests for previously-untested leaf helper functions across the codebase

### DIFF
--- a/tests/test_blt_script_helpers.py
+++ b/tests/test_blt_script_helpers.py
@@ -1,0 +1,58 @@
+"""Tests for two leaf BLT helpers with no direct coverage elsewhere:
+_package_json_scripts (package.json `scripts` map extraction) and
+_is_blt_feedback_warning (the CRITIC-pattern feedback injection gate).
+"""
+from __future__ import annotations
+
+import json
+
+
+class TestPackageJsonScripts:
+    def test_well_formed_file(self, leerie, tmp_path):
+        (tmp_path / "package.json").write_text(
+            json.dumps({"scripts": {"build": "tsc", "test": "vitest run"}}))
+        assert leerie._package_json_scripts(tmp_path) == {
+            "build": "tsc", "test": "vitest run"}
+
+    def test_missing_file(self, leerie, tmp_path):
+        assert leerie._package_json_scripts(tmp_path) == {}
+
+    def test_invalid_json(self, leerie, tmp_path):
+        (tmp_path / "package.json").write_text("{not valid json")
+        assert leerie._package_json_scripts(tmp_path) == {}
+
+    def test_scripts_value_not_a_dict(self, leerie, tmp_path):
+        (tmp_path / "package.json").write_text(
+            json.dumps({"scripts": ["build", "test"]}))
+        assert leerie._package_json_scripts(tmp_path) == {}
+
+    def test_scripts_key_absent(self, leerie, tmp_path):
+        (tmp_path / "package.json").write_text(json.dumps({"name": "x"}))
+        assert leerie._package_json_scripts(tmp_path) == {}
+
+    def test_top_level_not_a_dict(self, leerie, tmp_path):
+        (tmp_path / "package.json").write_text(json.dumps(["a", "b"]))
+        assert leerie._package_json_scripts(tmp_path) == {}
+
+    def test_non_string_script_values_dropped(self, leerie, tmp_path):
+        (tmp_path / "package.json").write_text(
+            json.dumps({"scripts": {"build": "tsc", "bad": 123}}))
+        assert leerie._package_json_scripts(tmp_path) == {"build": "tsc"}
+
+
+class TestIsBltFeedbackWarning:
+    def test_matches_auto_backgrounded_marker(self, leerie):
+        assert leerie._is_blt_feedback_warning(
+            "round-1: worker's invocation auto-backgrounded and was "
+            "followed by a retry")
+
+    def test_matches_ran_the_full_marker(self, leerie):
+        assert leerie._is_blt_feedback_warning(
+            "round-1: ran the full BUILD axis 2 time(s) (see log)")
+
+    def test_unrelated_warning_returns_false(self, leerie):
+        assert not leerie._is_blt_feedback_warning(
+            "round-1: some other advisory warning entirely")
+
+    def test_empty_string_returns_false(self, leerie):
+        assert not leerie._is_blt_feedback_warning("")

--- a/tests/test_chain_log.py
+++ b/tests/test_chain_log.py
@@ -1,0 +1,48 @@
+"""Unit tests for chain/_log.py's package-isolated log()/die() helpers."""
+from datetime import datetime
+
+import pytest
+
+from chain import _log
+
+
+def test_log_writes_prefixed_message_to_stdout(capsys):
+    _log.log("hello world")
+    captured = capsys.readouterr()
+    assert captured.err == ""
+    assert "[chain] hello world" in captured.out
+    assert captured.out.rstrip("\n").endswith("hello world")
+
+
+def test_die_writes_prefixed_message_to_stderr_and_exits_default_code(capsys):
+    with pytest.raises(SystemExit) as exc_info:
+        _log.die("bad input")
+    assert exc_info.value.code == 1
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "leerie-chain: error: bad input" in captured.err
+
+
+def test_die_exits_with_given_code(capsys):
+    with pytest.raises(SystemExit) as exc_info:
+        _log.die("bad", code=2)
+    assert exc_info.value.code == 2
+    captured = capsys.readouterr()
+    assert "leerie-chain: error: bad" in captured.err
+
+
+def test_iso_now_returns_parseable_iso8601_timestamp():
+    ts = _log._iso_now()
+    assert isinstance(ts, str)
+    assert ts.endswith("Z")
+    parsed = datetime.strptime(ts, "%Y-%m-%dT%H:%M:%SZ")
+    assert parsed.year >= 2024
+
+
+def test_log_message_prefixed_with_iso_now_timestamp(capsys):
+    _log.log("timestamped")
+    captured = capsys.readouterr()
+    line = captured.out.rstrip("\n")
+    ts_part, rest = line.split(" ", 1)
+    datetime.strptime(ts_part, "%Y-%m-%dT%H:%M:%SZ")
+    assert rest == "[chain] timestamped"

--- a/tests/test_checkpoint_noise_helpers.py
+++ b/tests/test_checkpoint_noise_helpers.py
@@ -1,0 +1,154 @@
+"""Tests for the checkpoint-parsing helpers `_split_checkpoint_sections`,
+`_normalize_for_noise`, and `_strip_bullet` (leerie.py:12437, 12508, 12523).
+
+These back checkpoint-file structural validation
+(`_validate_checkpoint`'s placeholder-token rejection). The one
+non-obvious invariant is `_normalize_for_noise`'s documented ordering:
+a pure run of `?` must collapse to a single `?` BEFORE trailing
+punctuation is stripped, otherwise `???` is eaten down to the empty
+string and never matches the bare `?` noise token.
+"""
+from __future__ import annotations
+
+
+class TestSplitCheckpointSections:
+    def test_buckets_lines_under_most_recent_header_in_order(self, leerie):
+        content = (
+            "# Checkpoint: feat-001\n"
+            "## Frozen success criteria\n"
+            "- [x] criterion 1\n"
+            "- [ ] criterion 2\n"
+            "## Current status\n"
+            "half done\n"
+        )
+        sections = leerie._split_checkpoint_sections(content)
+        assert list(sections.keys()) == [
+            "## Frozen success criteria",
+            "## Current status",
+        ]
+        assert sections["## Frozen success criteria"] == [
+            "- [x] criterion 1",
+            "- [ ] criterion 2",
+        ]
+        assert sections["## Current status"] == ["half done"]
+
+    def test_drops_blank_lines(self, leerie):
+        content = "## Next action\n\n  \nreal content\n\n"
+        sections = leerie._split_checkpoint_sections(content)
+        assert sections["## Next action"] == ["real content"]
+
+    def test_strips_whitespace_from_lines(self, leerie):
+        content = "## Open unknowns\n   - padded line   \n"
+        sections = leerie._split_checkpoint_sections(content)
+        assert sections["## Open unknowns"] == ["- padded line"]
+
+    def test_lines_before_any_header_are_ignored(self, leerie):
+        content = "preamble text\nmore preamble\n## Current status\nreal\n"
+        sections = leerie._split_checkpoint_sections(content)
+        assert sections == {"## Current status": ["real"]}
+
+    def test_header_with_no_content_yields_empty_bucket(self, leerie):
+        content = "## Decisions made\n## Open unknowns\n- one thing\n"
+        sections = leerie._split_checkpoint_sections(content)
+        assert sections["## Decisions made"] == []
+        assert sections["## Open unknowns"] == ["- one thing"]
+
+    def test_only_double_hash_space_starts_a_new_header(self, leerie):
+        # A line starting with "###" or "##" (no trailing space) must not
+        # be treated as a section header — it stays bucketed under the
+        # current section instead.
+        content = "## Current status\n### a sub-heading, not a new section\n"
+        sections = leerie._split_checkpoint_sections(content)
+        assert sections == {
+            "## Current status": ["### a sub-heading, not a new section"]
+        }
+
+    def test_empty_content_yields_empty_dict(self, leerie):
+        assert leerie._split_checkpoint_sections("") == {}
+
+
+class TestStripBullet:
+    def test_strips_dash_bullet(self, leerie):
+        assert leerie._strip_bullet("- none") == "none"
+
+    def test_strips_star_bullet(self, leerie):
+        assert leerie._strip_bullet("* none") == "none"
+
+    def test_strips_plus_bullet(self, leerie):
+        assert leerie._strip_bullet("+ none") == "none"
+
+    def test_strips_numbered_list_prefix(self, leerie):
+        assert leerie._strip_bullet("1. none") == "none"
+
+    def test_strips_multi_digit_numbered_list_prefix(self, leerie):
+        assert leerie._strip_bullet("12. none") == "none"
+
+    def test_leading_whitespace_before_bullet_is_handled(self, leerie):
+        assert leerie._strip_bullet("   - none") == "none"
+
+    def test_no_bullet_marker_returns_stripped_line_unchanged(self, leerie):
+        assert leerie._strip_bullet("just plain text") == "just plain text"
+
+    def test_bare_dash_with_no_space_is_not_a_bullet(self, leerie):
+        # "-none" has no space after the marker, so it isn't stripped.
+        assert leerie._strip_bullet("-none") == "-none"
+
+    def test_digit_not_followed_by_dot_space_is_not_a_numbered_list(self, leerie):
+        assert leerie._strip_bullet("1x none") == "1x none"
+
+    def test_digit_alone_is_not_a_numbered_list(self, leerie):
+        assert leerie._strip_bullet("1") == "1"
+
+
+class TestNormalizeForNoise:
+    def test_bare_none_normalizes_to_none(self, leerie):
+        assert leerie._normalize_for_noise("none") == "none"
+
+    def test_none_with_trailing_period_normalizes_to_bare_token(self, leerie):
+        assert leerie._normalize_for_noise("None.") == "none"
+
+    def test_tbd_with_trailing_bang_normalizes_to_bare_token(self, leerie):
+        assert leerie._normalize_for_noise("TBD!") == "tbd"
+
+    def test_pure_question_marks_collapse_to_single_question_mark(self, leerie):
+        # The documented load-bearing invariant: the `?`-run collapse must
+        # run BEFORE the trailing-punctuation strip. `?` is itself in the
+        # trailing-punctuation-adjacent noise set conceptually, but is not
+        # in the strip charset (".!…") — the real risk this guards is that
+        # collapsing after stripping would leave nothing to collapse.
+        assert leerie._normalize_for_noise("???") == "?"
+
+    def test_single_question_mark_normalizes_to_itself(self, leerie):
+        assert leerie._normalize_for_noise("?") == "?"
+
+    def test_ordering_invariant_directly(self, leerie):
+        """If the ?-collapse ran AFTER the trailing-punctuation strip,
+        '???' would have every '?' peeled off (were '?' in the strip
+        charset) or would fail the `set(s) == {"?"}` check post-strip in
+        some other rewrite — either way risking landing on the empty
+        string rather than the bare '?' token. Pin the actual documented
+        outcome directly against the noise-token set."""
+        result = leerie._normalize_for_noise("???")
+        assert result != ""
+        assert result in leerie._NOISE_TOKENS
+
+    def test_strips_bullet_before_noise_comparison(self, leerie):
+        assert leerie._normalize_for_noise("- none") == "none"
+
+    def test_lowercases(self, leerie):
+        assert leerie._normalize_for_noise("NONE") == "none"
+
+    def test_strips_ellipsis(self, leerie):
+        assert leerie._normalize_for_noise("pending…") == "pending"
+
+    def test_strips_multiple_trailing_punctuation_chars(self, leerie):
+        assert leerie._normalize_for_noise("todo!.") == "todo"
+
+    def test_none_and_tbd_land_in_noise_tokens(self, leerie):
+        assert leerie._normalize_for_noise("None.") in leerie._NOISE_TOKENS
+        assert leerie._normalize_for_noise("TBD!") in leerie._NOISE_TOKENS
+
+    def test_non_noise_content_is_untouched_besides_normalization(self, leerie):
+        result = leerie._normalize_for_noise("- Added new retry logic.")
+        assert result == "added new retry logic"
+        assert result not in leerie._NOISE_TOKENS

--- a/tests/test_command_tokens.py
+++ b/tests/test_command_tokens.py
@@ -1,0 +1,50 @@
+"""Unit tests for _command_tokens — the lowercasing/stopword-filtering
+primitive underneath check_prescribed_command_coverage (which already has
+exhaustive coverage in tests/test_prescribed_cmd_coverage.py, but not of
+this tokenizer's own boundary cases).
+"""
+from __future__ import annotations
+
+
+def test_lowercases_input(leerie):
+    assert leerie._command_tokens("RECON Browser") == frozenset(
+        {"recon", "browser"})
+
+
+def test_splits_on_whitespace(leerie):
+    assert leerie._command_tokens("recon   browser\tnow") == frozenset(
+        {"recon", "browser", "now"})
+
+
+def test_drops_every_stopword(leerie):
+    for word in leerie._STOPWORDS:
+        assert leerie._command_tokens(word) == frozenset()
+
+
+def test_keeps_non_stopword_tokens_alongside_stopwords(leerie):
+    assert leerie._command_tokens("barnacle recon the browser") == frozenset(
+        {"barnacle", "recon", "browser"})
+
+
+def test_returns_frozenset_type(leerie):
+    result = leerie._command_tokens("recon browser")
+    assert isinstance(result, frozenset)
+
+
+def test_dedup_by_construction(leerie):
+    assert leerie._command_tokens("recon recon browser") == frozenset(
+        {"recon", "browser"})
+
+
+def test_order_independent(leerie):
+    assert leerie._command_tokens("recon browser") == leerie._command_tokens(
+        "browser recon")
+
+
+def test_empty_string(leerie):
+    assert leerie._command_tokens("") == frozenset()
+
+
+def test_all_stopwords_input(leerie):
+    assert leerie._command_tokens(
+        "the a an to and or of in on for with") == frozenset()

--- a/tests/test_decompose_child_helpers.py
+++ b/tests/test_decompose_child_helpers.py
@@ -1,0 +1,311 @@
+"""Unit tests for the migration/decompose child-partition helpers
+(DESIGN §5½ (P1) *Sub-file* / *Migration*, DESIGN §5 *Id-vanishing
+operations*): `_grep_old_pattern`, `_deterministic_chunk_label`,
+`_subfile_child`, `_prune_orphaned_requires`.
+
+These back `_partition_files`, `_recursive_decompose` and
+`_remap_vanished_deps` (extensively tested elsewhere) but had no direct
+coverage of their own.
+"""
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+LEERIE_PY = REPO_ROOT / "orchestrator" / "leerie.py"
+
+
+@pytest.fixture(scope="session")
+def leerie():
+    spec = importlib.util.spec_from_file_location("leerie", LEERIE_PY)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# ---------------------------------------------------------------------------
+# _grep_old_pattern
+# ---------------------------------------------------------------------------
+
+def test_grep_old_pattern_finds_literal_across_allowlisted_extensions(leerie, tmp_path):
+    (tmp_path / "a.ts").write_text("const x = OldWidget();\n")
+    (tmp_path / "b.py").write_text("x = OldWidget()\n")
+    (tmp_path / "c.txt").write_text("OldWidget mentioned in prose\n")  # not in allowlist
+    (tmp_path / "d.rb").write_text("puts 'unrelated'\n")
+
+    found = leerie._grep_old_pattern("OldWidget", tmp_path)
+
+    assert found == {"a.ts", "b.py"}
+
+
+def test_grep_old_pattern_prefers_src_subdir_when_present(leerie, tmp_path):
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "in_src.ts").write_text("OldWidget()\n")
+    (tmp_path / "outside.ts").write_text("OldWidget()\n")  # outside src/, must not be searched
+
+    found = leerie._grep_old_pattern("OldWidget", tmp_path)
+
+    assert found == {"src/in_src.ts"}
+    assert "outside.ts" not in found
+
+
+def test_grep_old_pattern_returns_relative_paths(leerie, tmp_path):
+    (tmp_path / "nested").mkdir()
+    (tmp_path / "nested" / "deep.js").write_text("OldWidget();\n")
+
+    found = leerie._grep_old_pattern("OldWidget", tmp_path)
+
+    assert found == {"nested/deep.js"}
+    for f in found:
+        assert not Path(f).is_absolute()
+
+
+def test_grep_old_pattern_no_match_returns_empty_set(leerie, tmp_path):
+    (tmp_path / "a.ts").write_text("nothing relevant here\n")
+
+    assert leerie._grep_old_pattern("OldWidget", tmp_path) == set()
+
+
+def test_grep_old_pattern_missing_dir_degrades_to_empty_set(leerie, tmp_path):
+    missing = tmp_path / "does-not-exist"
+
+    assert leerie._grep_old_pattern("OldWidget", missing) == set()
+
+
+# ---------------------------------------------------------------------------
+# _deterministic_chunk_label
+# ---------------------------------------------------------------------------
+
+def test_deterministic_chunk_label_distinct_per_index(leerie):
+    subtask = {"title": "Migrate widgets", "success_criteria_seed": "all sites migrated"}
+    chunks = [["a.ts"], ["b.ts"], ["c.ts"]]
+
+    labels = [
+        leerie._deterministic_chunk_label(subtask, chunk, idx, len(chunks))
+        for idx, chunk in enumerate(chunks)
+    ]
+    titles = [t for t, _ in labels]
+    criteria = [c for _, c in labels]
+
+    assert len(set(titles)) == len(titles)
+    assert len(set(criteria)) == len(criteria)
+
+
+def test_deterministic_chunk_label_shape(leerie):
+    subtask = {"title": "Migrate widgets", "success_criteria_seed": "all sites migrated"}
+    title, criteria = leerie._deterministic_chunk_label(
+        subtask, ["a.ts", "b.ts"], 1, 3)
+
+    assert title == "Migrate widgets (part 2/3)"
+    assert "all sites migrated" in criteria
+    assert "a.ts, b.ts" in criteria
+
+
+def test_deterministic_chunk_label_same_index_different_files_still_distinct(leerie):
+    subtask = {"title": "Migrate widgets", "success_criteria_seed": "seed"}
+    _, criteria_a = leerie._deterministic_chunk_label(subtask, ["a.ts"], 0, 2)
+    _, criteria_b = leerie._deterministic_chunk_label(subtask, ["z.ts"], 0, 2)
+
+    # same idx/total but different chunk contents -> criteria (file list) differ
+    assert criteria_a != criteria_b
+
+
+# ---------------------------------------------------------------------------
+# _subfile_child
+# ---------------------------------------------------------------------------
+
+def _base_parent():
+    return {
+        "id": "feat-005",
+        "title": "Thread FrameTarget",
+        "success_criteria_seed": "all sites routed",
+        "intent": "Route FrameTarget through the flow runner",
+        "scope_note": "flow-runner.ts only",
+        "files_likely_touched": ["flow-runner.ts"],
+        "depends_on": ["feat-004"],
+        "requires": [{"tag": "frame-shape", "extent": "in_plan"}],
+        "provides": ["frame-target"],
+        "investigation_notes": "see flow-runner.ts:1-2000",
+    }
+
+
+def test_subfile_child_owns_region(leerie):
+    parent = _base_parent()
+    child = leerie._subfile_child(
+        parent, "flow-runner.ts", (1, 700), ["runFrame", "FrameTarget"],
+        "feat-005-r1", "flow-runner.ts", 0, 3)
+
+    assert child["id"] == "feat-005-r1"
+    assert child["files_likely_touched"] == ["flow-runner.ts"]
+    assert child["owned_region"] == {
+        "file": "flow-runner.ts", "start": 1, "end": 700,
+        "symbols": ["runFrame", "FrameTarget"],
+    }
+    assert child["_cofile_cluster"] == "flow-runner.ts"
+    assert "lines 1-700" in child["title"]
+    assert "lines 1-700" in child["success_criteria_seed"]
+    assert "lines 1-700" in child["intent"]
+
+
+def test_subfile_child_deep_copies_requires_and_provides_no_aliasing(leerie):
+    """Mirrors the _migration_child aliasing discipline (CLAUDE.md,
+    tests/test_recursive_decompose.py's peel test): a region child's
+    depends_on/requires/provides must not alias the parent's lists/dicts,
+    or a later in-place edit (e.g. _apply_overlap_drop, _prune_orphaned_requires)
+    on the child silently mutates the parent (and vice versa)."""
+    parent = _base_parent()
+    child = leerie._subfile_child(
+        parent, "flow-runner.ts", (1, 700), ["runFrame"],
+        "feat-005-r1", "flow-runner.ts", 0, 2)
+
+    assert child["depends_on"] == parent["depends_on"]
+    assert child["depends_on"] is not parent["depends_on"]
+
+    assert child["requires"] == parent["requires"]
+    assert child["requires"] is not parent["requires"]
+    assert child["requires"][0] is not parent["requires"][0]  # nested dict deep-copied
+
+    assert child["provides"] == parent["provides"]
+    assert child["provides"] is not parent["provides"]
+
+    # mutating the child must not leak back to the parent
+    child["depends_on"].append("feat-999")
+    child["requires"][0]["tag"] = "mutated"
+    child["provides"].append("new-tag")
+
+    assert parent["depends_on"] == ["feat-004"]
+    assert parent["requires"][0]["tag"] == "frame-shape"
+    assert parent["provides"] == ["frame-target"]
+
+
+def test_subfile_child_intent_is_region_scoped_not_verbatim(leerie):
+    """Unlike _migration_child (verbatim intent inheritance is safe because
+    chunks own disjoint files), region children co-own the SAME file, so
+    the intent must be scoped to the region to give plan_overlap_judge a
+    textual signal distinguishing siblings (DESIGN §5 *Cross-domain surface
+    overlap*)."""
+    parent = _base_parent()
+    child = leerie._subfile_child(
+        parent, "flow-runner.ts", (701, 1400), ["otherFn"],
+        "feat-005-r2", "flow-runner.ts", 1, 3)
+
+    assert child["intent"] != parent["intent"]
+    assert parent["intent"] in child["intent"]
+    assert "lines 701-1400" in child["intent"]
+    assert "sibling subtask owns the rest" in child["intent"]
+
+
+def test_subfile_child_no_symbols_in_range(leerie):
+    parent = _base_parent()
+    child = leerie._subfile_child(
+        parent, "flow-runner.ts", (1, 50), [], "feat-005-r1",
+        "flow-runner.ts", 0, 2)
+
+    assert "(no named symbols in range)" in child["intent"]
+    assert "(no named symbols in range)" in child["success_criteria_seed"]
+
+
+# ---------------------------------------------------------------------------
+# _prune_orphaned_requires
+# ---------------------------------------------------------------------------
+
+def _plan_with(subtasks):
+    return {"domain": "test", "subtasks": subtasks}
+
+
+def test_prune_orphaned_requires_removes_tag_with_no_surviving_provider(leerie):
+    plans = [_plan_with([
+        {"id": "feat-002", "requires": [{"tag": "widget-shape", "extent": "in_plan"}]},
+    ])]
+
+    leerie._prune_orphaned_requires(plans, dropped_provides={"widget-shape"})
+
+    assert plans[0]["subtasks"][0]["requires"] == []
+
+
+def test_prune_orphaned_requires_keeps_tag_still_provided_by_a_survivor(leerie):
+    """A tag that was dropped by one subtask but is ALSO provided by a
+    surviving subtask (possibly in a different plan) must be kept."""
+    plans = [
+        _plan_with([
+            {"id": "feat-002", "requires": [{"tag": "widget-shape", "extent": "in_plan"}]},
+        ]),
+        _plan_with([
+            {"id": "feat-010", "provides": ["widget-shape"]},
+        ]),
+    ]
+
+    leerie._prune_orphaned_requires(plans, dropped_provides={"widget-shape"})
+
+    assert plans[0]["subtasks"][0]["requires"] == [
+        {"tag": "widget-shape", "extent": "in_plan"}]
+
+
+def test_prune_orphaned_requires_leaves_never_provided_tag_intact(leerie):
+    """A tag no subtask ever provided (a genuine planner error) must not
+    be silently pruned — _validate_plan needs to still surface it."""
+    plans = [_plan_with([
+        {"id": "feat-002", "requires": [{"tag": "nonexistent-tag", "extent": "in_plan"}]},
+    ])]
+
+    leerie._prune_orphaned_requires(plans, dropped_provides={"widget-shape"})
+
+    assert plans[0]["subtasks"][0]["requires"] == [
+        {"tag": "nonexistent-tag", "extent": "in_plan"}]
+
+
+def test_prune_orphaned_requires_leaves_other_tags_and_subtasks_untouched(leerie):
+    plans = [_plan_with([
+        {
+            "id": "feat-002",
+            "requires": [
+                {"tag": "widget-shape", "extent": "in_plan"},
+                {"tag": "kept-tag", "extent": "in_plan"},
+            ],
+        },
+        {"id": "feat-003", "requires": [{"tag": "kept-tag", "extent": "in_plan"}]},
+    ])]
+
+    leerie._prune_orphaned_requires(plans, dropped_provides={"widget-shape"})
+
+    assert plans[0]["subtasks"][0]["requires"] == [
+        {"tag": "kept-tag", "extent": "in_plan"}]
+    assert plans[0]["subtasks"][1]["requires"] == [
+        {"tag": "kept-tag", "extent": "in_plan"}]
+
+
+def test_prune_orphaned_requires_empty_dropped_provides_is_noop(leerie):
+    plans = [_plan_with([
+        {"id": "feat-002", "requires": [{"tag": "widget-shape", "extent": "in_plan"}]},
+    ])]
+    original = plans[0]["subtasks"][0]["requires"]
+
+    leerie._prune_orphaned_requires(plans, dropped_provides=set())
+
+    # short-circuits before touching anything
+    assert plans[0]["subtasks"][0]["requires"] is original
+
+
+def test_prune_orphaned_requires_operates_across_all_plans_at_once(leerie):
+    """A per-plan prune would wrongly drop a tag a surviving subtask in a
+    *different* plan still provides — this pins the cross-plan gate."""
+    plans = [
+        _plan_with([
+            {"id": "feat-a", "requires": [{"tag": "shared-tag", "extent": "in_plan"}]},
+        ]),
+        _plan_with([
+            {"id": "feat-b", "provides": ["shared-tag"]},
+            {"id": "feat-c", "requires": [{"tag": "shared-tag", "extent": "in_plan"}]},
+        ]),
+    ]
+
+    leerie._prune_orphaned_requires(plans, dropped_provides={"shared-tag"})
+
+    for plan in plans:
+        for s in plan["subtasks"]:
+            if s["id"] in ("feat-a", "feat-c"):
+                assert s["requires"] == [{"tag": "shared-tag", "extent": "in_plan"}]

--- a/tests/test_dep_capture_manifest_helpers.py
+++ b/tests/test_dep_capture_manifest_helpers.py
@@ -1,0 +1,175 @@
+"""Tests for the dep-capture manifest helpers that feed the DESIGN §6½
+manifests-first corpus but are never referenced directly by name in the
+existing test suite: _normalize_setup_packages, _read_file_safely,
+_sample_workspace_manifests.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# _normalize_setup_packages
+# ---------------------------------------------------------------------------
+
+class TestNormalizeSetupPackages:
+
+    def test_order_preserving_dedup(self, leerie):
+        result = leerie._normalize_setup_packages(["a", "b", "a", "c", "b"])
+        assert result == "a b c"
+
+    def test_space_joins(self, leerie):
+        result = leerie._normalize_setup_packages(["libpq-dev", "postgresql"])
+        assert result == "libpq-dev postgresql"
+
+    def test_drops_falsy_entries(self, leerie):
+        result = leerie._normalize_setup_packages(["a", "", None, "b", ""])
+        assert result == "a b"
+
+    def test_empty_list_yields_empty_string(self, leerie):
+        assert leerie._normalize_setup_packages([]) == ""
+
+    def test_single_package(self, leerie):
+        assert leerie._normalize_setup_packages(["only-one"]) == "only-one"
+
+    def test_preserves_first_seen_order_not_sorted(self, leerie):
+        result = leerie._normalize_setup_packages(["zeta", "alpha", "zeta"])
+        assert result == "zeta alpha"
+
+
+# ---------------------------------------------------------------------------
+# _read_file_safely
+# ---------------------------------------------------------------------------
+
+class TestReadFileSafely:
+
+    def test_reads_full_content_under_budget(self, leerie, tmp_path):
+        p = tmp_path / "f.txt"
+        p.write_text("hello world")
+        assert leerie._read_file_safely(p, 1000) == "hello world"
+
+    def test_missing_file_returns_empty_string(self, leerie, tmp_path):
+        p = tmp_path / "does-not-exist.txt"
+        assert leerie._read_file_safely(p, 1000) == ""
+
+    def test_missing_file_never_raises(self, leerie, tmp_path):
+        p = tmp_path / "nested" / "does-not-exist.txt"
+        # Parent dir doesn't exist either — still must not raise.
+        try:
+            result = leerie._read_file_safely(p, 1000)
+        except OSError:
+            pytest.fail("_read_file_safely raised OSError instead of swallowing it")
+        assert result == ""
+
+    def test_directory_path_returns_empty_string(self, leerie, tmp_path):
+        # read_text(errors="replace") never raises UnicodeError in practice
+        # (replace mode always succeeds), so the swallow contract's OSError
+        # arm is exercised via a path that is a directory, not a file.
+        p = tmp_path / "a-directory"
+        p.mkdir()
+        result = leerie._read_file_safely(p, 1000)
+        assert result == ""
+
+    def test_truncates_to_byte_budget(self, leerie, tmp_path):
+        p = tmp_path / "f.txt"
+        p.write_text("abcdefghij")
+        assert leerie._read_file_safely(p, 5) == "abcde"
+
+    def test_budget_larger_than_content_returns_whole_file(self, leerie, tmp_path):
+        p = tmp_path / "f.txt"
+        p.write_text("short")
+        assert leerie._read_file_safely(p, 1000) == "short"
+
+
+# ---------------------------------------------------------------------------
+# _sample_workspace_manifests
+# ---------------------------------------------------------------------------
+
+class TestSampleWorkspaceManifests:
+
+    def test_no_workspaces_key_returns_empty(self, leerie, tmp_path):
+        pkg_json_text = '{"name": "root", "version": "1.0.0"}'
+        result = leerie._sample_workspace_manifests(tmp_path, pkg_json_text, 1000, 10)
+        assert result == []
+
+    def test_malformed_json_returns_empty(self, leerie, tmp_path):
+        result = leerie._sample_workspace_manifests(tmp_path, "not json{{{", 1000, 10)
+        assert result == []
+
+    def test_workspaces_not_a_list_returns_empty(self, leerie, tmp_path):
+        pkg_json_text = '{"workspaces": "packages/*"}'
+        result = leerie._sample_workspace_manifests(tmp_path, pkg_json_text, 1000, 10)
+        assert result == []
+
+    def test_empty_workspaces_list_returns_empty(self, leerie, tmp_path):
+        pkg_json_text = '{"workspaces": []}'
+        result = leerie._sample_workspace_manifests(tmp_path, pkg_json_text, 1000, 10)
+        assert result == []
+
+    def test_real_monorepo_fixture_returns_child_manifests(self, leerie, tmp_path):
+        (tmp_path / "packages" / "foo").mkdir(parents=True)
+        (tmp_path / "packages" / "bar").mkdir(parents=True)
+        (tmp_path / "packages" / "foo" / "package.json").write_text(
+            '{"name": "foo", "dependencies": {"left-pad": "1.0.0"}}'
+        )
+        (tmp_path / "packages" / "bar" / "package.json").write_text(
+            '{"name": "bar", "dependencies": {"right-pad": "1.0.0"}}'
+        )
+        pkg_json_text = '{"workspaces": ["packages/*"]}'
+        result = leerie._sample_workspace_manifests(tmp_path, pkg_json_text, 1000, 10)
+        assert len(result) == 2
+        rel_paths = {rel for rel, _text in result}
+        assert rel_paths == {"packages/foo/package.json", "packages/bar/package.json"}
+        texts = {rel: text for rel, text in result}
+        assert "left-pad" in texts["packages/foo/package.json"]
+        assert "right-pad" in texts["packages/bar/package.json"]
+
+    def test_npm_yarn_packages_dict_shape(self, leerie, tmp_path):
+        (tmp_path / "libs" / "a").mkdir(parents=True)
+        (tmp_path / "libs" / "a" / "package.json").write_text('{"name": "a"}')
+        pkg_json_text = '{"workspaces": {"packages": ["libs/*"]}}'
+        result = leerie._sample_workspace_manifests(tmp_path, pkg_json_text, 1000, 10)
+        assert len(result) == 1
+        assert result[0][0] == "libs/a/package.json"
+
+    def test_respects_max_files_cap(self, leerie, tmp_path):
+        for i in range(5):
+            d = tmp_path / "packages" / f"pkg{i}"
+            d.mkdir(parents=True)
+            (d / "package.json").write_text(f'{{"name": "pkg{i}"}}')
+        pkg_json_text = '{"workspaces": ["packages/*"]}'
+        result = leerie._sample_workspace_manifests(tmp_path, pkg_json_text, 1000, 2)
+        assert len(result) == 2
+
+    def test_per_file_budget_truncates_child_text(self, leerie, tmp_path):
+        d = tmp_path / "packages" / "big"
+        d.mkdir(parents=True)
+        (d / "package.json").write_text('{"name": "big-package-with-a-long-name"}')
+        pkg_json_text = '{"workspaces": ["packages/*"]}'
+        result = leerie._sample_workspace_manifests(tmp_path, pkg_json_text, 5, 10)
+        assert len(result) == 1
+        assert result[0][1] == '{"nam'
+
+    def test_pattern_with_no_matching_children_returns_empty(self, leerie, tmp_path):
+        pkg_json_text = '{"workspaces": ["nonexistent/*"]}'
+        result = leerie._sample_workspace_manifests(tmp_path, pkg_json_text, 1000, 10)
+        assert result == []
+
+    def test_non_string_pattern_is_skipped(self, leerie, tmp_path):
+        d = tmp_path / "packages" / "ok"
+        d.mkdir(parents=True)
+        (d / "package.json").write_text('{"name": "ok"}')
+        pkg_json_text = '{"workspaces": [123, "packages/*"]}'
+        result = leerie._sample_workspace_manifests(tmp_path, pkg_json_text, 1000, 10)
+        assert len(result) == 1
+        assert result[0][0] == "packages/ok/package.json"
+
+    def test_dedups_when_multiple_patterns_match_same_child(self, leerie, tmp_path):
+        d = tmp_path / "packages" / "shared"
+        d.mkdir(parents=True)
+        (d / "package.json").write_text('{"name": "shared"}')
+        pkg_json_text = '{"workspaces": ["packages/*", "packages/shared"]}'
+        result = leerie._sample_workspace_manifests(tmp_path, pkg_json_text, 1000, 10)
+        assert len(result) == 1

--- a/tests/test_mise_pin_discovery.py
+++ b/tests/test_mise_pin_discovery.py
@@ -1,0 +1,197 @@
+"""Unit tests for the mise/idiomatic-version-pin discovery helpers that
+feed `_synth_mise_go_override` (DESIGN §6½ "Per-repo dependency
+provisioning"): `_existing_mise_toml_path`, `_go_already_pinned`,
+`_existing_mise_toml_tool_keys`, `_read_idiomatic_pins`.
+"""
+
+
+class TestExistingMiseTomlPath:
+    def test_prefers_mise_toml_over_dotted_when_both_exist(self, leerie, tmp_path):
+        (tmp_path / "mise.toml").write_text("[tools]\n")
+        (tmp_path / ".mise.toml").write_text("[tools]\n")
+        assert leerie._existing_mise_toml_path(tmp_path) == tmp_path / "mise.toml"
+
+    def test_returns_dotted_when_only_dotted_exists(self, leerie, tmp_path):
+        (tmp_path / ".mise.toml").write_text("[tools]\n")
+        assert leerie._existing_mise_toml_path(tmp_path) == tmp_path / ".mise.toml"
+
+    def test_returns_none_when_neither_exists(self, leerie, tmp_path):
+        assert leerie._existing_mise_toml_path(tmp_path) is None
+
+    def test_ignores_a_directory_named_mise_toml(self, leerie, tmp_path):
+        (tmp_path / "mise.toml").mkdir()
+        assert leerie._existing_mise_toml_path(tmp_path) is None
+
+
+class TestGoAlreadyPinned:
+    def test_false_when_nothing_present(self, leerie, tmp_path):
+        assert leerie._go_already_pinned(tmp_path) is False
+
+    def test_true_for_go_version_file(self, leerie, tmp_path):
+        (tmp_path / ".go-version").write_text("1.22.0\n")
+        assert leerie._go_already_pinned(tmp_path) is True
+
+    def test_true_for_go_entry_in_tool_versions(self, leerie, tmp_path):
+        (tmp_path / ".tool-versions").write_text("go 1.22.0\nnodejs 20.11.0\n")
+        assert leerie._go_already_pinned(tmp_path) is True
+
+    def test_false_when_tool_versions_lacks_go(self, leerie, tmp_path):
+        (tmp_path / ".tool-versions").write_text("nodejs 20.11.0\n")
+        assert leerie._go_already_pinned(tmp_path) is False
+
+    def test_tool_versions_ignores_comments_and_blank_lines(self, leerie, tmp_path):
+        (tmp_path / ".tool-versions").write_text("# go 1.22.0\n\nnodejs 20.11.0\n")
+        assert leerie._go_already_pinned(tmp_path) is False
+
+    def test_tool_versions_matches_case_insensitively(self, leerie, tmp_path):
+        (tmp_path / ".tool-versions").write_text("Go 1.22.0\n")
+        assert leerie._go_already_pinned(tmp_path) is True
+
+    def test_true_for_go_pin_in_mise_toml(self, leerie, tmp_path):
+        (tmp_path / "mise.toml").write_text('[tools]\ngo = "1.22.0"\n')
+        assert leerie._go_already_pinned(tmp_path) is True
+
+    def test_true_for_go_pin_in_dotted_mise_toml(self, leerie, tmp_path):
+        (tmp_path / ".mise.toml").write_text('[tools]\ngo = "1.22.0"\n')
+        assert leerie._go_already_pinned(tmp_path) is True
+
+    def test_false_when_mise_toml_has_no_go_pin(self, leerie, tmp_path):
+        (tmp_path / "mise.toml").write_text('[tools]\nnode = "20.11.0"\n')
+        assert leerie._go_already_pinned(tmp_path) is False
+
+    def test_unreadable_tool_versions_is_tolerated(self, leerie, tmp_path):
+        d = tmp_path / ".tool-versions"
+        d.mkdir()
+        assert leerie._go_already_pinned(tmp_path) is False
+
+    def test_unreadable_mise_toml_is_tolerated(self, leerie, tmp_path):
+        d = tmp_path / "mise.toml"
+        d.mkdir()
+        assert leerie._go_already_pinned(tmp_path) is False
+
+
+class TestExistingMiseTomlToolKeys:
+    def test_none_returns_empty_set(self, leerie):
+        assert leerie._existing_mise_toml_tool_keys(None) == set()
+
+    def test_empty_string_returns_empty_set(self, leerie):
+        assert leerie._existing_mise_toml_tool_keys("") == set()
+
+    def test_extracts_keys_from_tools_section(self, leerie):
+        text = '[tools]\ngo = "1.22.0"\nnode = "20.11.0"\n'
+        assert leerie._existing_mise_toml_tool_keys(text) == {"go", "node"}
+
+    def test_ignores_keys_outside_tools_section(self, leerie):
+        text = '[env]\nFOO = "bar"\n\n[tools]\ngo = "1.22.0"\n'
+        assert leerie._existing_mise_toml_tool_keys(text) == {"go"}
+
+    def test_stops_collecting_at_next_section(self, leerie):
+        text = '[tools]\ngo = "1.22.0"\n\n[settings]\nnode = "20.11.0"\n'
+        assert leerie._existing_mise_toml_tool_keys(text) == {"go"}
+
+    def test_no_tools_section_returns_empty_set(self, leerie):
+        text = '[settings]\nfoo = "bar"\n'
+        assert leerie._existing_mise_toml_tool_keys(text) == set()
+
+    def test_malformed_lines_are_skipped(self, leerie):
+        text = "[tools]\nnot a valid line\ngo = \"1.22.0\"\n"
+        assert leerie._existing_mise_toml_tool_keys(text) == {"go"}
+
+    def test_handles_hyphen_and_underscore_in_keys(self, leerie):
+        text = '[tools]\nnode-gyp = "1.0"\nfoo_bar = "2.0"\n'
+        assert leerie._existing_mise_toml_tool_keys(text) == {"node-gyp", "foo_bar"}
+
+
+class TestReadIdiomaticPins:
+    def test_empty_repo_returns_empty_list(self, leerie, tmp_path):
+        assert leerie._read_idiomatic_pins(tmp_path, set()) == []
+
+    def test_reads_nvmrc(self, leerie, tmp_path):
+        (tmp_path / ".nvmrc").write_text("v20.11.0\n")
+        pins = leerie._read_idiomatic_pins(tmp_path, set())
+        assert pins == [("node", "20.11.0")]
+
+    def test_strips_leading_v_from_node_version(self, leerie, tmp_path):
+        (tmp_path / ".node-version").write_text("V18.0.0\n")
+        pins = leerie._read_idiomatic_pins(tmp_path, set())
+        assert pins == [("node", "18.0.0")]
+
+    def test_python_version_not_transformed(self, leerie, tmp_path):
+        (tmp_path / ".python-version").write_text("3.12.1\n")
+        pins = leerie._read_idiomatic_pins(tmp_path, set())
+        assert pins == [("python", "3.12.1")]
+
+    def test_ruby_version(self, leerie, tmp_path):
+        (tmp_path / ".ruby-version").write_text("3.3.0\n")
+        pins = leerie._read_idiomatic_pins(tmp_path, set())
+        assert pins == [("ruby", "3.3.0")]
+
+    def test_skips_tool_already_in_already_pinned(self, leerie, tmp_path):
+        (tmp_path / ".nvmrc").write_text("v20.11.0\n")
+        pins = leerie._read_idiomatic_pins(tmp_path, {"node"})
+        assert pins == []
+
+    def test_already_pinned_set_is_mutated_with_new_pins(self, leerie, tmp_path):
+        (tmp_path / ".python-version").write_text("3.12.1\n")
+        already_pinned = set()
+        leerie._read_idiomatic_pins(tmp_path, already_pinned)
+        assert "python" in already_pinned
+
+    def test_nvmrc_and_node_version_both_present_prefers_nvmrc(self, leerie, tmp_path):
+        # .nvmrc is listed first in _IDIOMATIC_VERSION_FILES, so it wins
+        # and .node-version is skipped via the already_pinned mutation.
+        (tmp_path / ".nvmrc").write_text("v20.11.0\n")
+        (tmp_path / ".node-version").write_text("18.0.0\n")
+        pins = leerie._read_idiomatic_pins(tmp_path, set())
+        assert pins == [("node", "20.11.0")]
+
+    def test_empty_file_yields_no_pin(self, leerie, tmp_path):
+        (tmp_path / ".python-version").write_text("\n")
+        assert leerie._read_idiomatic_pins(tmp_path, set()) == []
+
+    def test_uses_first_nonblank_line_only(self, leerie, tmp_path):
+        (tmp_path / ".python-version").write_text("3.12.1\nsome-other-line\n")
+        pins = leerie._read_idiomatic_pins(tmp_path, set())
+        assert pins == [("python", "3.12.1")]
+
+    def test_tool_versions_parsed_line_by_line(self, leerie, tmp_path):
+        (tmp_path / ".tool-versions").write_text(
+            "nodejs 20.11.0\npython 3.12.1\n# comment line\n\n"
+        )
+        pins = leerie._read_idiomatic_pins(tmp_path, set())
+        assert ("node", "20.11.0") in pins
+        assert ("python", "3.12.1") in pins
+
+    def test_tool_versions_asdf_alias_normalized_to_mise_name(self, leerie, tmp_path):
+        (tmp_path / ".tool-versions").write_text("nodejs 20.11.0\n")
+        pins = leerie._read_idiomatic_pins(tmp_path, set())
+        assert pins == [("node", "20.11.0")]
+
+    def test_tool_versions_skips_tool_already_pinned(self, leerie, tmp_path):
+        (tmp_path / ".tool-versions").write_text("go 1.22.0\npython 3.12.1\n")
+        pins = leerie._read_idiomatic_pins(tmp_path, {"go"})
+        assert pins == [("python", "3.12.1")]
+
+    def test_tool_versions_does_not_double_pin_nvmrc_and_nodejs_alias(self, leerie, tmp_path):
+        # A repo with both .nvmrc (injects "node") and .tool-versions
+        # carrying "nodejs 20.11.0" must not end up with both "node" and
+        # "nodejs" pinned — mise treats them as the same tool.
+        (tmp_path / ".nvmrc").write_text("v20.11.0\n")
+        (tmp_path / ".tool-versions").write_text("nodejs 18.0.0\n")
+        pins = leerie._read_idiomatic_pins(tmp_path, set())
+        assert pins == [("node", "20.11.0")]
+
+    def test_tool_versions_malformed_line_with_no_version_is_skipped(self, leerie, tmp_path):
+        (tmp_path / ".tool-versions").write_text("go\npython 3.12.1\n")
+        pins = leerie._read_idiomatic_pins(tmp_path, set())
+        assert pins == [("python", "3.12.1")]
+
+    def test_missing_tool_versions_file_is_a_no_op(self, leerie, tmp_path):
+        (tmp_path / ".python-version").write_text("3.12.1\n")
+        pins = leerie._read_idiomatic_pins(tmp_path, set())
+        assert pins == [("python", "3.12.1")]
+
+    def test_unreadable_idiomatic_file_is_tolerated(self, leerie, tmp_path):
+        d = tmp_path / ".python-version"
+        d.mkdir()
+        assert leerie._read_idiomatic_pins(tmp_path, set()) == []

--- a/tests/test_pid_still_exists.py
+++ b/tests/test_pid_still_exists.py
@@ -1,0 +1,20 @@
+import os
+import subprocess
+import sys
+
+from orchestrator import leerie
+
+
+def test_pid_still_exists_true_for_self():
+    assert leerie._pid_still_exists(os.getpid()) is True
+
+
+def test_pid_still_exists_false_after_reaped_child():
+    proc = subprocess.Popen([sys.executable, "-c", "pass"])
+    pid = proc.pid
+    proc.wait()
+    assert leerie._pid_still_exists(pid) is False
+
+
+def test_pid_still_exists_false_for_pid_far_past_pid_max():
+    assert leerie._pid_still_exists(2**30) is False

--- a/tests/test_reconciler_collision_helpers.py
+++ b/tests/test_reconciler_collision_helpers.py
@@ -1,0 +1,404 @@
+"""Unit tests for the leaf/formatting helpers underneath the reconciler's
+cycle-attribution and collision-resolution machinery (DESIGN §5): SCC edge
+attribution, shared-file detection, rename-tag resolution, collision
+drop/survivor accessors, wiring-defect label rendering, and the
+`depends_on` edge builder.
+
+These are the primitive accessors the multi-drop incident (CLAUDE.md,
+`test_apply_multi_drop_preserves_both_survivors`) sits one layer above —
+none are referenced directly by name in the existing overlap-judge /
+wiring-gate test suites, despite backing behavior those suites depend on.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from orchestrator import leerie
+
+
+# ===========================================================================
+# _attribute_cycle_edges
+# ===========================================================================
+
+class TestAttributeCycleEdges:
+    def test_planner_declared_when_no_mutation_closed_it(self):
+        scc = ["feat-001", "feat-002"]
+        succ = {"feat-001": {"feat-002"}, "feat-002": {"feat-001"}}
+        edge_sources = {
+            ("feat-001", "feat-002"): "depends_on",
+            ("feat-002", "feat-001"): "depends_on",
+        }
+        output = {"renames": [], "added_subtasks": [], "dependency_edges": []}
+        edges = leerie._attribute_cycle_edges(
+            scc, succ, edge_sources, output, {})
+        assert len(edges) == 2
+        for e in edges:
+            assert e["mutation"] == "planner-declared"
+
+    def test_added_subtask_as_source_attributes_to_it(self):
+        scc = ["feat-001", "feat-002"]
+        succ = {"feat-001": {"feat-002"}, "feat-002": {"feat-001"}}
+        edge_sources = {
+            ("feat-001", "feat-002"): "depends_on",
+            ("feat-002", "feat-001"): "depends_on",
+        }
+        output = {
+            "renames": [],
+            "added_subtasks": [{"id": "feat-001"}],
+            "dependency_edges": [],
+        }
+        edges = leerie._attribute_cycle_edges(
+            scc, succ, edge_sources, output, {})
+        by_pair = {(e["from"], e["to"]): e for e in edges}
+        assert by_pair[("feat-001", "feat-002")]["mutation"] == \
+            "added_subtask: feat-001"
+
+    def test_added_subtask_as_destination_attributes_to_it(self):
+        scc = ["feat-001", "feat-002"]
+        succ = {"feat-001": {"feat-002"}, "feat-002": {"feat-001"}}
+        edge_sources = {
+            ("feat-001", "feat-002"): "depends_on",
+            ("feat-002", "feat-001"): "depends_on",
+        }
+        output = {
+            "renames": [],
+            "added_subtasks": [{"id": "feat-002"}],
+            "dependency_edges": [],
+        }
+        edges = leerie._attribute_cycle_edges(
+            scc, succ, edge_sources, output, {})
+        by_pair = {(e["from"], e["to"]): e for e in edges}
+        assert by_pair[("feat-001", "feat-002")]["mutation"] == \
+            "added_subtask: feat-002"
+
+    def test_dependency_edge_attribution(self):
+        scc = ["feat-001", "feat-002"]
+        succ = {"feat-001": {"feat-002"}, "feat-002": {"feat-001"}}
+        edge_sources = {
+            ("feat-001", "feat-002"): "depends_on",
+            ("feat-002", "feat-001"): "depends_on",
+        }
+        output = {
+            "renames": [],
+            "added_subtasks": [],
+            "dependency_edges": [{"from": "feat-002", "to": "feat-001"}],
+        }
+        edges = leerie._attribute_cycle_edges(
+            scc, succ, edge_sources, output, {})
+        by_pair = {(e["from"], e["to"]): e for e in edges}
+        assert by_pair[("feat-002", "feat-001")]["mutation"] == \
+            "dependency_edge: feat-002 -> feat-001"
+        assert by_pair[("feat-001", "feat-002")]["mutation"] == \
+            "planner-declared"
+
+    def test_rename_attribution_on_requires_edge(self):
+        # feat-001 -> feat-002 means feat-001 provides what feat-002
+        # requires; the requires entry actually renamed lives on the
+        # CONSUMER (feat-002), looked up by (dst, tag).
+        scc = ["feat-001", "feat-002"]
+        succ = {"feat-001": {"feat-002"}, "feat-002": {"feat-001"}}
+        edge_sources = {
+            ("feat-001", "feat-002"): "requires:bar",
+            ("feat-002", "feat-001"): "depends_on",
+        }
+        output = {
+            "renames": [{"sid": "feat-002", "from": "foo", "to": "bar"}],
+            "added_subtasks": [],
+            "dependency_edges": [],
+        }
+        edges = leerie._attribute_cycle_edges(
+            scc, succ, edge_sources, output, {})
+        by_pair = {(e["from"], e["to"]): e for e in edges}
+        e = by_pair[("feat-001", "feat-002")]
+        assert e["mutation"] == \
+            "rename: feat-002's 'foo' -> 'bar' (provided by feat-001)"
+
+    def test_requires_edge_no_matching_rename_stays_planner_declared(self):
+        scc = ["feat-001", "feat-002"]
+        succ = {"feat-001": {"feat-002"}, "feat-002": {"feat-001"}}
+        edge_sources = {
+            ("feat-001", "feat-002"): "requires:bar",
+            ("feat-002", "feat-001"): "depends_on",
+        }
+        output = {"renames": [], "added_subtasks": [], "dependency_edges": []}
+        edges = leerie._attribute_cycle_edges(
+            scc, succ, edge_sources, output, {})
+        by_pair = {(e["from"], e["to"]): e for e in edges}
+        assert by_pair[("feat-001", "feat-002")]["mutation"] == \
+            "planner-declared"
+
+    def test_edges_outside_scc_are_excluded(self):
+        scc = ["feat-001", "feat-002"]
+        succ = {
+            "feat-001": {"feat-002"},
+            "feat-002": {"feat-001", "feat-003"},
+        }
+        edge_sources = {
+            ("feat-001", "feat-002"): "depends_on",
+            ("feat-002", "feat-001"): "depends_on",
+            ("feat-002", "feat-003"): "depends_on",
+        }
+        output = {"renames": [], "added_subtasks": [], "dependency_edges": []}
+        edges = leerie._attribute_cycle_edges(
+            scc, succ, edge_sources, output, {})
+        pairs = {(e["from"], e["to"]) for e in edges}
+        assert ("feat-002", "feat-003") not in pairs
+        assert len(edges) == 2
+
+    def test_unlabeled_edge_source_defaults_to_question_mark(self):
+        scc = ["feat-001", "feat-002"]
+        succ = {"feat-001": {"feat-002"}, "feat-002": {"feat-001"}}
+        edge_sources = {("feat-002", "feat-001"): "depends_on"}
+        output = {"renames": [], "added_subtasks": [], "dependency_edges": []}
+        edges = leerie._attribute_cycle_edges(
+            scc, succ, edge_sources, output, {})
+        by_pair = {(e["from"], e["to"]): e for e in edges}
+        assert by_pair[("feat-001", "feat-002")]["source"] == "?"
+
+
+# ===========================================================================
+# _shared_files_in_scc
+# ===========================================================================
+
+class TestSharedFilesInScc:
+    def test_scc_smaller_than_two_returns_empty(self):
+        subtasks = {"feat-001": {"files_likely_touched": ["a.py"]}}
+        assert leerie._shared_files_in_scc(["feat-001"], subtasks) == []
+        assert leerie._shared_files_in_scc([], subtasks) == []
+
+    def test_shared_file_across_two_members(self):
+        subtasks = {
+            "feat-001": {"files_likely_touched": ["a.py", "b.py"]},
+            "feat-002": {"files_likely_touched": ["b.py", "c.py"]},
+        }
+        result = leerie._shared_files_in_scc(
+            ["feat-001", "feat-002"], subtasks)
+        assert result == ["b.py"]
+
+    def test_no_overlap_returns_empty(self):
+        subtasks = {
+            "feat-001": {"files_likely_touched": ["a.py"]},
+            "feat-002": {"files_likely_touched": ["b.py"]},
+        }
+        assert leerie._shared_files_in_scc(
+            ["feat-001", "feat-002"], subtasks) == []
+
+    def test_result_is_sorted(self):
+        subtasks = {
+            "feat-001": {"files_likely_touched": ["z.py", "a.py"]},
+            "feat-002": {"files_likely_touched": ["z.py", "a.py"]},
+        }
+        result = leerie._shared_files_in_scc(
+            ["feat-001", "feat-002"], subtasks)
+        assert result == ["a.py", "z.py"]
+
+    def test_file_shared_by_all_three_still_counted_once(self):
+        subtasks = {
+            "feat-001": {"files_likely_touched": ["a.py"]},
+            "feat-002": {"files_likely_touched": ["a.py"]},
+            "feat-003": {"files_likely_touched": ["a.py"]},
+        }
+        result = leerie._shared_files_in_scc(
+            ["feat-001", "feat-002", "feat-003"], subtasks)
+        assert result == ["a.py"]
+
+    def test_missing_subtask_or_field_tolerated(self):
+        subtasks = {"feat-001": {"files_likely_touched": ["a.py"]}}
+        # feat-002 absent from the map entirely, feat-003 has no field.
+        subtasks["feat-003"] = {}
+        result = leerie._shared_files_in_scc(
+            ["feat-001", "feat-002", "feat-003"], subtasks)
+        assert result == []
+
+
+# ===========================================================================
+# _original_tag_for_rename_edge
+# ===========================================================================
+
+class TestOriginalTagForRenameEdge:
+    def test_non_requires_edge_returns_empty_string(self):
+        edge = {"from": "a", "to": "b", "source": "depends_on"}
+        assert leerie._original_tag_for_rename_edge(edge, {}) == ""
+
+    def test_returns_pre_rename_tag_when_rename_present(self):
+        edge = {"from": "a", "to": "b", "source": "requires:bar"}
+        output = {"renames": [{"sid": "b", "from": "foo", "to": "bar"}]}
+        assert leerie._original_tag_for_rename_edge(edge, output) == "foo"
+
+    def test_no_matching_rename_returns_post_rename_tag(self):
+        edge = {"from": "a", "to": "b", "source": "requires:bar"}
+        output = {"renames": []}
+        assert leerie._original_tag_for_rename_edge(edge, output) == "bar"
+
+    def test_rename_for_a_different_sid_is_ignored(self):
+        edge = {"from": "a", "to": "b", "source": "requires:bar"}
+        output = {"renames": [{"sid": "c", "from": "foo", "to": "bar"}]}
+        assert leerie._original_tag_for_rename_edge(edge, output) == "bar"
+
+    def test_rename_to_a_different_tag_is_ignored(self):
+        edge = {"from": "a", "to": "b", "source": "requires:bar"}
+        output = {
+            "renames": [{"sid": "b", "from": "foo", "to": "quux"}],
+        }
+        assert leerie._original_tag_for_rename_edge(edge, output) == "bar"
+
+    def test_missing_source_label_treated_as_non_requires(self):
+        edge = {"from": "a", "to": "b"}
+        assert leerie._original_tag_for_rename_edge(edge, {}) == ""
+
+
+# ===========================================================================
+# _collision_dropped_sid
+# ===========================================================================
+
+class TestCollisionDroppedSid:
+    def test_drop_a_returns_a_sid(self):
+        c = {"resolution": "drop_a", "a_sid": "feat-001", "b_sid": "feat-002"}
+        assert leerie._collision_dropped_sid(c) == "feat-001"
+
+    def test_drop_b_returns_b_sid(self):
+        c = {"resolution": "drop_b", "a_sid": "feat-001", "b_sid": "feat-002"}
+        assert leerie._collision_dropped_sid(c) == "feat-002"
+
+    def test_merge_returns_none(self):
+        c = {"resolution": "merge", "a_sid": "feat-001", "b_sid": "feat-002"}
+        assert leerie._collision_dropped_sid(c) is None
+
+    def test_unresolvable_returns_none(self):
+        c = {
+            "resolution": "unresolvable",
+            "a_sid": "feat-001",
+            "b_sid": "feat-002",
+        }
+        assert leerie._collision_dropped_sid(c) is None
+
+    def test_missing_resolution_returns_none(self):
+        assert leerie._collision_dropped_sid({}) is None
+
+
+# ===========================================================================
+# _collision_surviving_sids
+# ===========================================================================
+
+class TestCollisionSurvivingSids:
+    def test_merge_keeps_both_endpoints(self):
+        c = {"resolution": "merge", "a_sid": "feat-001", "b_sid": "feat-002"}
+        assert sorted(leerie._collision_surviving_sids(c)) == \
+            ["feat-001", "feat-002"]
+
+    def test_drop_a_keeps_b_sid(self):
+        c = {"resolution": "drop_a", "a_sid": "feat-001", "b_sid": "feat-002"}
+        assert leerie._collision_surviving_sids(c) == ["feat-002"]
+
+    def test_drop_b_keeps_a_sid(self):
+        c = {"resolution": "drop_b", "a_sid": "feat-001", "b_sid": "feat-002"}
+        assert leerie._collision_surviving_sids(c) == ["feat-001"]
+
+    def test_unresolvable_returns_empty(self):
+        c = {
+            "resolution": "unresolvable",
+            "a_sid": "feat-001",
+            "b_sid": "feat-002",
+        }
+        assert leerie._collision_surviving_sids(c) == []
+
+    def test_merge_missing_a_sid_only_keeps_b(self):
+        c = {"resolution": "merge", "b_sid": "feat-002"}
+        assert leerie._collision_surviving_sids(c) == ["feat-002"]
+
+    def test_drop_a_missing_b_sid_returns_empty(self):
+        c = {"resolution": "drop_a", "a_sid": "feat-001"}
+        assert leerie._collision_surviving_sids(c) == []
+
+
+# ===========================================================================
+# _wiring_defect_label
+# ===========================================================================
+
+class TestWiringDefectLabel:
+    def test_renders_documented_shape(self):
+        d = {
+            "kind": "missing_requires",
+            "sid": "feat-003",
+            "tag_or_dep": "parsed-config",
+            "concrete_reason": "no in-plan provider declares this tag",
+        }
+        label = leerie._wiring_defect_label(d)
+        assert label == (
+            "(missing_requires) feat-003 / parsed-config: "
+            "no in-plan provider declares this tag"
+        )
+
+    def test_missing_fields_fall_back_to_defaults(self):
+        label = leerie._wiring_defect_label({})
+        assert label == "(wiring_defect) ? / : "
+
+    def test_strips_whitespace_from_tag_and_reason(self):
+        d = {
+            "kind": "broken_by_drop",
+            "sid": "feat-004",
+            "tag_or_dep": "  some-tag  ",
+            "concrete_reason": "  the provider was dropped  ",
+        }
+        label = leerie._wiring_defect_label(d)
+        assert label == (
+            "(broken_by_drop) feat-004 / some-tag: the provider was dropped"
+        )
+
+
+# ===========================================================================
+# _add_depends_on_edge
+# ===========================================================================
+
+class TestAddDependsOnEdge:
+    def test_appends_to_existing_depends_on(self):
+        tree = [{
+            "subtasks": [
+                {"id": "feat-001", "depends_on": ["feat-000"]},
+                {"id": "feat-002", "depends_on": []},
+            ]
+        }]
+        leerie._add_depends_on_edge(tree, "feat-001", "feat-002")
+        assert tree[0]["subtasks"][0]["depends_on"] == [
+            "feat-000", "feat-002"]
+
+    def test_creates_depends_on_when_absent(self):
+        tree = [{"subtasks": [{"id": "feat-001"}]}]
+        leerie._add_depends_on_edge(tree, "feat-001", "feat-002")
+        assert tree[0]["subtasks"][0]["depends_on"] == ["feat-002"]
+
+    def test_finds_sid_across_multiple_plans(self):
+        tree = [
+            {"subtasks": [{"id": "feat-001"}]},
+            {"subtasks": [{"id": "feat-002", "depends_on": []}]},
+        ]
+        leerie._add_depends_on_edge(tree, "feat-002", "feat-003")
+        assert tree[1]["subtasks"][0]["depends_on"] == ["feat-003"]
+        assert "depends_on" not in tree[0]["subtasks"][0]
+
+    def test_unknown_sid_is_a_silent_no_op(self):
+        tree = [{"subtasks": [{"id": "feat-001", "depends_on": []}]}]
+        leerie._add_depends_on_edge(tree, "feat-999", "feat-002")
+        assert tree[0]["subtasks"][0]["depends_on"] == []
+
+    def test_mutates_in_place_not_a_copy(self):
+        tree = [{"subtasks": [{"id": "feat-001", "depends_on": []}]}]
+        target = tree[0]["subtasks"][0]
+        leerie._add_depends_on_edge(tree, "feat-001", "feat-002")
+        assert target["depends_on"] == ["feat-002"]
+
+    def test_stops_at_first_matching_sid(self):
+        # Guards against a future edit that iterates all plans/subtasks
+        # unconditionally instead of returning on first match.
+        tree = [{
+            "subtasks": [
+                {"id": "feat-001", "depends_on": []},
+                {"id": "feat-001", "depends_on": []},
+            ]
+        }]
+        leerie._add_depends_on_edge(tree, "feat-001", "feat-002")
+        assert tree[0]["subtasks"][0]["depends_on"] == ["feat-002"]
+        assert tree[0]["subtasks"][1]["depends_on"] == []

--- a/tests/test_repo_map_render_helpers.py
+++ b/tests/test_repo_map_render_helpers.py
@@ -1,0 +1,227 @@
+"""Unit tests for the repo-map rendering and safety leaf helpers (DESIGN §5½
+(P6)): _is_same_document, _render_repo_map_subgraph, _count_tokens_approx,
+_resolves_under.
+
+Their siblings (_rank_repo_map, _build_repo_map) are extensively covered in
+tests/test_repo_map.py; these four are not referenced by name anywhere else
+in the suite.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+
+# ---------------------------------------------------------------------------
+# _is_same_document
+# ---------------------------------------------------------------------------
+
+class TestIsSameDocument:
+    def test_true_for_exact_content_match(self, leerie, tmp_path):
+        text = "hello world\nline two"
+        f = tmp_path / "task.md"
+        f.write_text(text)
+        assert leerie._is_same_document(f, len(text.encode()), text) is True
+
+    def test_true_modulo_surrounding_whitespace(self, leerie, tmp_path):
+        text = "hello world"
+        f = tmp_path / "task.md"
+        f.write_text("  \n" + text + "\n\n  ")
+        assert leerie._is_same_document(
+            f, len(text.encode()), text
+        ) is True
+
+    def test_false_on_size_mismatch_beyond_threshold(self, leerie, tmp_path):
+        text = "short"
+        f = tmp_path / "task.md"
+        # far longer than `text`, well past the documented 8-byte pre-check
+        f.write_text("short" + "x" * 100)
+        assert leerie._is_same_document(
+            f, len(text.encode()), text
+        ) is False
+
+    def test_size_precheck_prevents_reading_when_mismatched(
+        self, leerie, tmp_path, monkeypatch
+    ):
+        text = "short"
+        f = tmp_path / "task.md"
+        f.write_text("short" + "x" * 100)
+
+        def _boom(*a, **kw):
+            raise AssertionError("read_text should not be called")
+
+        monkeypatch.setattr(Path, "read_text", _boom, raising=True)
+        assert leerie._is_same_document(
+            f, len(text.encode()), text
+        ) is False
+
+    def test_false_for_different_content_same_size(self, leerie, tmp_path):
+        text = "aaaa"
+        f = tmp_path / "task.md"
+        f.write_text("bbbb")
+        assert leerie._is_same_document(
+            f, len(text.encode()), text
+        ) is False
+
+    def test_false_on_missing_file(self, leerie, tmp_path):
+        text = "hello"
+        f = tmp_path / "missing.md"
+        assert leerie._is_same_document(
+            f, len(text.encode()), text
+        ) is False
+
+
+# ---------------------------------------------------------------------------
+# _render_repo_map_subgraph
+# ---------------------------------------------------------------------------
+
+class TestRenderRepoMapSubgraph:
+    def _repo_map(self):
+        return {
+            "files": {
+                "a.py": ["FooA", "BarA"],
+                "b.py": ["FooB"],
+                "c.py": [],  # no defs — must be omitted
+                "d.py": ["FooD"],
+            },
+            "refs": {},
+        }
+
+    def test_one_line_per_ranked_file_with_symbols(self, leerie):
+        repo_map = self._repo_map()
+        ranked = [("a.py", 3.0), ("b.py", 2.0), ("d.py", 1.0)]
+        out = leerie._render_repo_map_subgraph(repo_map, ranked, max_files=10)
+        lines = out.split("\n")
+        assert lines == [
+            "a.py: FooA, BarA",
+            "b.py: FooB",
+            "d.py: FooD",
+        ]
+
+    def test_honors_max_files(self, leerie):
+        repo_map = self._repo_map()
+        ranked = [("a.py", 3.0), ("b.py", 2.0), ("d.py", 1.0)]
+        out = leerie._render_repo_map_subgraph(repo_map, ranked, max_files=1)
+        assert out == "a.py: FooA, BarA"
+
+    def test_top_ranked_first(self, leerie):
+        repo_map = self._repo_map()
+        # ranked_files is already in rank order; the renderer must not
+        # re-sort it.
+        ranked = [("b.py", 9.0), ("a.py", 1.0)]
+        out = leerie._render_repo_map_subgraph(repo_map, ranked, max_files=10)
+        assert out.split("\n") == ["b.py: FooB", "a.py: FooA, BarA"]
+
+    def test_files_with_no_defs_are_omitted(self, leerie):
+        repo_map = self._repo_map()
+        ranked = [("c.py", 5.0), ("a.py", 1.0)]
+        out = leerie._render_repo_map_subgraph(repo_map, ranked, max_files=10)
+        assert "c.py" not in out
+        assert out == "a.py: FooA, BarA"
+
+    def test_file_not_in_files_map_is_skipped(self, leerie):
+        repo_map = self._repo_map()
+        ranked = [("nowhere.py", 5.0), ("a.py", 1.0)]
+        out = leerie._render_repo_map_subgraph(repo_map, ranked, max_files=10)
+        assert out == "a.py: FooA, BarA"
+
+    def test_empty_ranked_files_yields_empty_string(self, leerie):
+        repo_map = self._repo_map()
+        out = leerie._render_repo_map_subgraph(repo_map, [], max_files=10)
+        assert out == ""
+
+
+# ---------------------------------------------------------------------------
+# _count_tokens_approx
+# ---------------------------------------------------------------------------
+
+class TestCountTokensApprox:
+    def test_approximates_four_bytes_per_token(self, leerie):
+        text = "x" * 400
+        assert leerie._count_tokens_approx(text) == 100
+
+    def test_never_returns_zero_for_empty_string(self, leerie):
+        assert leerie._count_tokens_approx("") == 1
+
+    def test_never_returns_zero_for_tiny_string(self, leerie):
+        assert leerie._count_tokens_approx("ab") == 1
+
+    def test_uses_encoded_byte_length_not_char_length(self, leerie):
+        # multi-byte UTF-8 chars: byte length > char length
+        text = "é" * 8  # 2 bytes each in UTF-8 -> 16 bytes -> 4 tokens
+        assert leerie._count_tokens_approx(text) == 4
+
+
+# ---------------------------------------------------------------------------
+# _resolves_under
+# ---------------------------------------------------------------------------
+
+class TestResolvesUnder:
+    def test_true_for_relative_path_inside_root(self, leerie, tmp_path):
+        root = tmp_path / "repo"
+        root.mkdir()
+        (root / "sub").mkdir()
+        assert leerie._resolves_under("sub/file.py", root) is True
+
+    def test_true_for_absolute_path_inside_root(self, leerie, tmp_path):
+        root = tmp_path / "repo"
+        root.mkdir()
+        target = root / "sub" / "file.py"
+        assert leerie._resolves_under(str(target), root) is True
+
+    def test_false_for_path_escaping_root_via_dotdot(self, leerie, tmp_path):
+        root = tmp_path / "repo"
+        root.mkdir()
+        outside = tmp_path / "elsewhere"
+        outside.mkdir()
+        assert leerie._resolves_under("../elsewhere/x.py", root) is False
+
+    def test_false_for_absolute_path_outside_root(self, leerie, tmp_path):
+        root = tmp_path / "repo"
+        root.mkdir()
+        outside = tmp_path / "elsewhere" / "x.py"
+        assert leerie._resolves_under(str(outside), root) is False
+
+    def test_symlinked_decoy_escaping_root_returns_false(
+        self, leerie, tmp_path
+    ):
+        root = tmp_path / "repo"
+        root.mkdir()
+        outside_dir = tmp_path / "outside"
+        outside_dir.mkdir()
+        secret = outside_dir / "secret.txt"
+        secret.write_text("nope")
+
+        decoy = root / "decoy.txt"
+        decoy.symlink_to(secret)
+
+        assert leerie._resolves_under("decoy.txt", root) is False
+
+    def test_symlink_target_inside_root_returns_true(self, leerie, tmp_path):
+        root = tmp_path / "repo"
+        root.mkdir()
+        real = root / "real.txt"
+        real.write_text("hi")
+        link = root / "link.txt"
+        link.symlink_to(real)
+
+        assert leerie._resolves_under("link.txt", root) is True
+
+    def test_false_on_value_error(self, leerie, tmp_path, monkeypatch):
+        root = tmp_path / "repo"
+        root.mkdir()
+
+        def _boom(*a, **kw):
+            raise ValueError("boom")
+
+        monkeypatch.setattr(Path, "resolve", _boom, raising=True)
+        assert leerie._resolves_under("x.py", root) is False
+
+    def test_false_on_os_error(self, leerie, tmp_path, monkeypatch):
+        root = tmp_path / "repo"
+        root.mkdir()
+
+        def _boom(*a, **kw):
+            raise OSError("boom")
+
+        monkeypatch.setattr(Path, "resolve", _boom, raising=True)
+        assert leerie._resolves_under("x.py", root) is False

--- a/tests/test_resolve_enum_str_prefs.py
+++ b/tests/test_resolve_enum_str_prefs.py
@@ -1,0 +1,324 @@
+"""Tests for the shared `_resolve_enum_pref` / `_resolve_str_pref`
+primitives and their thin wrappers `resolve_judge_dir`, `resolve_heal_dir`,
+and `resolve_dangerously_allow_uncapped`.
+
+These mirror the existing `_resolve_bool_pref`-shape test files
+(`test_resolve_dangerously_skip_permissions.py`, `test_resolve_no_push.py`)
+but cover the two sibling resolvers (enum-valued, unvalidated-string) that
+had no direct precedence/die() tests of their own — only indirectly via
+callers like `resolve_runtime`/`resolve_pr_base_branch`.
+"""
+from __future__ import annotations
+
+import pytest
+
+
+# --- _resolve_enum_pref ---------------------------------------------------
+
+
+@pytest.fixture
+def repo_root(tmp_path, monkeypatch):
+    monkeypatch.delenv("LEERIE_TEST_ENUM", raising=False)
+    return tmp_path
+
+
+def _call_enum(leerie, repo_root, cli_value=None):
+    return leerie._resolve_enum_pref(
+        repo_root, cli_value,
+        env_var="LEERIE_TEST_ENUM", file_key="test_enum",
+        file_name="leerie.toml",
+        allowed=("a", "b", "c"), default="a")
+
+
+def test_enum_default_when_nothing_set(leerie, repo_root):
+    assert _call_enum(leerie, repo_root) == "a"
+
+
+def test_enum_cli_wins(leerie, repo_root, monkeypatch):
+    (repo_root / "leerie.toml").write_text("test_enum = b\n")
+    monkeypatch.setenv("LEERIE_TEST_ENUM", "c")
+    assert _call_enum(leerie, repo_root, cli_value="a") == "a"
+
+
+def test_enum_env_wins_over_file(leerie, repo_root, monkeypatch):
+    (repo_root / "leerie.toml").write_text("test_enum = c\n")
+    monkeypatch.setenv("LEERIE_TEST_ENUM", "b")
+    assert _call_enum(leerie, repo_root) == "b"
+
+
+def test_enum_file_used_when_env_unset(leerie, repo_root):
+    (repo_root / "leerie.toml").write_text("test_enum = c\n")
+    assert _call_enum(leerie, repo_root) == "c"
+
+
+def test_enum_full_precedence_cli_beats_env_beats_file(leerie, repo_root, monkeypatch):
+    (repo_root / "leerie.toml").write_text("test_enum = c\n")
+    monkeypatch.setenv("LEERIE_TEST_ENUM", "b")
+    assert _call_enum(leerie, repo_root) == "b"
+    assert _call_enum(leerie, repo_root, cli_value="a") == "a"
+
+
+def test_enum_empty_env_treated_as_unset(leerie, repo_root, monkeypatch):
+    monkeypatch.setenv("LEERIE_TEST_ENUM", "")
+    assert _call_enum(leerie, repo_root) == "a"
+
+
+def test_enum_empty_cli_falls_through(leerie, repo_root, monkeypatch):
+    monkeypatch.setenv("LEERIE_TEST_ENUM", "b")
+    assert _call_enum(leerie, repo_root, cli_value=None) == "b"
+
+
+def test_enum_bad_env_value_dies(leerie, repo_root, monkeypatch, capsys):
+    monkeypatch.setenv("LEERIE_TEST_ENUM", "bogus")
+    with pytest.raises(SystemExit) as exc:
+        _call_enum(leerie, repo_root)
+    assert exc.value.code != 0
+    err = capsys.readouterr().err
+    assert "is not one of" in err
+    assert "bogus" in err
+
+
+def test_enum_bad_file_value_dies(leerie, repo_root, capsys):
+    (repo_root / "leerie.toml").write_text("test_enum = bogus\n")
+    with pytest.raises(SystemExit) as exc:
+        _call_enum(leerie, repo_root)
+    assert exc.value.code != 0
+    err = capsys.readouterr().err
+    assert "is not one of" in err
+    assert "bogus" in err
+
+
+def test_enum_cli_value_bypasses_allowed_check(leerie, repo_root):
+    """CLI values are trusted (argparse choices= already validated them at
+    the parser level) — _resolve_enum_pref itself does not re-check `cli_value`
+    against `allowed`, mirroring resolve_source_of_truth's own docstring."""
+    assert _call_enum(leerie, repo_root, cli_value="not-in-allowed") == "not-in-allowed"
+
+
+@pytest.mark.parametrize("value", ["a", "b", "c"])
+def test_enum_all_allowed_values_accepted_in_env(leerie, repo_root, monkeypatch, value):
+    monkeypatch.setenv("LEERIE_TEST_ENUM", value)
+    assert _call_enum(leerie, repo_root) == value
+
+
+@pytest.mark.parametrize("value", ["a", "b", "c"])
+def test_enum_all_allowed_values_accepted_in_file(leerie, repo_root, value):
+    (repo_root / "leerie.toml").write_text(f"test_enum = {value}\n")
+    assert _call_enum(leerie, repo_root) == value
+
+
+# --- _resolve_str_pref -----------------------------------------------------
+
+
+@pytest.fixture
+def str_repo_root(tmp_path, monkeypatch):
+    monkeypatch.delenv("LEERIE_TEST_STR", raising=False)
+    return tmp_path
+
+
+def _call_str(leerie, repo_root, cli_value=None, default=None):
+    return leerie._resolve_str_pref(
+        repo_root, cli_value,
+        env_var="LEERIE_TEST_STR", file_key="test_str",
+        file_name="leerie.toml", default=default)
+
+
+def test_str_default_none_when_nothing_set(leerie, str_repo_root):
+    assert _call_str(leerie, str_repo_root) is None
+
+
+def test_str_default_custom_when_nothing_set(leerie, str_repo_root):
+    assert _call_str(leerie, str_repo_root, default="fallback") == "fallback"
+
+
+def test_str_cli_wins(leerie, str_repo_root, monkeypatch):
+    (str_repo_root / "leerie.toml").write_text("test_str = from-toml\n")
+    monkeypatch.setenv("LEERIE_TEST_STR", "from-env")
+    assert _call_str(leerie, str_repo_root, cli_value="from-cli") == "from-cli"
+
+
+def test_str_env_wins_over_file(leerie, str_repo_root, monkeypatch):
+    (str_repo_root / "leerie.toml").write_text("test_str = from-toml\n")
+    monkeypatch.setenv("LEERIE_TEST_STR", "from-env")
+    assert _call_str(leerie, str_repo_root) == "from-env"
+
+
+def test_str_file_used_when_env_unset(leerie, str_repo_root):
+    (str_repo_root / "leerie.toml").write_text("test_str = from-toml\n")
+    assert _call_str(leerie, str_repo_root) == "from-toml"
+
+
+def test_str_full_precedence_cli_beats_env_beats_file(leerie, str_repo_root, monkeypatch):
+    (str_repo_root / "leerie.toml").write_text("test_str = from-toml\n")
+    monkeypatch.setenv("LEERIE_TEST_STR", "from-env")
+    assert _call_str(leerie, str_repo_root) == "from-env"
+    assert _call_str(leerie, str_repo_root, cli_value="from-cli") == "from-cli"
+
+
+def test_str_empty_cli_falls_through_to_env(leerie, str_repo_root, monkeypatch):
+    """Empty/whitespace CLI value (argparse default) must not shadow env,
+    mirroring test_resolve_pr_base_branch.py."""
+    monkeypatch.setenv("LEERIE_TEST_STR", "from-env")
+    assert _call_str(leerie, str_repo_root, cli_value="") == "from-env"
+    assert _call_str(leerie, str_repo_root, cli_value="   ") == "from-env"
+
+
+def test_str_empty_env_treated_as_unset(leerie, str_repo_root, monkeypatch):
+    monkeypatch.setenv("LEERIE_TEST_STR", "")
+    assert _call_str(leerie, str_repo_root, default="fallback") == "fallback"
+
+
+def test_str_whitespace_only_env_treated_as_unset(leerie, str_repo_root, monkeypatch):
+    monkeypatch.setenv("LEERIE_TEST_STR", "   ")
+    assert _call_str(leerie, str_repo_root, default="fallback") == "fallback"
+
+
+def test_str_whitespace_only_file_value_treated_as_unset(leerie, str_repo_root):
+    (str_repo_root / "leerie.toml").write_text('test_str = "   "\n')
+    assert _call_str(leerie, str_repo_root, default="fallback") == "fallback"
+
+
+def test_str_no_enum_validation(leerie, str_repo_root):
+    """Free-form value — any string is accepted, no die()."""
+    (str_repo_root / "leerie.toml").write_text("test_str = anything-goes\n")
+    assert _call_str(leerie, str_repo_root) == "anything-goes"
+
+
+def test_str_env_value_stripped(leerie, str_repo_root, monkeypatch):
+    monkeypatch.setenv("LEERIE_TEST_STR", "  padded  ")
+    assert _call_str(leerie, str_repo_root) == "padded"
+
+
+def test_str_cli_value_stripped(leerie, str_repo_root):
+    assert _call_str(leerie, str_repo_root, cli_value="  padded  ") == "padded"
+
+
+# --- resolve_judge_dir / resolve_heal_dir -----------------------------
+
+
+@pytest.fixture
+def dir_repo_root(tmp_path, monkeypatch):
+    monkeypatch.delenv("LEERIE_JUDGE_DIR", raising=False)
+    monkeypatch.delenv("LEERIE_HEAL_DIR", raising=False)
+    return tmp_path
+
+
+def test_judge_dir_default(leerie, dir_repo_root):
+    assert leerie.resolve_judge_dir(dir_repo_root) == "judge-out"
+
+
+def test_judge_dir_env_var_name(leerie, dir_repo_root, monkeypatch):
+    monkeypatch.setenv("LEERIE_JUDGE_DIR", "custom-judge")
+    assert leerie.resolve_judge_dir(dir_repo_root) == "custom-judge"
+
+
+def test_judge_dir_file_key(leerie, dir_repo_root):
+    (dir_repo_root / "leerie.toml").write_text("judge_dir = custom-judge\n")
+    assert leerie.resolve_judge_dir(dir_repo_root) == "custom-judge"
+
+
+def test_judge_dir_cli_wins(leerie, dir_repo_root, monkeypatch):
+    monkeypatch.setenv("LEERIE_JUDGE_DIR", "from-env")
+    assert leerie.resolve_judge_dir(dir_repo_root, cli_value="from-cli") == "from-cli"
+
+
+def test_judge_dir_env_wins_over_file(leerie, dir_repo_root, monkeypatch):
+    (dir_repo_root / "leerie.toml").write_text("judge_dir = from-toml\n")
+    monkeypatch.setenv("LEERIE_JUDGE_DIR", "from-env")
+    assert leerie.resolve_judge_dir(dir_repo_root) == "from-env"
+
+
+def test_heal_dir_default(leerie, dir_repo_root):
+    assert leerie.resolve_heal_dir(dir_repo_root) == "heal-out"
+
+
+def test_heal_dir_env_var_name(leerie, dir_repo_root, monkeypatch):
+    monkeypatch.setenv("LEERIE_HEAL_DIR", "custom-heal")
+    assert leerie.resolve_heal_dir(dir_repo_root) == "custom-heal"
+
+
+def test_heal_dir_file_key(leerie, dir_repo_root):
+    (dir_repo_root / "leerie.toml").write_text("heal_dir = custom-heal\n")
+    assert leerie.resolve_heal_dir(dir_repo_root) == "custom-heal"
+
+
+def test_heal_dir_cli_wins(leerie, dir_repo_root, monkeypatch):
+    monkeypatch.setenv("LEERIE_HEAL_DIR", "from-env")
+    assert leerie.resolve_heal_dir(dir_repo_root, cli_value="from-cli") == "from-cli"
+
+
+def test_heal_dir_env_wins_over_file(leerie, dir_repo_root, monkeypatch):
+    (dir_repo_root / "leerie.toml").write_text("heal_dir = from-toml\n")
+    monkeypatch.setenv("LEERIE_HEAL_DIR", "from-env")
+    assert leerie.resolve_heal_dir(dir_repo_root) == "from-env"
+
+
+def test_judge_dir_and_heal_dir_are_independent(leerie, dir_repo_root, monkeypatch):
+    """The two resolvers must not cross-read each other's env var/file key."""
+    monkeypatch.setenv("LEERIE_JUDGE_DIR", "only-judge")
+    assert leerie.resolve_judge_dir(dir_repo_root) == "only-judge"
+    assert leerie.resolve_heal_dir(dir_repo_root) == "heal-out"
+
+
+# --- resolve_dangerously_allow_uncapped --------------------------------
+
+
+@pytest.fixture
+def uncapped_repo_root(tmp_path, monkeypatch):
+    monkeypatch.delenv("LEERIE_DANGEROUSLY_ALLOW_UNCAPPED", raising=False)
+    return tmp_path
+
+
+def test_uncapped_default_is_false(leerie, uncapped_repo_root):
+    assert leerie.resolve_dangerously_allow_uncapped(
+        uncapped_repo_root, cli_value=False) is False
+
+
+def test_uncapped_cli_flag_wins(leerie, uncapped_repo_root, monkeypatch):
+    monkeypatch.setenv("LEERIE_DANGEROUSLY_ALLOW_UNCAPPED", "0")
+    (uncapped_repo_root / "leerie.toml").write_text(
+        "dangerously_allow_uncapped = false\n")
+    assert leerie.resolve_dangerously_allow_uncapped(
+        uncapped_repo_root, cli_value=True) is True
+
+
+def test_uncapped_env_true(leerie, uncapped_repo_root, monkeypatch):
+    monkeypatch.setenv("LEERIE_DANGEROUSLY_ALLOW_UNCAPPED", "1")
+    assert leerie.resolve_dangerously_allow_uncapped(
+        uncapped_repo_root, cli_value=False) is True
+
+
+def test_uncapped_file_true_no_env(leerie, uncapped_repo_root):
+    (uncapped_repo_root / "leerie.toml").write_text(
+        "dangerously_allow_uncapped = true\n")
+    assert leerie.resolve_dangerously_allow_uncapped(
+        uncapped_repo_root, cli_value=False) is True
+
+
+def test_uncapped_env_wins_over_file(leerie, uncapped_repo_root, monkeypatch):
+    (uncapped_repo_root / "leerie.toml").write_text(
+        "dangerously_allow_uncapped = true\n")
+    monkeypatch.setenv("LEERIE_DANGEROUSLY_ALLOW_UNCAPPED", "false")
+    assert leerie.resolve_dangerously_allow_uncapped(
+        uncapped_repo_root, cli_value=False) is False
+
+
+def test_uncapped_env_garbage_dies(leerie, uncapped_repo_root, monkeypatch):
+    monkeypatch.setenv("LEERIE_DANGEROUSLY_ALLOW_UNCAPPED", "maybe")
+    with pytest.raises(SystemExit):
+        leerie.resolve_dangerously_allow_uncapped(
+            uncapped_repo_root, cli_value=False)
+
+
+def test_uncapped_file_garbage_dies(leerie, uncapped_repo_root):
+    (uncapped_repo_root / "leerie.toml").write_text(
+        "dangerously_allow_uncapped = sometimes\n")
+    with pytest.raises(SystemExit):
+        leerie.resolve_dangerously_allow_uncapped(
+            uncapped_repo_root, cli_value=False)
+
+
+def test_uncapped_env_empty_string_falls_through(leerie, uncapped_repo_root, monkeypatch):
+    monkeypatch.setenv("LEERIE_DANGEROUSLY_ALLOW_UNCAPPED", "")
+    assert leerie.resolve_dangerously_allow_uncapped(
+        uncapped_repo_root, cli_value=False) is False

--- a/tests/test_run_table_helpers.py
+++ b/tests/test_run_table_helpers.py
@@ -1,0 +1,221 @@
+"""Unit tests for the `leerie list`/resume-disambiguation formatting and
+sort helpers: `_format_run_duration`, `_run_recency_key`,
+`_format_run_for_disambiguation`, `_render_run_table`.
+
+These four functions had zero test references anywhere in tests/ before
+this file (grep across concatenated tests/*.py source returned no hits).
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "orchestrator"))
+import leerie  # noqa: E402
+
+
+# --- _format_run_duration ------------------------------------------------
+
+class TestFormatRunDuration:
+    def test_missing_started_at_returns_none(self):
+        assert leerie._format_run_duration(None, "2026-08-01T00:00:10+00:00") is None
+
+    def test_missing_finished_at_returns_none(self):
+        assert leerie._format_run_duration("2026-08-01T00:00:00+00:00", None) is None
+
+    def test_both_missing_returns_none(self):
+        assert leerie._format_run_duration(None, None) is None
+
+    def test_unparseable_started_at_returns_none(self):
+        assert leerie._format_run_duration("not-a-timestamp",
+                                            "2026-08-01T00:00:10+00:00") is None
+
+    def test_unparseable_finished_at_returns_none(self):
+        assert leerie._format_run_duration("2026-08-01T00:00:00+00:00",
+                                            "not-a-timestamp") is None
+
+    def test_seconds_only(self):
+        assert leerie._format_run_duration(
+            "2026-08-01T00:00:00+00:00", "2026-08-01T00:00:42+00:00") == "42s"
+
+    def test_minutes_and_seconds(self):
+        assert leerie._format_run_duration(
+            "2026-08-01T00:00:00+00:00", "2026-08-01T00:03:42+00:00") == "3m 42s"
+
+    def test_hours_and_minutes(self):
+        assert leerie._format_run_duration(
+            "2026-08-01T00:00:00+00:00", "2026-08-01T01:12:00+00:00") == "1h 12m"
+
+    def test_hours_only_omits_zero_minutes(self):
+        assert leerie._format_run_duration(
+            "2026-08-01T00:00:00+00:00", "2026-08-01T02:00:00+00:00") == "2h 0m"
+
+    def test_negative_delta_returns_none(self):
+        # finished_at before started_at is nonsensical, not crash-worthy.
+        assert leerie._format_run_duration(
+            "2026-08-01T01:00:00+00:00", "2026-08-01T00:00:00+00:00") is None
+
+    def test_zero_delta_returns_zero_seconds(self):
+        assert leerie._format_run_duration(
+            "2026-08-01T00:00:00+00:00", "2026-08-01T00:00:00+00:00") == "0s"
+
+
+# --- _run_recency_key ------------------------------------------------
+
+class TestRunRecencyKey:
+    def test_real_started_at_ranks_above_missing(self, tmp_path):
+        with_started = {"run_id": "run-a", "started_at": "2026-01-01T00:00:00+00:00"}
+        without_started = {"run_id": "run-b"}
+        (tmp_path / "runs" / "run-b").mkdir(parents=True)
+        # No state.json for run-b -> mtime lookup fails -> (0, "").
+        key_with = leerie._run_recency_key(with_started, tmp_path)
+        key_without = leerie._run_recency_key(without_started, tmp_path)
+        assert key_with > key_without
+        assert key_with[0] == 1
+        assert key_without[0] == 0
+
+    def test_missing_started_at_falls_back_to_mtime(self, tmp_path):
+        run_dir = tmp_path / "runs" / "run-c"
+        run_dir.mkdir(parents=True)
+        sidecar = run_dir / "state.json"
+        sidecar.write_text("{}")
+        key = leerie._run_recency_key({"run_id": "run-c"}, tmp_path)
+        assert key[0] == 0
+        assert key[1] == str(sidecar.stat().st_mtime)
+
+    def test_missing_started_at_and_missing_sidecar_returns_empty_string(self, tmp_path):
+        key = leerie._run_recency_key({"run_id": "does-not-exist"}, tmp_path)
+        assert key == (0, "")
+
+    def test_never_sorts_missing_above_real(self, tmp_path):
+        # Sort a list containing both shapes; the real-started_at run must
+        # land last (newest) regardless of how "recent" the mtime looks.
+        run_dir = tmp_path / "runs" / "run-mtime"
+        run_dir.mkdir(parents=True)
+        (run_dir / "state.json").write_text("{}")
+        rows = [
+            {"run_id": "run-mtime"},
+            {"run_id": "run-real", "started_at": "2020-01-01T00:00:00+00:00"},
+        ]
+        rows.sort(key=lambda r: leerie._run_recency_key(r, tmp_path))
+        assert rows[-1]["run_id"] == "run-real"
+
+    def test_two_real_started_at_sort_lexicographically(self, tmp_path):
+        earlier = {"run_id": "run-x", "started_at": "2026-01-01T00:00:00+00:00"}
+        later = {"run_id": "run-y", "started_at": "2026-06-01T00:00:00+00:00"}
+        rows = [later, earlier]
+        rows.sort(key=lambda r: leerie._run_recency_key(r, tmp_path))
+        assert rows == [earlier, later]
+
+
+# --- _format_run_for_disambiguation ------------------------------------------------
+
+class TestFormatRunForDisambiguation:
+    def test_includes_run_id_status_started(self, tmp_path):
+        run_dir = tmp_path / "runs" / "run-a"
+        run_dir.mkdir(parents=True)
+        state_path = run_dir / "state.json"
+        state_path.write_text("{}")
+        run = {
+            "run_id": "run-a",
+            "started_at": "2026-01-01T00:00:00+00:00",
+            "path": str(state_path),
+        }
+        out = leerie._format_run_for_disambiguation(run, tmp_path)
+        assert "run-a" in out
+        assert "started=2026-01-01T00:00:00+00:00" in out
+        assert "status=" in out
+        assert "last-activity=" in out
+
+    def test_missing_started_at_renders_question_mark(self, tmp_path):
+        run_dir = tmp_path / "runs" / "run-b"
+        run_dir.mkdir(parents=True)
+        run = {"run_id": "run-b"}
+        out = leerie._format_run_for_disambiguation(run, tmp_path)
+        assert "started=?" in out
+
+    def test_missing_path_renders_last_activity_question_mark(self, tmp_path):
+        run = {"run_id": "run-no-path", "started_at": "2026-01-01T00:00:00+00:00"}
+        out = leerie._format_run_for_disambiguation(run, tmp_path)
+        assert "last-activity=?" in out
+
+    def test_unreadable_state_json_degrades_gracefully(self, tmp_path):
+        # A run.json (consulted by _run_status_for -> _derive_run_status)
+        # that is present but unparseable must not raise -- the sidecar
+        # read is wrapped in a try/except and falls back to state.json
+        # alone.
+        run_dir = tmp_path / "runs" / "run-corrupt"
+        run_dir.mkdir(parents=True)
+        (run_dir / "run.json").write_text("{not valid json")
+        run = {"run_id": "run-corrupt", "started_at": "2026-01-01T00:00:00+00:00"}
+        out = leerie._format_run_for_disambiguation(run, tmp_path)
+        assert "run-corrupt" in out
+        assert "status=" in out
+
+    def test_nonexistent_sidecar_path_does_not_raise(self, tmp_path):
+        # `path` names a file that was deleted between _discover_runs and
+        # this call -- os.path.getmtime raises OSError, caught internally.
+        run = {
+            "run_id": "run-deleted",
+            "started_at": "2026-01-01T00:00:00+00:00",
+            "path": str(tmp_path / "runs" / "run-deleted" / "state.json"),
+        }
+        out = leerie._format_run_for_disambiguation(run, tmp_path)
+        assert "last-activity=?" in out
+
+    def test_no_runs_dir_at_all_does_not_raise(self, tmp_path):
+        # leerie_root/runs doesn't even exist -- _run_status_for's sidecar
+        # probe and this function must both tolerate that.
+        missing_root = tmp_path / "does-not-exist"
+        run = {"run_id": "run-x", "started_at": "2026-01-01T00:00:00+00:00"}
+        out = leerie._format_run_for_disambiguation(run, missing_root)
+        assert "run-x" in out
+
+
+# --- _render_run_table ------------------------------------------------
+
+class TestRenderRunTable:
+    def _row(self, run_id="r1", started="2026-01-01T00:00:00+00:00",
+             status="done", branch="leerie/subtasks/x", is_fly=False,
+             cost="$1.23", is_ec2=False):
+        return (run_id, started, status, branch, is_fly, cost, is_ec2)
+
+    def test_singleton_does_not_raise(self, capsys):
+        leerie._render_run_table([self._row()])
+        out = capsys.readouterr().out
+        assert "r1" in out
+        assert "run_id" in out  # header row
+
+    def test_multiple_rows_auto_sizes_columns(self, capsys):
+        rows = [
+            self._row(run_id="short", branch="b"),
+            self._row(run_id="a-much-longer-run-id", branch="a/much/longer/branch/name"),
+        ]
+        leerie._render_run_table(rows)
+        lines = capsys.readouterr().out.splitlines()
+        # Header, separator, and one line per row -> column widths line up
+        # (every data line is the same length as the header line).
+        assert len(lines) == 2 + len(rows)
+        header_len = len(lines[0])
+        for line in lines[1:]:
+            assert len(line) == header_len
+
+    def test_renders_run_id_started_status_cost_branch_not_is_fly_or_is_ec2(self, capsys):
+        leerie._render_run_table([self._row(is_fly=True, is_ec2=True)])
+        out = capsys.readouterr().out
+        assert "True" not in out
+        assert "False" not in out
+
+    def test_empty_input_raises_valueerror_shaped_error(self):
+        # _render_run_table is only ever called by _list_runs after an
+        # `if not rows:` guard that prints "no runs" instead -- an empty
+        # list reaching this function directly is not a supported input.
+        # Pinning the actual current behavior (a max()-on-empty TypeError)
+        # rather than papering over it, since fixing the underlying
+        # column-width computation is outside this subtask's scope
+        # (tests-only; files_likely_touched = tests/test_run_table_helpers.py).
+        with pytest.raises(TypeError):
+            leerie._render_run_table([])

--- a/tests/test_schema_fingerprint_and_cli_version_probe.py
+++ b/tests/test_schema_fingerprint_and_cli_version_probe.py
@@ -1,0 +1,116 @@
+"""Tests for `_fingerprint_to_worker_type` and `_parse_claude_cli_version_string`.
+
+Both are best-effort, degrade-gracefully helpers with no direct prior test:
+`_fingerprint_to_worker_type` (leerie.py) is a diagnostic-naming reverse
+lookup for constrained-decoding fallback logs; `_parse_claude_cli_version_string`
+is a User-Agent version probe for Probe A rate-limit avoidance (DESIGN §6
+*Multi-token rotation*).
+
+Per the subtask's investigation_notes, the fingerprint test builds its
+expectations from SCHEMAS / _structured_output_fingerprint's own
+canonicalization directly rather than hardcoding fingerprint hashes — the
+same discipline CLAUDE.md's collect-subtrees.sh drift incident argues for.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import subprocess
+
+import pytest
+
+
+class TestFingerprintToWorkerType:
+    def test_covers_every_worker_type_with_a_schema(self, leerie):
+        mapping = leerie._fingerprint_to_worker_type()
+        expected_workers = {w for w in leerie.WORKER_TYPES if w in leerie.SCHEMAS}
+        assert expected_workers, "sanity: WORKER_TYPES ∩ SCHEMAS must be non-empty"
+        assert set(mapping.values()) >= expected_workers
+
+    def test_fingerprint_matches_the_real_canonicalization(self, leerie):
+        # Build the expected fingerprint the same way _structured_output_fingerprint
+        # does for a request's input_schema, not a hardcoded hash.
+        mapping = leerie._fingerprint_to_worker_type()
+        for worker, schema in leerie.SCHEMAS.items():
+            canonical = json.dumps(schema, sort_keys=True)
+            fp = hashlib.sha256(canonical.encode()).hexdigest()[:16]
+            assert mapping[fp] == worker
+
+    def test_round_trips_through_structured_output_fingerprint(self, leerie):
+        # A request body carrying SCHEMAS[worker] as its tool's input_schema
+        # must resolve back to that worker via _worker_type_for_fingerprint.
+        for worker, schema in leerie.SCHEMAS.items():
+            body = json.dumps({
+                "tools": [{
+                    "name": leerie._STRICT_OUTPUT_TOOL_NAME,
+                    "input_schema": schema,
+                }],
+            }).encode()
+            fp = leerie._structured_output_fingerprint(body)
+            assert fp is not None
+            assert leerie._worker_type_for_fingerprint(fp) == worker
+
+    def test_unknown_fingerprint_resolves_to_none(self, leerie):
+        assert leerie._worker_type_for_fingerprint("deadbeefdeadbeef") is None
+
+    def test_none_fingerprint_resolves_to_none(self, leerie):
+        assert leerie._worker_type_for_fingerprint(None) is None
+
+    def test_result_is_cached(self, leerie):
+        # @functools.lru_cache(maxsize=1) — same dict object across calls.
+        assert leerie._fingerprint_to_worker_type() is leerie._fingerprint_to_worker_type()
+
+
+class TestParseClaudeCliVersionString:
+    def test_returns_version_on_success(self, leerie, monkeypatch):
+        def fake_run(*args, **kwargs):
+            return subprocess.CompletedProcess(
+                args=args, returncode=0, stdout="2.1.210 (Claude Code)\n", stderr="")
+
+        monkeypatch.setattr(leerie.subprocess, "run", fake_run)
+        assert leerie._parse_claude_cli_version_string() == "2.1.210"
+
+    def test_falls_back_on_missing_binary(self, leerie, monkeypatch):
+        def fake_run(*args, **kwargs):
+            raise FileNotFoundError("claude not found")
+
+        monkeypatch.setattr(leerie.subprocess, "run", fake_run)
+        assert leerie._parse_claude_cli_version_string() == "0.0.0"
+
+    def test_falls_back_on_nonzero_exit(self, leerie, monkeypatch):
+        def fake_run(*args, **kwargs):
+            return subprocess.CompletedProcess(
+                args=args, returncode=1, stdout="", stderr="error")
+
+        monkeypatch.setattr(leerie.subprocess, "run", fake_run)
+        assert leerie._parse_claude_cli_version_string() == "0.0.0"
+
+    def test_falls_back_on_malformed_output(self, leerie, monkeypatch):
+        def fake_run(*args, **kwargs):
+            return subprocess.CompletedProcess(
+                args=args, returncode=0, stdout="not a version\n", stderr="")
+
+        monkeypatch.setattr(leerie.subprocess, "run", fake_run)
+        assert leerie._parse_claude_cli_version_string() == "0.0.0"
+
+    def test_falls_back_on_timeout(self, leerie, monkeypatch):
+        def fake_run(*args, **kwargs):
+            raise subprocess.TimeoutExpired(cmd=["claude", "--version"], timeout=10)
+
+        monkeypatch.setattr(leerie.subprocess, "run", fake_run)
+        assert leerie._parse_claude_cli_version_string() == "0.0.0"
+
+    def test_never_raises_on_arbitrary_oserror(self, leerie, monkeypatch):
+        def fake_run(*args, **kwargs):
+            raise PermissionError("denied")
+
+        monkeypatch.setattr(leerie.subprocess, "run", fake_run)
+        assert leerie._parse_claude_cli_version_string() == "0.0.0"
+
+    def test_empty_stdout_falls_back(self, leerie, monkeypatch):
+        def fake_run(*args, **kwargs):
+            return subprocess.CompletedProcess(
+                args=args, returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(leerie.subprocess, "run", fake_run)
+        assert leerie._parse_claude_cli_version_string() == "0.0.0"

--- a/tests/test_worker_memory_admission_token.py
+++ b/tests/test_worker_memory_admission_token.py
@@ -1,0 +1,87 @@
+"""Unit tests for the burst-reservation token pair that backs the memory
+admission gate (DESIGN §6 Memory containment): `_reserve_worker_memory_admission`
+issues a monotonically increasing release token and records its reservation
+timestamp in the module-level `_active_admissions` dict; `_release_worker_memory_admission`
+removes that entry and is idempotent on `None` or an already-released token.
+
+The larger gate consumers (tests/test_slice_aware_memory.py,
+tests/test_memory_admission_degrade.py) exercise this pair indirectly but
+never reference it by name.
+"""
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _reset_admissions(leerie):
+    """`_active_admissions` is module-level mutable state and conftest's
+    `leerie` fixture is **session-scoped** — the module is loaded once for
+    the whole suite, so entries survive across tests AND across files.
+    Clear on both sides: before, so these tests are order-independent;
+    after, so they cannot perturb any other file that exercises the gate."""
+    leerie._active_admissions.clear()
+    yield
+    leerie._active_admissions.clear()
+
+
+def test_reserve_returns_a_new_unique_token_each_call(leerie):
+    t1 = leerie._reserve_worker_memory_admission()
+    t2 = leerie._reserve_worker_memory_admission()
+    t3 = leerie._reserve_worker_memory_admission()
+    assert len({t1, t2, t3}) == 3
+
+
+def test_reserve_tokens_are_monotonically_increasing(leerie):
+    t1 = leerie._reserve_worker_memory_admission()
+    t2 = leerie._reserve_worker_memory_admission()
+    t3 = leerie._reserve_worker_memory_admission()
+    assert t1 < t2 < t3
+
+
+def test_reserve_records_token_in_active_admissions(leerie):
+    token = leerie._reserve_worker_memory_admission()
+    assert token in leerie._active_admissions
+
+
+def test_reserve_records_a_monotonic_timestamp(leerie, monkeypatch):
+    fake_clock = iter([100.0])
+    monkeypatch.setattr(leerie.time, "monotonic", lambda: next(fake_clock))
+    token = leerie._reserve_worker_memory_admission()
+    assert leerie._active_admissions[token] == 100.0
+
+
+def test_release_removes_the_entry(leerie):
+    token = leerie._reserve_worker_memory_admission()
+    assert token in leerie._active_admissions
+    leerie._release_worker_memory_admission(token)
+    assert token not in leerie._active_admissions
+
+
+def test_release_only_removes_the_named_token(leerie):
+    t1 = leerie._reserve_worker_memory_admission()
+    t2 = leerie._reserve_worker_memory_admission()
+    leerie._release_worker_memory_admission(t1)
+    assert t1 not in leerie._active_admissions
+    assert t2 in leerie._active_admissions
+
+
+def test_release_is_a_noop_on_none(leerie):
+    token = leerie._reserve_worker_memory_admission()
+    leerie._release_worker_memory_admission(None)
+    assert token in leerie._active_admissions
+    assert leerie._active_admissions == {token: leerie._active_admissions[token]}
+
+
+def test_release_is_idempotent_on_an_already_released_token(leerie):
+    token = leerie._reserve_worker_memory_admission()
+    leerie._release_worker_memory_admission(token)
+    assert token not in leerie._active_admissions
+    leerie._release_worker_memory_admission(token)
+    assert token not in leerie._active_admissions
+
+
+def test_release_is_a_noop_on_an_unknown_token(leerie):
+    leerie._reserve_worker_memory_admission()
+    leerie._release_worker_memory_admission(999999)
+    assert len(leerie._active_admissions) == 1


### PR DESCRIPTION
## Summary

<!-- 1-2 sentences. Why is this change being made, and what does it do? -->

Adds direct unit test coverage for 14 groups of leaf/helper functions that were previously exercised only indirectly (or not at all) through their callers — spanning migration/decompose partitioning, run-listing formatting, the prescribed-command tokenizer, CLI preference resolvers, the memory-admission reservation pair, dep-capture manifest sampling, repo-map rendering, PID-liveness checking, schema-fingerprint/CLI-version probing, checkpoint noise normalization, mise pin discovery, reconciler cycle/collision helpers, package.json script extraction, and `chain/_log.py`'s package-isolated `log()`/`die()`.

## Which layer(s) does this PR touch?

(See [`CLAUDE.md`](../CLAUDE.md) for the three-layer rule.)

- [ ] `docs/DESIGN.md` (architecture)
- [ ] `docs/IMPLEMENTATION.md` (code surface)
- [ ] `orchestrator/leerie.py` (code)
- [ ] docs (`README.md`, `docs/USAGE.md`, `CONTRIBUTING.md`, etc.)
- [x] tests (`tests/`)
- [ ] CI / repo meta (`.github/`)

If multiple, has the change propagated **top-down** per the three-layer rule
(DESIGN → IMPLEMENTATION → code)?

- [ ] yes
- [x] not applicable (single layer)

## Task-completion checklist

(Mirrors `CLAUDE.md` and `CONTRIBUTING.md`.)

- [ ] `docs/IMPLEMENTATION.md` updated if code surface changed
- [ ] `docs/DESIGN.md` updated if architecture changed
- [ ] `pytest tests/` passes
- [ ] `python3 -c "import ast; ast.parse(open('orchestrator/leerie.py').read())"` passes
- [ ] `git diff --stat` reviewed for scope (no collateral edits)

## Testing notes

<!-- What new test coverage did you add? If none, why not? -->

14 new/expanded test files, ~2400 lines added, targeting functions that had zero or only indirect coverage:

- `tests/test_decompose_child_helpers.py` — `_grep_old_pattern`, `_deterministic_chunk_label`, `_subfile_child`, `_prune_orphaned_requires`
- `tests/test_run_table_helpers.py` — `_format_run_duration`, `_run_recency_key`, `_format_run_for_disambiguation`, `_render_run_table`
- `tests/test_command_tokens.py` — the prescribed-command tokenizer
- `tests/test_resolve_enum_str_prefs.py` — `_resolve_enum_pref`/`_resolve_str_pref` precedence plus `resolve_judge_dir`/`resolve_heal_dir`/`resolve_dangerously_allow_uncapped`
- `tests/test_worker_memory_admission_token.py` — `_reserve_worker_memory_admission`/`_release_worker_memory_admission`
- `tests/test_dep_capture_manifest_helpers.py` — `_normalize_setup_packages`, `_read_file_safely`, `_sample_workspace_manifests`
- `tests/test_repo_map_render_helpers.py` — `_is_same_document`, `_render_repo_map_subgraph`, `_count_tokens_approx`, `_resolves_under`
- `tests/test_pid_still_exists.py` — the standalone PID-liveness check
- `tests/test_schema_fingerprint_and_cli_version_probe.py` — `_fingerprint_to_worker_type` (derived from `SCHEMAS`/the real fingerprint canonicalization, not hardcoded hashes) and `_parse_claude_cli_version_string`
- `tests/test_checkpoint_noise_helpers.py` — `_split_checkpoint_sections`, `_normalize_for_noise`, `_strip_bullet`
- `tests/test_mise_pin_discovery.py` — `_existing_mise_toml_path`, `_go_already_pinned`, `_existing_mise_toml_tool_keys`, `_read_idiomatic_pins`
- `tests/test_reconciler_collision_helpers.py` — cycle-attribution and collision-resolution leaf helpers (`_attribute_cycle_edges`, `_shared_files_in_scc`, `_original_tag_for_rename_edge`, `_collision_dropped_sid`, `_collision_surviving_sids`, `_wiring_defect_label`, `_add_depends_on_edge`)
- `tests/test_blt_script_helpers.py` — `_package_json_scripts`, `_is_blt_feedback_warning`
- `tests/test_chain_log.py` — `chain/_log.py`'s package-isolated `log()`/`die()`/`_iso_now()`

The whole-tree conformer pass reported 8 pre-existing `pytest` failures (`test_signal_cleanup.py`'s grandchildren/session-reaping tests and a meminfo-fallback test) that match the recorded baseline-red state and are not touched by this run's diff (which is scoped to new `tests/*.py` files); base health was already `red` on the `tests` axis before this run started.
