### PR TITLE
leerie: Add unit tests for chunked decoder, tool parsing, and git helpers

### DIFF
--- a/tests/test_clobbered_owned_files.py
+++ b/tests/test_clobbered_owned_files.py
@@ -313,3 +313,66 @@ def test_final_pass_passes_a_snapshot_not_the_run_branch(leerie):
     assert "run_branch" not in call, (
         "the final pass must NOT pass the run branch as base_ref — staging has "
         "it checked out, so base and HEAD collapse:\n" + call)
+
+
+def _single_commit_repo(tmp_path):
+    """A repo with one base commit only. Returns (path, base_sha)."""
+    d = tmp_path
+    _git(d, "init", "-q", "-b", "main")
+    _git(d, "config", "user.email", "t@leerie.local")
+    _git(d, "config", "user.name", "leerie test")
+    (d / "a.py").write_text("base a\n")
+    _git(d, "add", "-A")
+    _git(d, "commit", "-qm", "base")
+    return d, _rev(d)
+
+
+class TestProtectedPathsSince:
+    def test_empty_before_sha_returns_empty(self, leerie, tmp_path):
+        d, _base = _single_commit_repo(tmp_path)
+        r = asyncio.run(leerie._protected_paths_since(str(d), ""))
+        assert r == []
+
+    def test_bad_before_sha_git_failure_returns_empty(self, leerie, tmp_path):
+        d, _base = _single_commit_repo(tmp_path)
+        r = asyncio.run(
+            leerie._protected_paths_since(str(d), "deadbeefdeadbeef"))
+        assert r == []
+
+    def test_clean_diff_returns_empty(self, leerie, tmp_path):
+        d, base = _single_commit_repo(tmp_path)
+        r = asyncio.run(leerie._protected_paths_since(str(d), base))
+        assert r == []
+
+    def test_only_protected_subset_of_diff_returned(self, leerie, tmp_path):
+        d, base = _single_commit_repo(tmp_path)
+        (d / ".leerie").mkdir()
+        (d / ".leerie" / "config.toml").write_text("x = 1\n")
+        (d / "b.py").write_text("ordinary\n")
+        _git(d, "add", "-A")
+        _git(d, "commit", "-qm", "touch protected and ordinary")
+        r = asyncio.run(leerie._protected_paths_since(str(d), base))
+        assert r == [".leerie/config.toml"], r
+
+
+class TestUncommittedPaths:
+    def test_clean_worktree_returns_empty(self, leerie, tmp_path):
+        d, _base = _single_commit_repo(tmp_path)
+        r = asyncio.run(leerie._uncommitted_paths(str(d)))
+        assert r == []
+
+    def test_tracked_modified_kept_untracked_excluded(self, leerie, tmp_path):
+        d, _base = _single_commit_repo(tmp_path)
+        (d / "a.py").write_text("uncommitted edit\n")
+        (d / "new.py").write_text("untracked\n")
+        r = asyncio.run(leerie._uncommitted_paths(str(d)))
+        assert len(r) == 1
+        assert "a.py" in r[0]
+        assert not any(line.startswith("??") for line in r)
+        assert not any("new.py" in line for line in r)
+
+    def test_non_git_directory_returns_empty(self, leerie, tmp_path):
+        d = tmp_path / "not-a-repo"
+        d.mkdir()
+        r = asyncio.run(leerie._uncommitted_paths(str(d)))
+        assert r == []

