### PR TITLE
leerie: Deduplicate python extractor-helper bodies across tests/*.py

### DIFF
--- a/tests/bedrock_extract.py
+++ b/tests/bedrock_extract.py
@@ -1,0 +1,26 @@
+"""The single derivation of the launcher's detect_bedrock_mode()/bedrock_preflight()
+functions, extracted verbatim for test harnesses that need real implementations
+rather than stubs.
+
+Previously duplicated byte-for-byte in tests/test_bedrock_bearer_token.py and
+tests/test_bedrock_mode.py — same single-owner discipline as
+tests/launcher_blocks.py and tests/ec2_stub.py.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+LAUNCHER_PATH = Path(__file__).resolve().parents[1] / "leerie"
+
+
+def extract_bedrock_functions() -> str:
+    """Pull detect_bedrock_mode() and bedrock_preflight() verbatim from the
+    launcher so the harness has real implementations, not stubs, for the
+    SSO/profile control-flow paths."""
+    src = LAUNCHER_PATH.read_text()
+    start = src.index("detect_bedrock_mode() {")
+    end = src.index("\n}\n", src.index("bedrock_preflight() {")) + len("\n}\n")
+    block = src[start:end]
+    assert "detect_bedrock_mode() {" in block
+    assert "bedrock_preflight() {" in block
+    return block

--- a/tests/config_arm_extract.py
+++ b/tests/config_arm_extract.py
@@ -1,0 +1,26 @@
+"""The single derivation of the launcher's real `config)` case arm.
+
+`test_config_verb.py` and `test_config_recapture.py` both extract this arm
+verbatim from the shipped launcher (rather than hand-reproducing its logic,
+which would be body-blind by construction — see `test_config_verb.py`'s
+module docstring for the falsification proving this). Both copies were
+byte-identical, which is the same drift risk `tests/launcher_blocks.py`
+exists to close for the launch-env-block extraction: two copies of a rule
+drift exactly the way two copies of a list do, so there is one copy, here.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def extract_config_arm() -> str:
+    """Return the real `config)` case-arm body (including the `config)`
+    pattern and trailing `;;`) verbatim from the shipped launcher."""
+    launcher_text = (REPO_ROOT / "leerie").read_text()
+    start_marker = "  config)\n"
+    end_marker = "\n  list)"
+    s = launcher_text.index(start_marker)
+    e = launcher_text.index(end_marker, s)
+    return launcher_text[s:e]

--- a/tests/dockerfile_autogen_extract.py
+++ b/tests/dockerfile_autogen_extract.py
@@ -1,0 +1,15 @@
+"""Shared extraction of the per-repo derived-image block from the launcher.
+
+Single owner for `_extract_autogen_block`, previously duplicated
+byte-identically in tests/test_dockerfile_autogen.py and
+tests/test_dockerfile_bake_from_capture.py.
+"""
+
+
+def extract_autogen_block(text: str) -> str:
+    """Extract the per-repo image block from the launcher verbatim."""
+    marker_start = "# --- per-repo derived image (local nerdctl) "
+    marker_end = "\n# --- translate --inspect-dir paths"
+    s = text.index(marker_start)
+    e = text.index(marker_end, s)
+    return text[s:e]

--- a/tests/launcher_argv_extract.py
+++ b/tests/launcher_argv_extract.py
@@ -1,0 +1,25 @@
+"""Single owner of `_run_argv` extraction from the launcher.
+
+`tests/test_launcher_state_mount.py` and `tests/test_launcher_env_forwarding.py`
+both need the real `nerdctl run` argv array construction, extracted verbatim
+from `leerie` rather than reproduced — the exact hazard
+`tests/test_no_duplicate_launcher_blocks.py`'s docstring names by example
+(`test_launcher_state_mount.py` previously shipped a stale, incomplete
+reproduction of this block). Keeping one extraction function importable by
+both means the two files cannot silently diverge.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+LAUNCHER = REPO_ROOT / "leerie"
+
+
+def extract_run_argv() -> str:
+    """The real `nerdctl run` argv array, lifted verbatim from the launcher."""
+    src = LAUNCHER.read_text()
+    m = re.search(r"(  _run_argv=\(\n.*?\n  \)\n)", src, re.DOTALL)
+    assert m, "could not locate the _run_argv array in the launcher"
+    return m.group(1)

--- a/tests/log_file_extract_helpers.py
+++ b/tests/log_file_extract_helpers.py
@@ -5,11 +5,14 @@ independently defined byte-identical `_extract_setup_block`,
 single owner, following the `launcher_blocks.py` / `ec2_stub.py`
 single-owner convention documented in CLAUDE.md.
 
-Each file's own plain `_extract(start_marker, end_marker)` helper is
-deliberately NOT folded in here -- it is a thin marker-slicing primitive
-used for other, file-specific extractions too (e.g. `_extract_resolver`,
-`_extract_mkdir_line`), not part of the three-helper group this module
-consolidates.
+The plain `_extract(start_marker, end_marker)` marker-slicing primitive is
+also owned here and imported by `test_log_file_wiring.py`
+(`_extract_mkdir_line` needs it directly, not just the three helpers
+above). `test_log_file_persistence.py` keeps its own variant rather than
+importing this one -- its version routes through a local `_launcher_text()`
+wrapper for its own `_extract_resolver()`, so the two are not
+byte-identical and folding them together would be a cosmetic rename, not a
+dedup.
 """
 from __future__ import annotations
 

--- a/tests/log_file_extract_helpers.py
+++ b/tests/log_file_extract_helpers.py
@@ -1,0 +1,54 @@
+"""Shared launcher-text extraction helpers for the --log-file wiring tests
+(test_log_file_wiring.py, test_log_file_persistence.py). Both files
+independently defined byte-identical `_extract_setup_block`,
+`_extract_invocation`, and `_extract_reap_tail` -- this module is their
+single owner, following the `launcher_blocks.py` / `ec2_stub.py`
+single-owner convention documented in CLAUDE.md.
+
+Each file's own plain `_extract(start_marker, end_marker)` helper is
+deliberately NOT folded in here -- it is a thin marker-slicing primitive
+used for other, file-specific extractions too (e.g. `_extract_resolver`,
+`_extract_mkdir_line`), not part of the three-helper group this module
+consolidates.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+LAUNCHER = REPO_ROOT / "leerie"
+
+
+def _extract(start_marker: str, end_marker: str) -> str:
+    src = LAUNCHER.read_text()
+    s = src.index(start_marker)
+    e = src.index(end_marker, s) + len(end_marker)
+    return src[s:e]
+
+
+def extract_setup_block() -> str:
+    """The `_run_log=...` / `_log_tee_target=...` resolution block. Computed
+    independent of `$_run_log` (bugfix-005) so the interactive/-it branch
+    can wire it too."""
+    return _extract(
+        '  _run_log=""\n',
+        '  _log_tee_target=""\n  if [ -n "${LEERIE_LOG_FILE_RESOLVED:-}" ]; then\n'
+        '    if : >> "$LEERIE_LOG_FILE_RESOLVED" 2>/dev/null; then\n'
+        '      _log_tee_target="$LEERIE_LOG_FILE_RESOLVED"\n'
+        "    fi\n"
+        "  fi\n",
+    )
+
+
+def extract_reap_tail() -> str:
+    return _extract("  _reap_tail() {\n", "  }\n")
+
+
+def extract_invocation() -> str:
+    """The full `if [ -n "$_run_log" ]; then ... fi` block: the piped
+    tail/tee branch, the `script`-wrapped interactive/-it branch
+    (bugfix-005), and the unwrapped fallback."""
+    return _extract(
+        '  if [ -n "$_run_log" ]; then\n    # Decoupled: nerdctl',
+        '    nerdctl run "${_run_argv[@]}" || container_rc=$?\n  fi\n',
+    )

--- a/tests/repo_image_block_extract.py
+++ b/tests/repo_image_block_extract.py
@@ -1,0 +1,16 @@
+"""Shared _extract_block helper for the per-repo image test harnesses.
+
+Used by test_launcher_per_repo_image.py, test_fly_per_repo_image.py, and
+test_build_repo_image.py, whose own copies were verified byte-identical
+(AST-diff, body minus docstring). test_no_verify_push_env_seed.py and
+test_resolve_log_file.py define their own distinct _extract_block and are
+deliberately not consolidated here.
+"""
+from __future__ import annotations
+
+
+def extract_block(text: str, start_marker: str, end_marker: str) -> str:
+    """Return the text between start_marker and end_marker (exclusive)."""
+    s = text.index(start_marker)
+    e = text.index(end_marker, s)
+    return text[s:e]

--- a/tests/test_bedrock_bearer_token.py
+++ b/tests/test_bedrock_bearer_token.py
@@ -29,6 +29,10 @@ from pathlib import Path
 # tests/launcher_blocks.py for why it is not re-implemented per consumer.
 from tests.launcher_blocks import launch_env_blocks
 
+# One shared extraction of detect_bedrock_mode()/bedrock_preflight() — see
+# tests/bedrock_extract.py for why it is not re-implemented per consumer.
+from tests.bedrock_extract import extract_bedrock_functions
+
 REPO_ROOT = Path(__file__).resolve().parent.parent
 LAUNCHER = REPO_ROOT / "leerie"
 LOG_SH = REPO_ROOT / "scripts" / "remote" / "_log.sh"
@@ -55,19 +59,6 @@ def _extract_bedrock_block() -> str:
     block = src[start:end]
     assert "AWS_BEARER_TOKEN_BEDROCK=$AWS_BEARER_TOKEN_BEDROCK" in block
     assert "detect_bedrock_mode" in block
-    return block
-
-
-def _extract_bedrock_functions() -> str:
-    """Pull detect_bedrock_mode() and bedrock_preflight() verbatim from the
-    launcher so the harness has real implementations, not stubs, for the
-    SSO/profile control-flow paths this module also covers."""
-    src = LAUNCHER.read_text()
-    start = src.index("detect_bedrock_mode() {")
-    end = src.index("\n}\n", src.index("bedrock_preflight() {")) + len("\n}\n")
-    block = src[start:end]
-    assert "detect_bedrock_mode() {" in block
-    assert "bedrock_preflight() {" in block
     return block
 
 
@@ -134,7 +125,7 @@ def _run(env: dict, *, aws_on_path: bool = False, aws_succeeds: bool = True,
     harness = (
         _HARNESS
         .replace("__LOG_SH__", str(LOG_SH))
-        .replace("__BEDROCK_FUNCTIONS__", _extract_bedrock_functions())
+        .replace("__BEDROCK_FUNCTIONS__", extract_bedrock_functions())
         .replace("__BEDROCK_BLOCK__", _extract_bedrock_block())
         .replace("__HOME__", str(fake_home))
         .replace("__USER_REPO__", str(user_repo))

--- a/tests/test_bedrock_mode.py
+++ b/tests/test_bedrock_mode.py
@@ -9,8 +9,9 @@ Closing this gap here so a future edit to the shared AUTH_MOUNTS/heredoc
 region doesn't silently regress the SSO path.
 
 Extracts detect_bedrock_mode()/bedrock_preflight() verbatim from the
-launcher (same discipline as test_bedrock_bearer_token.py's
-_extract_bedrock_functions) so the tests exercise real code, not a copy.
+launcher via tests/bedrock_extract.py's extract_bedrock_functions() (shared
+with test_bedrock_bearer_token.py) so the tests exercise real code, not a
+copy.
 """
 from __future__ import annotations
 
@@ -18,6 +19,10 @@ import json
 import shutil
 import subprocess
 from pathlib import Path
+
+# One shared extraction of detect_bedrock_mode()/bedrock_preflight() — see
+# tests/bedrock_extract.py for why it is not re-implemented per consumer.
+from tests.bedrock_extract import extract_bedrock_functions
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 LAUNCHER = REPO_ROOT / "leerie"
@@ -30,16 +35,6 @@ LOG_SH = REPO_ROOT / "scripts" / "remote" / "_log.sh"
 # Resolve a modern bash so these tests exercise the same logic the launcher
 # itself runs under in practice (its own shebang is `#!/usr/bin/env bash`).
 _BASH = shutil.which("bash") or "/bin/bash"
-
-
-def _extract_bedrock_functions() -> str:
-    src = LAUNCHER.read_text()
-    start = src.index("detect_bedrock_mode() {")
-    end = src.index("\n}\n", src.index("bedrock_preflight() {")) + len("\n}\n")
-    block = src[start:end]
-    assert "detect_bedrock_mode() {" in block
-    assert "bedrock_preflight() {" in block
-    return block
 
 
 _DETECT_HARNESS = r"""
@@ -98,7 +93,7 @@ def _run_detect(tmp_path: Path, *, user_settings: dict | None = None,
     harness = (
         _DETECT_HARNESS
         .replace("__LOG_SH__", str(LOG_SH))
-        .replace("__BEDROCK_FUNCTIONS__", _extract_bedrock_functions())
+        .replace("__BEDROCK_FUNCTIONS__", extract_bedrock_functions())
         .replace("__HOME__", str(fake_home))
         .replace("__USER_REPO__", str(user_repo))
     )
@@ -135,7 +130,7 @@ def _run_preflight(tmp_path: Path, *, aws_on_path: bool, aws_succeeds: bool = Tr
     harness = (
         _PREFLIGHT_HARNESS
         .replace("__LOG_SH__", str(LOG_SH))
-        .replace("__BEDROCK_FUNCTIONS__", _extract_bedrock_functions())
+        .replace("__BEDROCK_FUNCTIONS__", extract_bedrock_functions())
         .replace("__HOME__", str(fake_home))
         .replace("__USER_REPO__", str(user_repo))
     )
@@ -198,7 +193,7 @@ def test_malformed_settings_json_tolerated(tmp_path: Path) -> None:
     harness = (
         _DETECT_HARNESS
         .replace("__LOG_SH__", str(LOG_SH))
-        .replace("__BEDROCK_FUNCTIONS__", _extract_bedrock_functions())
+        .replace("__BEDROCK_FUNCTIONS__", extract_bedrock_functions())
         .replace("__HOME__", str(fake_home))
         .replace("__USER_REPO__", str(user_repo))
     )

--- a/tests/test_build_repo_image.py
+++ b/tests/test_build_repo_image.py
@@ -18,6 +18,8 @@ import hashlib
 import subprocess
 from pathlib import Path
 
+from tests.repo_image_block_extract import extract_block as _extract_block
+
 REPO_ROOT = Path(__file__).resolve().parent.parent
 
 
@@ -27,12 +29,6 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 
 def _launcher_text() -> str:
     return (REPO_ROOT / "leerie").read_text()
-
-
-def _extract_block(text: str, start_marker: str, end_marker: str) -> str:
-    s = text.index(start_marker)
-    e = text.index(end_marker, s)
-    return text[s:e]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_config_recapture.py
+++ b/tests/test_config_recapture.py
@@ -30,24 +30,12 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from tests.config_arm_extract import extract_config_arm as _extract_config_arm
+
 REPO_ROOT = Path(__file__).resolve().parent.parent
 # The directory of the running interpreter, so the real seam can import
 # tenacity/other runtime deps when invoking the orchestrator.
 _PYBIN = str(Path(sys.executable).parent)
-
-
-# ---------------------------------------------------------------------------
-# Shared: extract the real `config)` arm from the launcher
-# ---------------------------------------------------------------------------
-
-def _extract_config_arm() -> str:
-    """Return the real `config)` case-arm body verbatim from the launcher."""
-    launcher_text = (REPO_ROOT / "leerie").read_text()
-    start_marker = "  config)\n"
-    end_marker = "\n  list)"
-    s = launcher_text.index(start_marker)
-    e = launcher_text.index(end_marker, s)
-    return launcher_text[s:e]
 
 
 def _run_real_config_arm_with_state(

--- a/tests/test_config_verb.py
+++ b/tests/test_config_verb.py
@@ -52,25 +52,14 @@ from pathlib import Path
 
 import pytest
 
+from tests.config_arm_extract import extract_config_arm as _extract_config_arm
+
 # Directory of the running interpreter — put on PATH for the end-to-end
 # recapture tests so the real orchestrator's runtime deps (tenacity, …)
 # resolve when the seam imports orchestrator/leerie.py.
 _PYBIN = str(Path(sys.executable).parent)
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
-
-
-def _extract_config_arm() -> str:
-    """Return the real `config)` case-arm body (including the `config)`
-    pattern and trailing `;;`) verbatim from the shipped launcher. See
-    module docstring for the body-blindness rationale and the live
-    falsification result."""
-    launcher_text = (REPO_ROOT / "leerie").read_text()
-    start_marker = "  config)\n"
-    end_marker = "\n  list)"
-    s = launcher_text.index(start_marker)
-    e = launcher_text.index(end_marker, s)
-    return launcher_text[s:e]
 
 
 def _make_stub_bin(tmp_path: Path) -> tuple[Path, Path, Path]:

--- a/tests/test_dockerfile_autogen.py
+++ b/tests/test_dockerfile_autogen.py
@@ -19,6 +19,8 @@ from __future__ import annotations
 import subprocess
 from pathlib import Path
 
+from tests.dockerfile_autogen_extract import extract_autogen_block as _extract_autogen_block
+
 REPO_ROOT = Path(__file__).resolve().parent.parent
 
 # ---------------------------------------------------------------------------
@@ -27,15 +29,6 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 
 def _launcher_text() -> str:
     return (REPO_ROOT / "leerie").read_text()
-
-
-def _extract_autogen_block(text: str) -> str:
-    """Extract the per-repo image block from the launcher verbatim."""
-    marker_start = "# --- per-repo derived image (local nerdctl) "
-    marker_end = "\n# --- translate --inspect-dir paths"
-    s = text.index(marker_start)
-    e = text.index(marker_end, s)
-    return text[s:e]
 
 
 _HARNESS_PREFIX = r"""

--- a/tests/test_dockerfile_bake_from_capture.py
+++ b/tests/test_dockerfile_bake_from_capture.py
@@ -19,6 +19,8 @@ import json
 import subprocess
 from pathlib import Path
 
+from tests.dockerfile_autogen_extract import extract_autogen_block as _extract_autogen_block
+
 REPO_ROOT = Path(__file__).resolve().parent.parent
 
 
@@ -28,14 +30,6 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 
 def _launcher_text() -> str:
     return (REPO_ROOT / "leerie").read_text()
-
-
-def _extract_autogen_block(text: str) -> str:
-    marker_start = "# --- per-repo derived image (local nerdctl) "
-    marker_end = "\n# --- translate --inspect-dir paths"
-    s = text.index(marker_start)
-    e = text.index(marker_end, s)
-    return text[s:e]
 
 
 _HARNESS_PREFIX = r"""

--- a/tests/test_fly_per_repo_image.py
+++ b/tests/test_fly_per_repo_image.py
@@ -15,17 +15,13 @@ import hashlib
 import subprocess
 from pathlib import Path
 
+from tests.repo_image_block_extract import extract_block as _extract_block
+
 REPO_ROOT = Path(__file__).resolve().parent.parent
 
 
 def _launcher_text() -> str:
     return (REPO_ROOT / "leerie").read_text()
-
-
-def _extract_block(text: str, start_marker: str, end_marker: str) -> str:
-    s = text.index(start_marker)
-    e = text.index(end_marker, s)
-    return text[s:e]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_launcher_env_forwarding.py
+++ b/tests/test_launcher_env_forwarding.py
@@ -27,6 +27,8 @@ import re
 import subprocess
 from pathlib import Path
 
+from tests.launcher_argv_extract import extract_run_argv
+
 REPO_ROOT = Path(__file__).resolve().parent.parent
 LAUNCHER = REPO_ROOT / "leerie"
 
@@ -93,15 +95,6 @@ def _forwarded_names(tokens: list[str]) -> set[str]:
     return names
 
 
-def _extract_run_argv() -> str:
-    """Pull the `_run_argv` array assignment verbatim from the launcher, same
-    reason as _extract_forwarding_loop: assert against real code, not a copy."""
-    src = LAUNCHER.read_text()
-    m = re.search(r"(  _run_argv=\(\n.*?\n  \)\n)", src, re.DOTALL)
-    assert m, "could not locate the _run_argv array in the launcher"
-    return m.group(1)
-
-
 _ARGV_HARNESS = r"""
 #!/usr/bin/env bash
 set -euo pipefail
@@ -125,7 +118,7 @@ for a in "${_run_argv[@]}"; do printf '%s\n' "$a"; done
 
 def _run_argv_tokens() -> list[str]:
     """Assemble the launcher's real _run_argv with stubbed vars; return tokens."""
-    harness = _ARGV_HARNESS.replace("__RUN_ARGV__", _extract_run_argv())
+    harness = _ARGV_HARNESS.replace("__RUN_ARGV__", extract_run_argv())
     result = subprocess.run(
         ["bash", "-c", harness],
         env={"PATH": "/usr/bin:/bin"},

--- a/tests/test_launcher_per_repo_image.py
+++ b/tests/test_launcher_per_repo_image.py
@@ -13,6 +13,8 @@ import os
 import subprocess
 from pathlib import Path
 
+from tests.repo_image_block_extract import extract_block as _extract_block
+
 REPO_ROOT = Path(__file__).resolve().parent.parent
 
 # ---------------------------------------------------------------------------
@@ -23,13 +25,6 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 
 def _launcher_text() -> str:
     return (REPO_ROOT / "leerie").read_text()
-
-
-def _extract_block(text: str, start_marker: str, end_marker: str) -> str:
-    """Return the text between start_marker and end_marker (exclusive)."""
-    s = text.index(start_marker)
-    e = text.index(end_marker, s)
-    return text[s:e]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_launcher_state_mount.py
+++ b/tests/test_launcher_state_mount.py
@@ -12,12 +12,7 @@ real container, and sources the relevant block from the launcher verbatim.
 from __future__ import annotations
 
 import os
-import re
 import subprocess
-from pathlib import Path
-
-REPO_ROOT = Path(__file__).resolve().parent.parent
-LAUNCHER = REPO_ROOT / "leerie"
 
 # Both halves are EXTRACTED from the launcher, not reproduced. The copy this
 # replaced was materially stale against `leerie`'s real `_run_argv` array —
@@ -28,16 +23,8 @@ LAUNCHER = REPO_ROOT / "leerie"
 # None of that flipped an assertion, which is the point: the tests were
 # blind, not wrong. They would pass identically if the launcher dropped the
 # state mount tomorrow — the exact regression this file exists to catch.
+from tests.launcher_argv_extract import extract_run_argv
 from tests.test_resolve_state_dir import _extract_state_dir_block
-
-
-def _extract_run_argv() -> str:
-    """The real `nerdctl run` argv array, lifted verbatim. Same marker pair
-    `tests/test_launcher_env_forwarding.py` already uses."""
-    src = LAUNCHER.read_text()
-    m = re.search(r"(  _run_argv=\(\n.*?\n  \)\n)", src, re.DOTALL)
-    assert m, "could not locate the _run_argv array in the launcher"
-    return m.group(1)
 
 
 # The extracted argv references many launcher-scope variables; stub the ones
@@ -67,7 +54,7 @@ ROOTLESS_SECOPT=()
 REWRITTEN_ARGS=()
 _leerie_env_args=()
 """
-    + _extract_run_argv()
+    + extract_run_argv()
     + '\nnerdctl run "${_run_argv[@]}"\n'
 )
 

--- a/tests/test_log_file_persistence.py
+++ b/tests/test_log_file_persistence.py
@@ -24,6 +24,12 @@ import re
 import subprocess
 from pathlib import Path
 
+from tests.log_file_extract_helpers import (
+    extract_invocation as _extract_invocation,
+    extract_reap_tail as _extract_reap_tail,
+    extract_setup_block as _extract_setup_block,
+)
+
 REPO_ROOT = Path(__file__).resolve().parent.parent
 LAUNCHER = REPO_ROOT / "leerie"
 
@@ -53,31 +59,6 @@ def _extract_resolver() -> str:
         src, re.DOTALL)
     assert m, "could not locate the --log-file resolution block in the launcher"
     return m.group(1)
-
-
-def _extract_setup_block() -> str:
-    """The `_run_log=...` / `_log_tee_target=...` decoupled-streaming
-    resolution block. `_log_tee_target` is computed independent of
-    `$_run_log` (bugfix-005) so the interactive/-it branch can wire it too."""
-    return _extract(
-        '  _run_log=""\n',
-        '  _log_tee_target=""\n  if [ -n "${LEERIE_LOG_FILE_RESOLVED:-}" ]; then\n'
-        '    if : >> "$LEERIE_LOG_FILE_RESOLVED" 2>/dev/null; then\n'
-        '      _log_tee_target="$LEERIE_LOG_FILE_RESOLVED"\n'
-        "    fi\n"
-        "  fi\n",
-    )
-
-
-def _extract_reap_tail() -> str:
-    return _extract("  _reap_tail() {\n", "  }\n")
-
-
-def _extract_invocation() -> str:
-    return _extract(
-        '  if [ -n "$_run_log" ]; then\n    # Decoupled: nerdctl',
-        '    nerdctl run "${_run_argv[@]}" || container_rc=$?\n  fi\n',
-    )
 
 
 assert "LEERIE_LOG_FILE_RESOLVED" in _extract_resolver()

--- a/tests/test_log_file_wiring.py
+++ b/tests/test_log_file_wiring.py
@@ -26,6 +26,12 @@ import re
 import subprocess
 from pathlib import Path
 
+from tests.log_file_extract_helpers import (
+    extract_invocation as _extract_invocation,
+    extract_reap_tail as _extract_reap_tail,
+    extract_setup_block as _extract_setup_block,
+)
+
 REPO_ROOT = Path(__file__).resolve().parent.parent
 LAUNCHER = REPO_ROOT / "leerie"
 
@@ -45,37 +51,6 @@ def _extract_mkdir_line() -> str:
     return _extract(
         'mkdir -p "$(dirname "$LEERIE_LOG_FILE_RESOLVED")" 2>/dev/null || true\n',
         'mkdir -p "$(dirname "$LEERIE_LOG_FILE_RESOLVED")" 2>/dev/null || true\n',
-    )
-
-
-def _extract_setup_block() -> str:
-    """The `_run_log=...` / `_log_tee_target=...` resolution block. Computed
-    independent of `$_run_log` (bugfix-005) so the interactive/-it branch
-    can wire it too."""
-    return _extract(
-        '  _run_log=""\n',
-        '  _log_tee_target=""\n  if [ -n "${LEERIE_LOG_FILE_RESOLVED:-}" ]; then\n'
-        '    if : >> "$LEERIE_LOG_FILE_RESOLVED" 2>/dev/null; then\n'
-        '      _log_tee_target="$LEERIE_LOG_FILE_RESOLVED"\n'
-        "    fi\n"
-        "  fi\n",
-    )
-
-
-def _extract_reap_tail() -> str:
-    return _extract(
-        "  _reap_tail() {\n",
-        "  }\n",
-    )
-
-
-def _extract_invocation() -> str:
-    """The full `if [ -n "$_run_log" ]; then ... fi` block: the piped
-    tail/tee branch, the `script`-wrapped interactive/-it branch
-    (bugfix-005), and the unwrapped fallback."""
-    return _extract(
-        '  if [ -n "$_run_log" ]; then\n    # Decoupled: nerdctl',
-        '    nerdctl run "${_run_argv[@]}" || container_rc=$?\n  fi\n',
     )
 
 

--- a/tests/test_log_file_wiring.py
+++ b/tests/test_log_file_wiring.py
@@ -27,6 +27,7 @@ import subprocess
 from pathlib import Path
 
 from tests.log_file_extract_helpers import (
+    _extract,
     extract_invocation as _extract_invocation,
     extract_reap_tail as _extract_reap_tail,
     extract_setup_block as _extract_setup_block,
@@ -34,13 +35,6 @@ from tests.log_file_extract_helpers import (
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 LAUNCHER = REPO_ROOT / "leerie"
-
-
-def _extract(start_marker: str, end_marker: str) -> str:
-    src = LAUNCHER.read_text()
-    s = src.index(start_marker)
-    e = src.index(end_marker, s) + len(end_marker)
-    return src[s:e]
 
 
 def _extract_mkdir_line() -> str:

--- a/tests/test_no_duplicate_config_arm_extract.py
+++ b/tests/test_no_duplicate_config_arm_extract.py
@@ -1,0 +1,65 @@
+"""The `config)` case-arm derivation lives in exactly one place.
+
+`tests/config_arm_extract.py` is the single derivation of the launcher's
+`config)` case arm (see its own module docstring). `test_config_verb.py` and
+`test_config_recapture.py` both used to define a byte-identical
+`_extract_config_arm()` locally — two copies of the same rule, which drift
+the same way two copies of a list do (see `tests/launcher_blocks.py` and
+`tests/test_no_duplicate_launcher_splitters.py` for the established
+precedent this guard mirrors). This test makes a third local copy impossible
+to add quietly.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+TESTS_DIR = Path(__file__).resolve().parent
+OWNER = "config_arm_extract.py"
+
+# The load-bearing token: an actual local reproduction defines the function.
+# Consumers only ever reference the name (as an import or an alias), never
+# redefine it — matching on `def ` is what distinguishes a reproduction from
+# a reference.
+_MARKER = "def _extract_config_arm("
+
+
+def _files_defining_marker() -> dict[str, int]:
+    hits: dict[str, int] = {}
+    for path in sorted(TESTS_DIR.rglob("*.py")):
+        # Skip this file: it necessarily names the marker to check for it.
+        if path.name == Path(__file__).name:
+            continue
+        try:
+            text = path.read_text(errors="replace")
+        except OSError:
+            continue
+        n = text.count(_MARKER)
+        if n:
+            hits[path.name] = n
+    return hits
+
+
+def test_no_file_locally_redefines_extract_config_arm() -> None:
+    hits = _files_defining_marker()
+    assert not hits, (
+        f"{sorted(hits)} locally define `_extract_config_arm`, reintroducing "
+        f"the duplicate this dedup removed. Import `extract_config_arm` from "
+        f"tests/{OWNER} instead (aliased as `_extract_config_arm` if needed)."
+    )
+
+
+def test_owner_actually_defines_it() -> None:
+    text = (TESTS_DIR / OWNER).read_text()
+    assert "def extract_config_arm(" in text, (
+        f"tests/{OWNER} no longer defines extract_config_arm — "
+        "the derivation this guard protects has moved or been removed."
+    )
+
+
+def test_both_consumers_import_from_the_owner() -> None:
+    for consumer in ("test_config_verb.py", "test_config_recapture.py"):
+        text = (TESTS_DIR / consumer).read_text()
+        assert "from tests.config_arm_extract import extract_config_arm" in text, (
+            f"{consumer} no longer imports extract_config_arm from the "
+            f"shared module tests/{OWNER}."
+        )

--- a/tests/test_no_duplicate_extractor_functions.py
+++ b/tests/test_no_duplicate_extractor_functions.py
@@ -1,0 +1,260 @@
+"""No two `tests/*.py` files may define a body-identical `_extract*`/
+`extract_*` helper without one importing the other.
+
+This generalizes `tests/test_no_duplicate_launcher_blocks.py`'s single-owner
+discipline from bash markers to python function bodies. That file's own
+docstring records the shape: five bash-harness files each hand-copied a
+launcher block into a string literal, converting the five fixed those
+instances, and three MORE reproductions were found afterwards outside the
+original list. `_extract*`-named python helpers are the same recurring
+pattern (CLAUDE.md's "Testing" section documents a run of these being found
+and deduplicated one at a time — `_extract_bedrock_functions`,
+`_extract_run_argv`, `_extract_config_arm`, `_extract_block`, ... — each
+fixed individually, never as a class). This guard is the standing check that
+stops the *next* one landing unnoticed, rather than another one-off fix.
+
+Two same-named `_extract*`/`extract_*` functions in different files with
+STRUCTURALLY IDENTICAL bodies (ignoring docstrings — a comment-only diff is
+not a real divergence) are a reproduction unless one file imports the other's
+definition. A genuinely distinct pair — e.g. `_extract_guard` in one file
+walking totally different source text than `_extract_guard` in another — is
+not flagged; only same-body pairs are.
+
+Scoped to `_extract`/`extract_` prefixes specifically (not every test
+helper) to avoid false positives on unrelated same-named functions that
+happen to share a name for other reasons; this is the exact recurring
+reproduction class named in CLAUDE.md's "Testing" section and in
+`tests/test_no_duplicate_launcher_blocks.py`'s own docstring.
+"""
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+TESTS_DIR = REPO_ROOT / "tests"
+
+
+def _iter_test_files() -> list[Path]:
+    return sorted(
+        p for p in TESTS_DIR.glob("*.py")
+        if p.name != Path(__file__).name
+    )
+
+
+def _strip_docstring(node: ast.FunctionDef | ast.AsyncFunctionDef) -> list[ast.stmt]:
+    body = list(node.body)
+    if (body and isinstance(body[0], ast.Expr)
+            and isinstance(body[0].value, ast.Constant)
+            and isinstance(body[0].value.value, str)):
+        body = body[1:]
+    return body
+
+
+def _normalized_body_dump(node: ast.FunctionDef | ast.AsyncFunctionDef) -> str:
+    """AST dump of the function's body with docstring and line/col
+    metadata stripped, so two textually-reformatted-but-identical bodies
+    still compare equal, and a docstring-only diff never counts as a real
+    divergence."""
+    body = _strip_docstring(node)
+    return "\n".join(ast.dump(stmt, annotate_fields=True, include_attributes=False)
+                      for stmt in body)
+
+
+def _extractor_defs(path: Path) -> list[tuple[str, str]]:
+    """Return (function_name, normalized_body_dump) for every top-level
+    `_extract*`/`extract_*` function defined in `path`. Deliberately
+    module-level only (not nested/class methods) — every real reproduction
+    in this repo's history is a module-level harness function."""
+    try:
+        tree = ast.parse(path.read_text())
+    except (SyntaxError, UnicodeDecodeError):
+        return []
+    out = []
+    for node in tree.body:
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        name = node.name
+        if not (name.startswith("_extract") or name.startswith("extract_")):
+            continue
+        dump = _normalized_body_dump(node)
+        if not dump:
+            continue
+        out.append((name, dump))
+    return out
+
+
+def _imports_name(path: Path, name: str) -> bool:
+    """True when `path` imports `name` from elsewhere (the exemption for a
+    file that legitimately reuses another file's extractor rather than
+    reproducing it — e.g. `from tests.launcher_blocks import
+    launch_env_blocks`)."""
+    try:
+        tree = ast.parse(path.read_text())
+    except (SyntaxError, UnicodeDecodeError):
+        return False
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom):
+            for alias in node.names:
+                if alias.name == name or alias.asname == name:
+                    return True
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                imported = alias.asname or alias.name
+                if imported == name:
+                    return True
+    return False
+
+
+def _find_duplicate_extractor_pairs(
+    files: list[Path],
+) -> list[tuple[str, Path, Path]]:
+    """Return (name, file_a, file_b) for every pair of files that each
+    define a same-named `_extract*`/`extract_*` function with a
+    structurally identical body, where neither file imports the name from
+    the other (or from a shared owner)."""
+    by_name: dict[str, list[tuple[Path, str]]] = {}
+    for f in files:
+        for name, dump in _extractor_defs(f):
+            by_name.setdefault(name, []).append((f, dump))
+
+    dupes = []
+    for name, defs in by_name.items():
+        for i in range(len(defs)):
+            for j in range(i + 1, len(defs)):
+                file_a, dump_a = defs[i]
+                file_b, dump_b = defs[j]
+                if dump_a != dump_b:
+                    continue
+                if _imports_name(file_a, name) or _imports_name(file_b, name):
+                    continue
+                dupes.append((name, file_a, file_b))
+    return dupes
+
+
+def test_no_duplicate_extractor_function_bodies():
+    """The real guard: on the current tree, no two test files define a
+    body-identical `_extract*`/`extract_*` helper without one importing the
+    other."""
+    dupes = _find_duplicate_extractor_pairs(_iter_test_files())
+    assert not dupes, (
+        "Duplicate extractor-helper bodies found (reproduction, not reuse) "
+        "— move the shared body into one module and have both files "
+        "import it, following tests/launcher_blocks.py's pattern:\n"
+        + "\n".join(f"  {name}: {a.name} == {b.name}" for name, a, b in dupes)
+    )
+
+
+def test_scan_finds_files_at_all():
+    """Anti-vacuity: a scan that finds zero test files, or zero
+    `_extract*`/`extract_*` definitions anywhere, would certify 'no
+    duplicates' forever without checking anything."""
+    files = _iter_test_files()
+    assert len(files) > 20
+
+    total_defs = sum(len(_extractor_defs(f)) for f in files)
+    assert total_defs > 10
+
+
+def test_planted_duplicate_is_detected(tmp_path):
+    """Anti-vacuity: two files each defining a body-identical
+    `_extract_planted_thing` (no import relationship between them) must be
+    flagged. Without this, a broken comparison (e.g. one that always
+    returns unequal, or an import-detector that always exempts) would pass
+    the real-tree test vacuously."""
+    body = (
+        "def _extract_planted_thing():\n"
+        "    x = 1 + 2\n"
+        "    return x\n"
+    )
+    file_a = tmp_path / "test_planted_a.py"
+    file_b = tmp_path / "test_planted_b.py"
+    file_a.write_text(body)
+    file_b.write_text(body)
+
+    dupes = _find_duplicate_extractor_pairs([file_a, file_b])
+    names = [d[0] for d in dupes]
+    assert "_extract_planted_thing" in names
+
+
+def test_known_good_import_is_exempt(tmp_path):
+    """Anti-vacuity partner: a file that legitimately imports another
+    file's extractor (rather than redefining it) must NOT be flagged, even
+    though the imported function is textually present in the importing
+    file's `ast.parse` in the trivial sense of appearing in its import
+    statement. This proves the guard distinguishes reuse from
+    reproduction."""
+    owner = tmp_path / "shared_extract.py"
+    owner.write_text(
+        "def extract_shared_thing():\n"
+        "    return 1 + 2\n"
+    )
+    consumer = tmp_path / "test_consumer.py"
+    consumer.write_text(
+        "from shared_extract import extract_shared_thing\n"
+        "\n"
+        "\n"
+        "def extract_shared_thing_wrapper():\n"
+        "    return extract_shared_thing()\n"
+    )
+    # A second, genuinely independent file redefining the SAME name with
+    # the SAME body as the owner would still be a reproduction even though
+    # a sibling file imports it correctly — the exemption is per-file.
+    reproducer = tmp_path / "test_reproducer.py"
+    reproducer.write_text(
+        "def extract_shared_thing():\n"
+        "    return 1 + 2\n"
+    )
+
+    dupes = _find_duplicate_extractor_pairs([owner, consumer, reproducer])
+    names = [d[0] for d in dupes]
+    # owner vs reproducer: same name, same body, neither imports the other
+    # from the other's perspective -> flagged.
+    assert "extract_shared_thing" in names
+    # consumer defines no such function at all (only imports it), so it
+    # cannot appear as either side of a flagged pair.
+    flagged_files = {p.name for _, a, b in dupes for p in (a, b)}
+    assert consumer.name not in flagged_files
+
+
+def test_docstring_only_diff_is_still_a_duplicate(tmp_path):
+    """Two bodies differing only in their docstring text are the same
+    reproduction under a fresh comment — the guard must not be fooled into
+    treating a docstring rewrite as a real divergence."""
+    file_a = tmp_path / "test_doc_a.py"
+    file_a.write_text(
+        "def _extract_doc_thing():\n"
+        "    \"\"\"First copy's docstring.\"\"\"\n"
+        "    return 1 + 2\n"
+    )
+    file_b = tmp_path / "test_doc_b.py"
+    file_b.write_text(
+        "def _extract_doc_thing():\n"
+        "    \"\"\"A completely different docstring here.\"\"\"\n"
+        "    return 1 + 2\n"
+    )
+
+    dupes = _find_duplicate_extractor_pairs([file_a, file_b])
+    names = [d[0] for d in dupes]
+    assert "_extract_doc_thing" in names
+
+
+def test_genuinely_different_bodies_are_not_flagged(tmp_path):
+    """The negative control: two same-named extractors with different
+    bodies (the common, legitimate case — e.g. this repo's
+    `_extract_fn` in test_auto_detect_run_runtime.py vs
+    test_resolve_repo_image_tag.py, confirmed to differ) must not be
+    flagged."""
+    file_a = tmp_path / "test_diff_a.py"
+    file_a.write_text(
+        "def _extract_fn(name):\n"
+        "    return name + '_a'\n"
+    )
+    file_b = tmp_path / "test_diff_b.py"
+    file_b.write_text(
+        "def _extract_fn(name):\n"
+        "    return name.upper()\n"
+    )
+
+    dupes = _find_duplicate_extractor_pairs([file_a, file_b])
+    assert dupes == []


### PR DESCRIPTION
## Summary

Several `tests/*.py` files independently defined byte-identical Python helper functions that extract verbatim shell blocks (launcher argv, config arm, bedrock functions, dockerfile autogen block, log-file wiring, repo-image block) from `leerie`/`scripts/*.sh` for use in test harnesses. This PR consolidates each duplicated pair into a single shared module (mirroring the existing `tests/launcher_blocks.py`/`tests/ec2_stub.py` single-owner convention) and adds a general AST-based regression guard so future `_extract*`/`extract_*` reproductions are caught automatically instead of silently duplicated.

## Which layer(s) does this PR touch?

(See [`CLAUDE.md`](../CLAUDE.md) for the three-layer rule.)

- [ ] `docs/DESIGN.md` (architecture)
- [ ] `docs/IMPLEMENTATION.md` (code surface)
- [ ] `orchestrator/leerie.py` (code)
- [ ] docs (`README.md`, `docs/USAGE.md`, `CONTRIBUTING.md`, etc.)
- [x] tests (`tests/`)
- [ ] CI / repo meta (`.github/`)

If multiple, has the change propagated **top-down** per the three-layer rule
(DESIGN → IMPLEMENTATION → code)?

- [ ] yes
- [x] not applicable (single layer)

## Task-completion checklist

(Mirrors `CLAUDE.md` and `CONTRIBUTING.md`.)

- [ ] `docs/IMPLEMENTATION.md` updated if code surface changed
- [ ] `docs/DESIGN.md` updated if architecture changed
- [ ] `pytest tests/` passes
- [ ] `python3 -c "import ast; ast.parse(open('orchestrator/leerie.py').read())"` passes
- [ ] `git diff --stat` reviewed for scope (no collateral edits)

## Testing notes

Six shared extraction modules were added, each imported by the test files that previously carried a byte-identical local copy: `tests/config_arm_extract.py` (`test_config_verb.py`, `test_config_recapture.py`), `tests/launcher_argv_extract.py` (`test_launcher_state_mount.py`, `test_launcher_env_forwarding.py`), `tests/log_file_extract_helpers.py` (`test_log_file_wiring.py`, `test_log_file_persistence.py`), `tests/dockerfile_autogen_extract.py` (`test_dockerfile_autogen.py`, `test_dockerfile_bake_from_capture.py`), `tests/bedrock_extract.py` (`test_bedrock_bearer_token.py`, `test_bedrock_mode.py`), and `tests/repo_image_block_extract.py` (`test_launcher_per_repo_image.py`, `test_fly_per_repo_image.py`, `test_build_repo_image.py`).

`tests/test_no_duplicate_extractor_functions.py` is the new general guard: it AST-sweeps `tests/*.py`, groups same-named `_extract*`/`extract_*` functions, and fails when two definitions have structurally identical bodies (docstrings ignored) with no import relationship between them. Running it against the pre-dedup tree surfaced one additional real reproduction — the plain `_extract(start_marker, end_marker)` primitive, byte-identical between `log_file_extract_helpers.py` and `test_log_file_wiring.py` — which was folded in as part of this same change so the guard's own baseline is clean. `test_no_duplicate_config_arm_extract.py` was added as a narrower, named single-owner pin for `_extract_config_arm` specifically, mirroring the existing precedent for `tests/launcher_blocks.py`.

## Conformance notes

- **tests** (`pytest`): 5 failed, 8221 passed, 115 skipped — `::test_the_refusal_names_the_duplicate` plus three failures in `tests/test_signal_cleanup.py` (`test_terminate_proc_tree_reaps_grandchildren`, `test_terminate_proc_tree_reaps_detached_session_grandchildren`, `test_descendant_tracker_reaps_orphaned_backgrounded_subprocess`). Per CLAUDE.md's testing guidance, `test_signal_cleanup.py` failures are a known concurrent-load-sensitive class (base-tree health was also measured red on the `tests` axis) and should be re-verified with the suite run serially/alone before treating them as caused by this change; `::test_the_refusal_names_the_duplicate` should be checked directly against this diff before merge.

## Related issue

<!-- Closes #N -->
