### PR TITLE
docs: correct three counts #217 left stale, and name the mechanism

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2733,7 +2733,7 @@ byte cut is safe for `run.json`.)
 
 The per-subtask delta proxy's `{test_files}` tier is covered by
 `tests/test_test_files_proxy.py` (48), `tests/test_scoped_proxy_corpus.py` (5)
-and `tests/test_scoped_degrade_warning.py` (10). Three lessons generalise past
+and `tests/test_scoped_degrade_warning.py` (11). Three lessons generalise past
 this feature. **(1) A non-test path is an ERROR to pytest, not a no-op, and one
 of them poisons the whole invocation** — measured, `pytest orchestrator/leerie.py`
 exits 5, `pytest docs/DESIGN.md` exits 4, and `pytest docs/DESIGN.md


### PR DESCRIPTION
## Summary

Three counts from #217 are wrong. One is in a tracked file and fixed here; two are in #217's squash body on `main`, where they cannot be edited, so they are corrected in this commit message for the record.

No behaviour change.

## Which layer(s) does this PR touch?

- [ ] `docs/DESIGN.md` (architecture)
- [ ] `docs/IMPLEMENTATION.md` (code surface)
- [ ] `orchestrator/leerie.py` (code)
- [x] docs (`CLAUDE.md`)
- [ ] tests (`tests/`)
- [ ] CI / repo meta (`.github/`)

- [ ] yes
- [x] not applicable (single layer)

## Task-completion checklist

- [x] `docs/IMPLEMENTATION.md` updated if code surface changed — n/a, no code change
- [x] `docs/DESIGN.md` updated if architecture changed — n/a
- [ ] `pytest tests/` passes — not run locally (host rule); no code changed, and CI runs it
- [x] `python3 -c "import ast; ast.parse(...)"` passes — unchanged file not touched
- [x] `git diff --stat` reviewed for scope — 1 file, 1 line

## The corrections

| claim | where | actual |
|---|---|---|
| `test_scoped_degrade_warning.py` (10) | CLAUDE.md — **fixed here** | 11 |
| "61 new tests", later "now 63" | #217 squash body | **64** (48 + 5 + 11) |
| "removing the `phase_execute` call fails 1" | #217 squash body | **2** |

The second is 2 because `test_the_call_cannot_abort_phase_execute` also reads that function's source, and its `src.index(...)` raises when the call is absent.

Both totals were re-derived from `--collect-only` at commit time rather than carried forward from the plan.

## Why it happened — the part worth keeping

This is **not** the failure CLAUDE.md's "Commit messages are the permanent record" section already covers. That one is a figure measured against an earlier state and carried forward unchanged. These three were each measured correctly, written down correctly, and then invalidated by a **later commit of the same branch** — the CLAUDE.md number by the commit two steps afterwards that added a test to the very file it counts, inside the Testing entry being added.

So re-deriving at write time is necessary but not sufficient while the branch is still moving. A count that names a file has to be re-derived whenever that file changes, and a per-branch total can only be stated truthfully in the branch's final commit.

## Note

#217's remaining figures were re-verified this pass and are unchanged: 279 runs across 6 repos; proxy resolution 23-of-23 (barnacle), 340-of-342 (funeralworks), 0-of-16 (this repo); 6.9 h across 27 orchestrator-run suites; 109-of-270 predicted vs 34-of-36 real; and the four measured `pytest` exit codes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