--- a/tests/test_scan_conflict_markers.py
+++ b/tests/test_scan_conflict_markers.py
@@ -1,0 +1,91 @@
+"""Tests for _scan_conflict_markers() (leerie.py:12969) — the deterministic
+post-integration safety net phase 5's wave-integration loop calls after
+every wave (leerie.py:30310) to detect unresolved `<<<<<<<` conflict
+markers left in the staging tree.
+
+Builds real temp git repos rather than mocking git (mirroring
+tests/test_check_rebaser_worktree_state.py's discipline), since this
+function's entire job is inspecting real git grep output.
+"""
+from __future__ import annotations
+
+import asyncio
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+def _git(repo: Path, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(["git", "-C", str(repo), *args], check=True,
+                          capture_output=True, text=True)
+
+
+def _init_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "staging"
+    repo.mkdir()
+    _git(repo, "init", "-q", "-b", "main")
+    _git(repo, "config", "user.email", "test@x")
+    _git(repo, "config", "user.name", "test")
+    (repo / "a.txt").write_text("a\n")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-q", "-m", "a")
+    return repo
+
+
+def test_nonexistent_staging_returns_none_without_shelling_out(
+        leerie, tmp_path, monkeypatch):
+    missing = tmp_path / "does-not-exist"
+
+    async def _boom(*a, **k):
+        raise AssertionError("run_proc should not be called")
+
+    monkeypatch.setattr(leerie, "run_proc", _boom)
+    result = asyncio.run(leerie._scan_conflict_markers(missing))
+    assert result is None
+
+
+def test_clean_tree_returns_none(leerie, tmp_path):
+    repo = _init_repo(tmp_path)
+    result = asyncio.run(leerie._scan_conflict_markers(repo))
+    assert result is None
+
+
+def test_tree_with_conflict_markers_returns_message_with_file_count_and_sample(
+        leerie, tmp_path):
+    repo = _init_repo(tmp_path)
+    (repo / "b.txt").write_text("<<<<<<< HEAD\nours\n=======\ntheirs\n>>>>>>> x\n")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-q", "-m", "leaves markers")
+
+    result = asyncio.run(leerie._scan_conflict_markers(repo))
+    assert result is not None
+    assert "1 file(s)" in result
+    assert "b.txt" in result
+    assert "…" not in result
+
+
+def test_more_than_five_files_gets_ellipsis_marker(leerie, tmp_path):
+    repo = _init_repo(tmp_path)
+    for i in range(7):
+        (repo / f"c{i}.txt").write_text(
+            "<<<<<<< HEAD\nours\n=======\ntheirs\n>>>>>>> x\n")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-q", "-m", "leaves markers in 7 files")
+
+    result = asyncio.run(leerie._scan_conflict_markers(repo))
+    assert result is not None
+    assert "7 file(s)" in result
+    assert "…" in result
+
+
+def test_oserror_from_run_proc_is_caught_and_returns_none(
+        leerie, tmp_path, monkeypatch):
+    repo = _init_repo(tmp_path)
+
+    async def _raise_oserror(*a, **k):
+        raise OSError("git binary not found")
+
+    monkeypatch.setattr(leerie, "run_proc", _raise_oserror)
+    result = asyncio.run(leerie._scan_conflict_markers(repo))
+    assert result is None

--- a/tests/test_strict_output_proxy.py
+++ b/tests/test_strict_output_proxy.py
@@ -439,6 +439,83 @@ def test_one_aborted_connection_does_not_kill_the_listener(leerie, mock_upstream
     assert b'"saw_strict": true' in asyncio.run(go())
 
 
+# ----- _read_chunked: the chunked-transfer-encoding body decoder ------------
+
+
+class _FakeChunkedReader:
+    """A minimal stand-in for asyncio.StreamReader's `read(n)` coroutine.
+
+    Each call returns the next item off a queue, ignoring `n` (the real
+    _read_chunked only ever uses the return value's length/content, never
+    slices by the requested size) -- so a test can script exactly how the
+    bytes arrive across calls, including splitting a chunk-size line across
+    reads."""
+
+    def __init__(self, chunks: list[bytes]):
+        self._chunks = list(chunks)
+
+    async def read(self, n: int) -> bytes:
+        if not self._chunks:
+            return b""
+        return self._chunks.pop(0)
+
+
+def test_single_chunk_then_terminator(leerie):
+    reader = _FakeChunkedReader([])
+    rest = b"5\r\nhello\r\n0\r\n\r\n"
+    got = asyncio.run(leerie._StrictOutputProxy._read_chunked(reader, rest))
+    assert got == b"hello"
+
+
+def test_multiple_chunks_concatenate(leerie):
+    reader = _FakeChunkedReader([])
+    rest = b"5\r\nhello\r\n6\r\n world\r\n0\r\n\r\n"
+    got = asyncio.run(leerie._StrictOutputProxy._read_chunked(reader, rest))
+    assert got == b"hello world"
+
+
+def test_chunk_size_line_split_across_reads(leerie):
+    # The size-line's CRLF terminator arrives in a later read() than its
+    # digits -- `rest` holds only "5\r" and reader.read() supplies the rest.
+    reader = _FakeChunkedReader([b"\nhello\r\n0\r\n\r\n"])
+    rest = b"5\r"
+    got = asyncio.run(leerie._StrictOutputProxy._read_chunked(reader, rest))
+    assert got == b"hello"
+
+
+def test_malformed_chunk_size_returns_bytes_decoded_so_far(leerie):
+    reader = _FakeChunkedReader([])
+    rest = b"5\r\nhello\r\nZZZ\r\nbogus\r\n0\r\n\r\n"
+    got = asyncio.run(leerie._StrictOutputProxy._read_chunked(reader, rest))
+    assert got == b"hello"
+
+
+def test_eof_mid_chunk_body_returns_partial_body(leerie):
+    # A well-formed 10-byte chunk header, but the reader hits EOF (returns
+    # b"") after delivering only 3 of those 10 bytes.
+    reader = _FakeChunkedReader([b""])
+    rest = b"a\r\nabc"
+    got = asyncio.run(leerie._StrictOutputProxy._read_chunked(reader, rest))
+    assert got == b"abc"
+
+
+def test_eof_while_searching_for_the_size_line_terminator(leerie):
+    # No CRLF anywhere yet, and the reader immediately hits EOF.
+    reader = _FakeChunkedReader([b""])
+    rest = b"5"
+    got = asyncio.run(leerie._StrictOutputProxy._read_chunked(reader, rest))
+    assert got == b""
+
+
+def test_chunk_extension_after_semicolon_is_ignored(leerie):
+    # A chunk-size line may carry a `;`-delimited extension per RFC 7230;
+    # the decoder must parse only the hex size before it.
+    reader = _FakeChunkedReader([])
+    rest = b"5;ext=foo\r\nhello\r\n0\r\n\r\n"
+    got = asyncio.run(leerie._StrictOutputProxy._read_chunked(reader, rest))
+    assert got == b"hello"
+
+
 # ----- flag resolution, collision guard, and the numeric bounds --------------
 
 def test_flag_defaults_off(leerie, tmp_path):

--- a/tests/test_tool_surface_self_reporting.py
+++ b/tests/test_tool_surface_self_reporting.py
@@ -53,6 +53,26 @@ def test_empty_tools_array_flags_nothing(leerie):
     assert _flagged(leerie, []) == []
 
 
+# ----- _bare_tool_names parsing (direct, not via KNOWN_TOOLS) ---------------
+
+def test_bare_tool_names_plain_comma_separated_list(leerie):
+    assert leerie._bare_tool_names("Read,Write,Bash") == {"Read", "Write", "Bash"}
+
+
+def test_bare_tool_names_strips_allow_pattern_suffix(leerie):
+    assert leerie._bare_tool_names("Bash(git:*)") == {"Bash"}
+    assert leerie._bare_tool_names("Read,Bash(git:*),Write") == {
+        "Read", "Bash", "Write"}
+
+
+def test_bare_tool_names_single_entry_no_comma(leerie):
+    assert leerie._bare_tool_names("Read") == {"Read"}
+
+
+def test_bare_tool_names_empty_string(leerie):
+    assert leerie._bare_tool_names("") == {""}
+
+
 # ----- wiring (source-coupling, mirrors test_rejected_payload_logging.py) ---
 
 def test_read_stream_latches_the_tool_surface(leerie):


### PR DESCRIPTION
## Summary

Adds direct unit coverage for four leerie internals that previously had none: `_StrictOutputProxy._read_chunked`'s chunked-transfer-encoding decoder, `_bare_tool_names`' comma/paren-suffix parsing, `_scan_conflict_markers`' git-grep-based unresolved-conflict detection, and `_protected_paths_since`/`_uncommitted_paths`' git-shelling helpers.

## Which layer(s) does this PR touch?

(See [`CLAUDE.md`](../CLAUDE.md) for the three-layer rule.)

- [ ] `docs/DESIGN.md` (architecture)
- [ ] `docs/IMPLEMENTATION.md` (code surface)
- [ ] `orchestrator/leerie.py` (code)
- [ ] docs (`README.md`, `docs/USAGE.md`, `CONTRIBUTING.md`, etc.)
- [x] tests (`tests/`)
- [ ] CI / repo meta (`.github/`)

If multiple, has the change propagated **top-down** per the three-layer rule
(DESIGN → IMPLEMENTATION → code)?

- [ ] yes
- [x] not applicable (single layer)

## Task-completion checklist

(Mirrors `CLAUDE.md` and `CONTRIBUTING.md`.)

- [ ] `docs/IMPLEMENTATION.md` updated if code surface changed
- [ ] `docs/DESIGN.md` updated if architecture changed
- [ ] `pytest tests/` passes
- [ ] `python3 -c "import ast; ast.parse(open('orchestrator/leerie.py').read())"` passes
- [x] `git diff --stat` reviewed for scope (no collateral edits)

## Testing notes

Four new/expanded test files, no production code touched:

- `tests/test_strict_output_proxy.py`: `_read_chunked` against a fake `StreamReader` — single/multiple chunks, a chunk-size line split across reads, a malformed hex size, EOF mid-chunk-body, EOF while still searching for the size-line terminator, and a chunk-extension suffix per RFC 7230.
- `tests/test_tool_surface_self_reporting.py`: `_bare_tool_names` called directly with a plain comma list, a `Bash(git:*)`-shaped allow-pattern suffix, a single no-comma entry, and an empty string — closing the gap where only `KNOWN_TOOLS` membership was previously asserted, which couldn't distinguish a parsing regression from a constant edit.
- `tests/test_scan_conflict_markers.py` (new): `_scan_conflict_markers` against real temp git repos — a nonexistent staging dir short-circuits without shelling out, a clean tree returns `None`, a tree with markers reports the file count and a sample, more than five files gets an ellipsis marker, and an `OSError` from `run_proc` is caught and returns `None`.
- `tests/test_clobbered_owned_files.py`: `_protected_paths_since` and `_uncommitted_paths` against real temp git repos — empty/bad `before_sha`, a clean diff, only-the-protected-subset returned; a clean worktree, tracked-modified-kept-vs-untracked-excluded, and a non-git directory.

## Conformance notes

- tests: `pytest — r_re_seed_requires_run_id_arg - ass...\nFAILED tests/test_signal_cleanup.py::test_terminate_proc_tree_reaps_grandchildren\nFAILED tests/test_signal_cleanup.py::test_terminate_proc_tree_reaps_detached_session_grandchildren\nFAILED tests/test_signal_cleanup.py::test_descendant_tracker_reaps_orphaned_backgrounded_subprocess\n====== 6 failed, 7733 passed, 110 skipped, 1 warning in 829.61s (0:13:49) ======` — the base-tree health check independently reports `tests` red on the same axis before this branch's changes are applied, so these `test_signal_cleanup.py` failures pre-exist and are unrelated to the diff (which touches only the four test files listed above). Per CLAUDE.md's own guidance on `test_signal_cleanup.py`, this file is timing/PID-reaping-sensitive and known to fail nondeterministically under load — re-run in isolation before treating this as a regression.

## Related issue

<!-- Closes #N -->
