### PR TITLE
leerie: Deduplicate repeated test-helper functions across tests/*.py

### DIFF
--- a/tests/ec2_stub.py
+++ b/tests/ec2_stub.py
@@ -328,6 +328,34 @@ def read_log(dir: Path) -> list[str]:
     return [line for line in log_path.read_text().splitlines() if line]
 
 
+def seed_running_instance(
+    aws_dir: Path,
+    *,
+    instance_id: str | None = None,
+    public_ip: str = "203.0.113.20",
+    status_ok: bool = True,
+    ip_gen: int | None = None,
+) -> str:
+    """Directly seed a `running` instance into the stub's state.json.
+
+    Bypasses a real `run-instances` round trip, for tests that only need
+    a pre-existing instance to act on (stop/kill/resume dispatch, not
+    provisioning itself — covered by test_ec2_provision.py). `instance_id`
+    defaults to an auto-generated id (mirroring the stub's own `next_id`
+    shape); pass it explicitly to pin a known id. `ip_gen` seeds the
+    stub's `_ip_gen` counter field only when given, since not every
+    caller's readiness/IP-reassignment assertions need it.
+    """
+    state = read_state(aws_dir)
+    iid = instance_id or ("i-" + format(len(state["instances"]), "017x"))
+    entry: dict = {"state": "running", "public_ip": public_ip, "status_ok": status_ok}
+    if ip_gen is not None:
+        entry["_ip_gen"] = ip_gen
+    state["instances"][iid] = entry
+    (aws_dir / STATE_FILENAME).write_text(json.dumps(state))
+    return iid
+
+
 def leaked_resources(state: dict) -> dict:
     """Return the subset of `state` that is not fully torn down.
 

--- a/tests/stub_helpers.py
+++ b/tests/stub_helpers.py
@@ -1,0 +1,24 @@
+"""Shared test-stub builders used across the launcher test suite."""
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+
+def _stub_self_cmd(tmp_path: Path) -> tuple[Path, Path]:
+    """Build a stub binary that records its argv to a log and exits 0.
+
+    Used to intercept ``LEERIE_SELF_CMD`` dispatch in chain/group launcher
+    tests so they don't actually shell out to a real launcher recursion.
+
+    Returns ``(stub_path, log_path)``.
+    """
+    log = tmp_path / "stub-self.log"
+    stub = tmp_path / "self-stub"
+    stub.write_text(textwrap.dedent(f"""\
+        #!/usr/bin/env bash
+        echo "$@" >> "{log}"
+        exit 0
+        """))
+    stub.chmod(0o755)
+    return stub, log

--- a/tests/stub_helpers.py
+++ b/tests/stub_helpers.py
@@ -1,0 +1,36 @@
+"""The single owner of the no-op `timeout` bash stub used across test PATHs.
+
+Six test files each defined a byte-identical `_make_stub_timeout(stub_dir)`,
+differing only in docstring wording: it writes a `timeout` shim that skips
+any leading `--flag`/duration args and execs the wrapped command, ignoring
+the time cap. Adequate for tests that merely need the `timeout` binary to
+exist on the stubbed PATH (macOS ships no `/usr/bin/timeout`; it's coreutils,
+via Homebrew). A single-owner module keeps future changes to the stub's
+semantics from silently desyncing across call sites — same precedent as
+`tests/ec2_stub.py` and `tests/launcher_blocks.py`.
+
+This is deliberately NOT the stub for tests that assert the cap actually
+*fires*: `_stub_timeout` in `tests/test_ec2_transport.py` is a distinct,
+intentionally different killing variant for that case, and stays there.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def _make_stub_timeout(stub_dir: Path) -> None:
+    """No-op `timeout`: run the child, ignore the cap.
+
+    Adequate for tests that merely need the binary to exist on the
+    stubbed PATH. A test that asserts the cap actually *fires* must
+    use `_stub_timeout` (imported from tests.test_ec2_transport) instead.
+    """
+    stub = stub_dir / "timeout"
+    stub.write_text(
+        """#!/usr/bin/env bash
+while [[ "$1" == --* ]]; do shift; done
+shift
+exec "$@"
+"""
+    )
+    stub.chmod(0o755)

--- a/tests/stub_helpers.py
+++ b/tests/stub_helpers.py
@@ -1,0 +1,21 @@
+"""Shared extractor helpers reused across tests/*.py.
+
+Single-owner discipline (see CLAUDE.md's `launcher_blocks.py`/`ec2_stub.py`
+precedent): each helper here previously existed as byte-identical copies in
+every consuming test file, which is the drift risk this module exists to
+remove.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+ENTRY_SH = REPO_ROOT / "scripts" / "container-entry.sh"
+
+
+def _entry_sh_rootful_block() -> str:
+    text = ENTRY_SH.read_text()
+    marker = 'if [ "$ROOTLESS" != "true" ] && getent passwd leerie'
+    start = text.index(marker)
+    end = text.index("\nfi", start)
+    return text[start:end]

--- a/tests/test_chain_launcher_id_dispatch.py
+++ b/tests/test_chain_launcher_id_dispatch.py
@@ -16,8 +16,9 @@ from __future__ import annotations
 import json
 import os
 import subprocess
-import textwrap
 from pathlib import Path
+
+from tests.stub_helpers import _stub_self_cmd
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 LAUNCHER = REPO_ROOT / "leerie"
@@ -64,24 +65,6 @@ def _fixture_two_run_chain(tmp_path: Path) -> Path:
         "fly_machine_id": NON_CHAIN_RUN,
     })
     return state_dir
-
-
-def _stub_self_cmd(tmp_path: Path) -> tuple[Path, Path]:
-    """Build a stub binary that records its argv. Exposed to the launcher
-    via the ``LEERIE_SELF_CMD`` env override so --chain-id dispatch invokes
-    the stub instead of the real launcher for per-run recursion.
-
-    Returns ``(stub_path, log_path)``.
-    """
-    log = tmp_path / "stub-self.log"
-    stub = tmp_path / "self-stub"
-    stub.write_text(textwrap.dedent(f"""\
-        #!/usr/bin/env bash
-        echo "$@" >> "{log}"
-        exit 0
-        """))
-    stub.chmod(0o755)
-    return stub, log
 
 
 def _run(tmp_path: Path, args: list[str], env_extra: dict | None = None,

--- a/tests/test_claude_json_dir_mount.py
+++ b/tests/test_claude_json_dir_mount.py
@@ -20,6 +20,8 @@ import subprocess
 import tempfile
 from pathlib import Path
 
+from tests.stub_helpers import _entry_sh_rootful_block
+
 REPO_ROOT = Path(__file__).resolve().parent.parent
 LAUNCHER = REPO_ROOT / "leerie"
 ENTRY_SH = REPO_ROOT / "scripts" / "container-entry.sh"
@@ -78,20 +80,6 @@ def test_claude_dir_mount_untouched():
 def _entry_sh_claude_json_copy_block() -> str:
     text = _entry_sh_text()
     marker = "if [ -f /opt/leerie-claude-json-src/.claude.json ]; then"
-    start = text.index(marker)
-    end = text.index("\nfi", start)
-    return text[start:end]
-
-
-def _entry_sh_rootful_block() -> str:
-    """The pre-existing `/work` ownership-fix guard, which now also owns
-    the `.claude.json` chown. Same marker pair
-    `tests/test_home_leerie_ownership.py` /
-    `tests/test_tmp_cache_writable.py` already extract this block with —
-    deliberately reused so a future edit to this guard's boundaries can't
-    silently desync between the two files."""
-    text = _entry_sh_text()
-    marker = 'if [ "$ROOTLESS" != "true" ] && getent passwd leerie'
     start = text.index(marker)
     end = text.index("\nfi", start)
     return text[start:end]

--- a/tests/test_claude_json_mount.py
+++ b/tests/test_claude_json_mount.py
@@ -18,6 +18,8 @@ import os
 import tempfile
 from pathlib import Path
 
+from tests.stub_helpers import _entry_sh_rootful_block
+
 REPO_ROOT = Path(__file__).resolve().parent.parent
 LAUNCHER = REPO_ROOT / "leerie"
 ENTRY_SH = REPO_ROOT / "scripts" / "container-entry.sh"
@@ -31,14 +33,6 @@ def _entry_sh_copy_block() -> str:
     marker = "if [ -f /opt/leerie-claude-json-src/.claude.json ]; then"
     start = text.index(marker)
     end = text.index("\nfi", start) + len("\nfi")
-    return text[start:end]
-
-
-def _entry_sh_rootful_block() -> str:
-    text = ENTRY_SH.read_text()
-    marker = 'if [ "$ROOTLESS" != "true" ] && getent passwd leerie'
-    start = text.index(marker)
-    end = text.index("\nfi", start)
     return text[start:end]
 
 

--- a/tests/test_ec2_bash32_portability.py
+++ b/tests/test_ec2_bash32_portability.py
@@ -46,7 +46,7 @@ from pathlib import Path
 
 import pytest
 
-from tests.ec2_stub import _stub_aws, read_state
+from tests.ec2_stub import _stub_aws, seed_running_instance
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 SCRIPTS = REPO_ROOT / "scripts" / "remote"
@@ -286,15 +286,6 @@ def _launcher_env(tmp_path: Path, aws_dir: Path) -> tuple[dict, Path]:
     return env, state_dir
 
 
-def _seed_running_instance(aws_dir: Path) -> str:
-    state = read_state(aws_dir)
-    iid = "i-" + format(len(state["instances"]), "017x")
-    state["instances"][iid] = {"state": "running", "public_ip": "203.0.113.20",
-                                "status_ok": True}
-    (aws_dir / "state.json").write_text(json.dumps(state))
-    return iid
-
-
 def _write_ec2_sidecar(run_dir: Path, run_id: str, instance_id: str) -> None:
     run_dir.mkdir(parents=True, exist_ok=True)
     (run_dir / "ec2-instance.json").write_text(json.dumps({
@@ -352,7 +343,7 @@ def test_ec2_launcher_verb_runs_cleanly_under_bash32(verb_args, tmp_path):
     aws_dir = tmp_path / "bin"
     aws_dir.mkdir()
     _stub_aws(aws_dir)
-    iid = _seed_running_instance(aws_dir)
+    iid = seed_running_instance(aws_dir)
 
     env, state_dir = _launcher_env(tmp_path, aws_dir)
     run_dir = state_dir / "runs" / RUN_ID

--- a/tests/test_ec2_fetch_branch.py
+++ b/tests/test_ec2_fetch_branch.py
@@ -22,6 +22,8 @@ import os
 import subprocess
 from pathlib import Path
 
+from tests.stub_helpers import _make_stub_timeout
+
 REPO_ROOT = Path(__file__).resolve().parent.parent
 EC2_FETCH_SH = REPO_ROOT / "scripts" / "remote" / "ec2-fetch-branch.sh"
 EC2_LIB_SH = REPO_ROOT / "scripts" / "remote" / "ec2-lib.sh"
@@ -135,18 +137,6 @@ esac
 """
     )
     stub_path.chmod(0o755)
-
-
-def _make_stub_timeout(stub_dir: Path) -> None:
-    stub = stub_dir / "timeout"
-    stub.write_text(
-        """#!/usr/bin/env bash
-while [[ "$1" == --* ]]; do shift; done
-shift
-exec "$@"
-"""
-    )
-    stub.chmod(0o755)
 
 
 def _make_git_repo(tmp_path: Path, subdir: str = "myrepo") -> Path:

--- a/tests/test_ec2_launcher_kill.py
+++ b/tests/test_ec2_launcher_kill.py
@@ -40,7 +40,7 @@ import os
 import subprocess
 from pathlib import Path
 
-from tests.ec2_stub import leaked_resources, read_log, read_state
+from tests.ec2_stub import leaked_resources, read_log, read_state, seed_running_instance
 from tests.test_ec2_fetch_branch import (
     _init_instance_repo_with_run,
     _make_git_repo,
@@ -128,21 +128,6 @@ def _read_flyctl_log(bin_dir: Path) -> list[str]:
     return [l for l in log.read_text().splitlines() if l]
 
 
-def _seed_running_instance(aws_dir: Path, *, public_ip: str = "203.0.113.11") -> str:
-    """Seed the stub's state with one already-`running` instance (as if
-    a prior `provision_instance()` call had created it) without paying
-    for a real run-instances round trip."""
-    state = json.loads((aws_dir / "state.json").read_text())
-    state["instances"][INSTANCE_ID] = {
-        "state": "running",
-        "_ip_gen": 1,
-        "public_ip": public_ip,
-        "status_ok": True,
-    }
-    (aws_dir / "state.json").write_text(json.dumps(state))
-    return INSTANCE_ID
-
-
 def _make_run_dir(state_dir: Path, run_id: str, *, instance_id: str = INSTANCE_ID,
                    on_run_json: bool = True) -> Path:
     run_dir = state_dir / "runs" / run_id
@@ -184,7 +169,8 @@ def _setup_fixture(tmp_path: Path, *, with_completed_run: bool = True):
 
     state_dir = tmp_path / "state"
     run_dir = _make_run_dir(state_dir, "r1")
-    instance_id = _seed_running_instance(bin_dir)
+    instance_id = seed_running_instance(
+        bin_dir, instance_id=INSTANCE_ID, public_ip="203.0.113.11", ip_gen=1)
 
     home = tmp_path / "home"
     home.mkdir()

--- a/tests/test_ec2_launcher_kill.py
+++ b/tests/test_ec2_launcher_kill.py
@@ -41,11 +41,11 @@ import subprocess
 from pathlib import Path
 
 from tests.ec2_stub import leaked_resources, read_log, read_state
+from tests.stub_helpers import _make_stub_timeout
 from tests.test_ec2_fetch_branch import (
     _init_instance_repo_with_run,
     _make_git_repo,
     _make_stub_ssh,
-    _make_stub_timeout,
     _setup_instance,
 )
 

--- a/tests/test_ec2_launcher_readonly_verbs.py
+++ b/tests/test_ec2_launcher_readonly_verbs.py
@@ -44,7 +44,7 @@ import json
 import subprocess
 from pathlib import Path
 
-from tests.ec2_stub import _STUB_SOURCE, read_log, read_state
+from tests.ec2_stub import _STUB_SOURCE, read_log, read_state, seed_running_instance
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 LAUNCHER = REPO_ROOT / "leerie"
@@ -153,14 +153,6 @@ def _stub_aws_with_ssm(dir: Path) -> Path:
     return stub
 
 
-def _seed_running_instance(aws_dir: Path) -> str:
-    state = read_state(aws_dir)
-    iid = "i-" + format(len(state["instances"]), "017x")
-    state["instances"][iid] = {"state": "running", "public_ip": "203.0.113.20", "status_ok": True}
-    (aws_dir / "state.json").write_text(json.dumps(state))
-    return iid
-
-
 def _seed_stopped_instance(aws_dir: Path) -> str:
     state = read_state(aws_dir)
     iid = "i-" + format(len(state["instances"]), "017x")
@@ -238,7 +230,7 @@ def test_accept_blocked_ec2_autodetects_runtime_not_local(tmp_path: Path) -> Non
     and fail with a 'local' error message rather than an EC2 one."""
     aws_dir = tmp_path / "bin"
     _stub_aws_with_ssm(aws_dir)
-    iid = _seed_running_instance(aws_dir)
+    iid = seed_running_instance(aws_dir)
 
     env, state_dir, work_dest = _env(tmp_path, aws_dir)
     run_dir = state_dir / "runs" / RUN_ID
@@ -261,7 +253,7 @@ def test_accept_blocked_ec2_writes_accept_record(tmp_path: Path) -> None:
     prove the mirror step runs) reflects the same mutation afterward."""
     aws_dir = tmp_path / "bin"
     _stub_aws_with_ssm(aws_dir)
-    iid = _seed_running_instance(aws_dir)
+    iid = seed_running_instance(aws_dir)
 
     env, state_dir, work_dest = _env(tmp_path, aws_dir)
     run_dir = state_dir / "runs" / RUN_ID
@@ -287,7 +279,7 @@ def test_accept_blocked_ec2_explicit_runtime_flag_accepted(tmp_path: Path) -> No
     by the pre-fix fly|local-only check (leerie:1321 pre-fix)."""
     aws_dir = tmp_path / "bin"
     _stub_aws_with_ssm(aws_dir)
-    iid = _seed_running_instance(aws_dir)
+    iid = seed_running_instance(aws_dir)
 
     env, state_dir, work_dest = _env(tmp_path, aws_dir)
     run_dir = state_dir / "runs" / RUN_ID
@@ -347,7 +339,7 @@ def test_accept_blocked_ec2_already_running_not_paused_afterward(tmp_path: Path)
     _ab_started_machine conditional."""
     aws_dir = tmp_path / "bin"
     _stub_aws_with_ssm(aws_dir)
-    iid = _seed_running_instance(aws_dir)
+    iid = seed_running_instance(aws_dir)
 
     env, state_dir, work_dest = _env(tmp_path, aws_dir)
     run_dir = state_dir / "runs" / RUN_ID

--- a/tests/test_ec2_launcher_resume.py
+++ b/tests/test_ec2_launcher_resume.py
@@ -27,7 +27,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-from tests.ec2_stub import _stub_aws, read_log, read_state
+from tests.ec2_stub import _stub_aws, read_log, read_state, seed_running_instance
 from tests.test_ec2_e2e_provision import (
     REQUIRED_PROVISION_ENV,
     extract_ec2_dispatch_block,
@@ -69,19 +69,6 @@ def _seed_stopped_instance(aws_dir: Path, *, status_ok: bool = True,
         "_ip_gen": 1,
         "public_ip": public_ip,
         "status_ok": status_ok,
-    }
-    (aws_dir / "state.json").write_text(json.dumps(state))
-    return iid
-
-
-def _seed_running_instance(aws_dir: Path, *, public_ip: str = "203.0.113.20") -> str:
-    state = read_state(aws_dir)
-    iid = "i-" + format(len(state["instances"]), "017x")
-    state["instances"][iid] = {
-        "state": "running",
-        "_ip_gen": 1,
-        "public_ip": public_ip,
-        "status_ok": True,
     }
     (aws_dir / "state.json").write_text(json.dumps(state))
     return iid
@@ -237,7 +224,7 @@ def test_resume_on_already_running_instance_is_noop(tmp_path):
     aws_dir = tmp_path / "bin"
     env, state_dir = _resume_env(aws_dir, RUN_ID)
     _stub_aws(aws_dir)
-    iid = _seed_running_instance(aws_dir)
+    iid = seed_running_instance(aws_dir, ip_gen=1)
     _write_ec2_sidecar(state_dir, RUN_ID, iid)
 
     result = run_ec2_dispatch(env)

--- a/tests/test_ec2_launcher_stop.py
+++ b/tests/test_ec2_launcher_stop.py
@@ -40,27 +40,12 @@ import os
 import subprocess
 from pathlib import Path
 
-from tests.ec2_stub import _stub_aws, read_state
+from tests.ec2_stub import _stub_aws, read_state, seed_running_instance
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 LAUNCHER = REPO_ROOT / "leerie"
 
 RUN_ID = "ec2-run-0001"
-
-
-def _seed_running_instance(aws_dir: Path) -> str:
-    """Directly seed a `running` instance in the stub's state.json,
-    bypassing `run-instances` — this file only exercises the launcher's
-    `stop` dispatch, not provisioning (covered by
-    tests/test_ec2_provision.py)."""
-    state = read_state(aws_dir)
-    iid = "i-" + format(len(state["instances"]), "017x")
-    state["instances"][iid] = {
-        "state": "running",
-        "public_ip": "203.0.113.20",
-    }
-    (aws_dir / "state.json").write_text(json.dumps(state))
-    return iid
 
 
 def _write_ec2_sidecar(run_dir: Path, run_id: str, instance_id: str) -> None:
@@ -109,7 +94,7 @@ def test_stop_ec2_run_stops_instance_and_writes_sidecar(tmp_path: Path) -> None:
     aws_dir = tmp_path / "bin"
     aws_dir.mkdir()
     _stub_aws(aws_dir)
-    iid = _seed_running_instance(aws_dir)
+    iid = seed_running_instance(aws_dir)
 
     env, state_dir = _env(tmp_path, aws_dir)
     run_dir = state_dir / "runs" / RUN_ID
@@ -135,7 +120,7 @@ def test_stop_ec2_run_explicit_runtime_flag(tmp_path: Path) -> None:
     aws_dir = tmp_path / "bin"
     aws_dir.mkdir()
     _stub_aws(aws_dir)
-    iid = _seed_running_instance(aws_dir)
+    iid = seed_running_instance(aws_dir)
 
     env, state_dir = _env(tmp_path, aws_dir)
     run_dir = state_dir / "runs" / RUN_ID
@@ -153,7 +138,7 @@ def test_stop_ec2_run_does_not_terminate_instance(tmp_path: Path) -> None:
     aws_dir = tmp_path / "bin"
     aws_dir.mkdir()
     _stub_aws(aws_dir)
-    iid = _seed_running_instance(aws_dir)
+    iid = seed_running_instance(aws_dir)
 
     env, state_dir = _env(tmp_path, aws_dir)
     run_dir = state_dir / "runs" / RUN_ID
@@ -236,7 +221,7 @@ def test_stop_ec2_run_credential_failure_does_not_call_stop_instances(tmp_path: 
     aws_dir = tmp_path / "bin"
     aws_dir.mkdir()
     _stub_aws(aws_dir)
-    iid = _seed_running_instance(aws_dir)
+    iid = seed_running_instance(aws_dir)
 
     env, state_dir = _env(tmp_path, aws_dir)
     run_dir = state_dir / "runs" / RUN_ID

--- a/tests/test_ec2_seed_auth.py
+++ b/tests/test_ec2_seed_auth.py
@@ -23,6 +23,7 @@ import os
 import subprocess
 from pathlib import Path
 
+from tests.stub_helpers import _make_stub_timeout
 from tests.test_ec2_transport import _stub_timeout as _make_killing_stub_timeout
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -154,25 +155,6 @@ esac
 """
     )
     stub_path.chmod(0o755)
-
-
-def _make_stub_timeout(stub_dir: Path) -> None:
-    """No-op `timeout`: run the child, ignore the cap.
-
-    Adequate for tests that merely need the binary to exist on the
-    stubbed PATH. A test that asserts the cap actually *fires* must
-    use `_make_killing_stub_timeout` (imported from
-    test_ec2_transport) instead.
-    """
-    stub = stub_dir / "timeout"
-    stub.write_text(
-        """#!/usr/bin/env bash
-while [[ "$1" == --* ]]; do shift; done
-shift
-exec "$@"
-"""
-    )
-    stub.chmod(0o755)
 
 
 def _make_stub_git(stub_path: Path, *, name: str = "Test User",

--- a/tests/test_ec2_seed_repo.py
+++ b/tests/test_ec2_seed_repo.py
@@ -26,6 +26,7 @@ import os
 import subprocess
 from pathlib import Path
 
+from tests.stub_helpers import _make_stub_timeout
 from tests.test_ec2_transport import _stub_timeout as _make_killing_stub_timeout
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -193,26 +194,6 @@ esac
 """
     )
     stub_path.chmod(0o755)
-
-
-def _make_stub_timeout(stub_dir: Path) -> None:
-    """No-op `timeout`: run the child, ignore the cap.
-
-    Adequate for tests that merely need the binary to exist on the
-    stubbed PATH (macOS ships no /usr/bin/timeout). A test that asserts
-    the cap actually *fires* must use `_stub_timeout` from
-    test_ec2_transport instead — this one would let a stalled stub run
-    to completion.
-    """
-    stub = stub_dir / "timeout"
-    stub.write_text(
-        """#!/usr/bin/env bash
-while [[ "$1" == --* ]]; do shift; done
-shift
-exec "$@"
-"""
-    )
-    stub.chmod(0o755)
 
 
 def _init_repo(repo: Path) -> None:

--- a/tests/test_group_launcher.py
+++ b/tests/test_group_launcher.py
@@ -18,6 +18,8 @@ import subprocess
 import textwrap
 from pathlib import Path
 
+from tests.stub_helpers import _stub_self_cmd
+
 REPO_ROOT = Path(__file__).resolve().parent.parent
 LAUNCHER = REPO_ROOT / "leerie"
 
@@ -53,19 +55,6 @@ def _write_run(state_dir: Path, run_id: str, fields: dict) -> None:
     rd = state_dir / "runs" / run_id
     rd.mkdir(parents=True)
     (rd / "run.json").write_text(json.dumps(fields))
-
-
-def _stub_self_cmd(tmp_path: Path) -> tuple[Path, Path]:
-    """Stub binary that records its argv to a log and exits 0."""
-    log = tmp_path / "stub-self.log"
-    stub = tmp_path / "self-stub"
-    stub.write_text(textwrap.dedent(f"""\
-        #!/usr/bin/env bash
-        echo "$@" >> "{log}"
-        exit 0
-        """))
-    stub.chmod(0o755)
-    return stub, log
 
 
 def _stub_group_self_cmd(tmp_path: Path) -> tuple[Path, Path]:

--- a/tests/test_group_launcher_verbs.py
+++ b/tests/test_group_launcher_verbs.py
@@ -20,8 +20,9 @@ from __future__ import annotations
 import json
 import os
 import subprocess
-import textwrap
 from pathlib import Path
+
+from tests.stub_helpers import _stub_self_cmd
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 LAUNCHER = REPO_ROOT / "leerie"
@@ -43,22 +44,6 @@ def _write_run(state_dir: Path, run_id: str, fields: dict) -> None:
     rd = state_dir / "runs" / run_id
     rd.mkdir(parents=True)
     (rd / "run.json").write_text(json.dumps(fields))
-
-
-def _stub_self_cmd(tmp_path: Path) -> tuple[Path, Path]:
-    """Stub binary that records its full argv per invocation.
-
-    Returns ``(stub_path, log_path)``.
-    """
-    log = tmp_path / "stub-self.log"
-    stub = tmp_path / "self-stub"
-    stub.write_text(textwrap.dedent(f"""\
-        #!/usr/bin/env bash
-        echo "$@" >> "{log}"
-        exit 0
-        """))
-    stub.chmod(0o755)
-    return stub, log
 
 
 def _two_member_fixture(tmp_path: Path) -> tuple[Path, Path]:

--- a/tests/test_home_leerie_ownership.py
+++ b/tests/test_home_leerie_ownership.py
@@ -12,6 +12,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from tests.stub_helpers import _entry_sh_rootful_block
+
 REPO_ROOT = Path(__file__).resolve().parent.parent
 DOCKERFILE = REPO_ROOT / "Dockerfile"
 ENTRY_SH = REPO_ROOT / "scripts" / "container-entry.sh"
@@ -23,14 +25,6 @@ def _dockerfile_home_leerie_block() -> str:
     end_marker = "chmod 700 /home/leerie/.gnupg"
     start = text.index(marker)
     end = text.index(end_marker, start) + len(end_marker)
-    return text[start:end]
-
-
-def _entry_sh_rootful_block() -> str:
-    text = ENTRY_SH.read_text()
-    marker = 'if [ "$ROOTLESS" != "true" ] && getent passwd leerie'
-    start = text.index(marker)
-    end = text.index("\nfi", start)
     return text[start:end]
 
 

--- a/tests/test_no_duplicate_stub_timeout.py
+++ b/tests/test_no_duplicate_stub_timeout.py
@@ -1,0 +1,59 @@
+"""`_make_stub_timeout` has exactly one definition, in tests/stub_helpers.py.
+
+Six test files previously each defined a byte-identical no-op `timeout`
+bash-stub builder. Nothing stops a future edit from reintroducing a copy in
+one of the consumer files — this is a structural regression guard against
+exactly that, mirroring the single-owner discipline in
+`tests/test_no_duplicate_seed_shell_helpers.py` and
+`tests/test_no_duplicate_launcher_blocks.py`.
+
+The distinct killing variant `_stub_timeout` in tests/test_ec2_transport.py
+is intentionally different (it asserts the cap actually fires) and is out
+of scope for this guard.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+TESTS_DIR = Path(__file__).resolve().parent
+
+_MARKER_RE = re.compile(r"^def _make_stub_timeout\(", re.MULTILINE)
+
+
+def _definition_sites() -> dict[str, int]:
+    hits: dict[str, int] = {}
+    for path in sorted(TESTS_DIR.glob("*.py")):
+        text = path.read_text(errors="replace")
+        n = len(_MARKER_RE.findall(text))
+        if n:
+            hits[path.name] = n
+    return hits
+
+
+def test_defined_exactly_once_repo_wide() -> None:
+    sites = _definition_sites()
+    total = sum(sites.values())
+    assert total == 1, (
+        f"`_make_stub_timeout` should be defined exactly once across "
+        f"tests/*.py, found {total} definition(s): {sites} — a duplicate "
+        f"has been reintroduced outside tests/stub_helpers.py"
+    )
+
+
+def test_defined_only_in_stub_helpers() -> None:
+    sites = _definition_sites()
+    assert sites == {"stub_helpers.py": 1}, (
+        f"`_make_stub_timeout` is expected to be defined only in "
+        f"tests/stub_helpers.py, found: {sites}"
+    )
+
+
+def test_anti_vacuity_the_scan_can_find_a_real_definition() -> None:
+    """A scan matching nothing would certify 'no duplicates' forever."""
+    sites = _definition_sites()
+    assert sites, (
+        "expected to find at least one definition of `_make_stub_timeout` "
+        "in tests/*.py — the scan's marker is stale and its guards above "
+        "are vacuous"
+    )

--- a/tests/test_seed_inspect_dirs.py
+++ b/tests/test_seed_inspect_dirs.py
@@ -38,6 +38,8 @@ import os
 import subprocess
 from pathlib import Path
 
+from tests.stub_helpers import _make_stub_timeout
+
 REPO_ROOT = Path(__file__).resolve().parent.parent
 SEED_SH = REPO_ROOT / "scripts" / "remote" / "seed-repo.sh"
 
@@ -177,20 +179,6 @@ esac
 """
     )
     stub_path.chmod(0o755)
-
-
-def _make_stub_timeout(stub_dir: Path) -> None:
-    """Same `timeout` stub as test_seed_repo_sh.py — macOS doesn't ship
-    GNU `timeout` in /usr/bin."""
-    stub = stub_dir / "timeout"
-    stub.write_text(
-        """#!/usr/bin/env bash
-while [[ "$1" == --* ]]; do shift; done
-shift
-exec "$@"
-"""
-    )
-    stub.chmod(0o755)
 
 
 def _make_git_repo(root: Path, name: str, files: dict[str, str],

--- a/tests/test_seed_repo_sh.py
+++ b/tests/test_seed_repo_sh.py
@@ -36,6 +36,8 @@ import os
 import subprocess
 from pathlib import Path
 
+from tests.stub_helpers import _make_stub_timeout
+
 REPO_ROOT = Path(__file__).resolve().parent.parent
 SEED_SH = REPO_ROOT / "scripts" / "remote" / "seed-repo.sh"
 
@@ -155,30 +157,6 @@ esac
 """
     )
     stub_path.chmod(0o755)
-
-
-def _make_stub_timeout(stub_dir: Path) -> None:
-    """Stub `timeout` for hosts where coreutils isn't on /usr/bin.
-
-    lib.sh's wait_for_fly_ssh_ready wraps flyctl in `timeout <secs>`
-    so a stuck WireGuard handshake doesn't hang the seed forever.
-    macOS doesn't ship `timeout` in /usr/bin (it's in
-    coreutils via Homebrew). Tests pin PATH to a controlled set so they
-    don't depend on the host's Homebrew layout; this stub provides
-    `timeout` semantics (run the child, propagate rc, ignore the time
-    cap) good enough for unit tests."""
-    stub = stub_dir / "timeout"
-    stub.write_text(
-        """#!/usr/bin/env bash
-# Stub timeout: skip the time arg(s), exec the rest. Handles both
-#   timeout 8 cmd ...
-#   timeout --kill-after=2 10 cmd ...
-while [[ "$1" == --* ]]; do shift; done
-shift  # discard the seconds arg
-exec "$@"
-"""
-    )
-    stub.chmod(0o755)
 
 
 def test_seed_repo_sh_exists():

--- a/tests/test_tmp_cache_writable.py
+++ b/tests/test_tmp_cache_writable.py
@@ -24,6 +24,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from tests.stub_helpers import _entry_sh_rootful_block
+
 REPO_ROOT = Path(__file__).resolve().parent.parent
 DOCKERFILE = REPO_ROOT / "Dockerfile"
 ENTRY_SH = REPO_ROOT / "scripts" / "container-entry.sh"
@@ -34,14 +36,6 @@ def _dockerfile_tmp_cache_block() -> str:
     marker = "RUN chown -R leerie: /tmp/.cache"
     start = text.index(marker)
     end = text.index("\n\n", start)
-    return text[start:end]
-
-
-def _entry_sh_rootful_block() -> str:
-    text = ENTRY_SH.read_text()
-    marker = 'if [ "$ROOTLESS" != "true" ] && getent passwd leerie'
-    start = text.index(marker)
-    end = text.index("\nfi", start)
     return text[start:end]
 
 


### PR DESCRIPTION
## Summary

Consolidates four families of byte-identical (or near-identical) helper functions that had been copy-pasted across the test suite into single owners, matching the repo's existing single-owner discipline (`tests/ec2_stub.py`, `tests/launcher_blocks.py`).

## Which layer(s) does this PR touch?

(See [`CLAUDE.md`](../CLAUDE.md) for the three-layer rule.)

- [ ] `docs/DESIGN.md` (architecture)
- [ ] `docs/IMPLEMENTATION.md` (code surface)
- [ ] `orchestrator/leerie.py` (code)
- [ ] docs (`README.md`, `docs/USAGE.md`, `CONTRIBUTING.md`, etc.)
- [x] tests (`tests/`)
- [ ] CI / repo meta (`.github/`)

If multiple, has the change propagated **top-down** per the three-layer rule
(DESIGN → IMPLEMENTATION → code)?

- [ ] yes
- [x] not applicable (single layer)

## Task-completion checklist

(Mirrors `CLAUDE.md` and `CONTRIBUTING.md`.)

- [ ] `docs/IMPLEMENTATION.md` updated if code surface changed
- [ ] `docs/DESIGN.md` updated if architecture changed
- [ ] `pytest tests/` passes
- [x] `python3 -c "import ast; ast.parse(open('orchestrator/leerie.py').read())"` passes
- [x] `git diff --stat` reviewed for scope (no collateral edits)

## Testing notes

New shared module `tests/stub_helpers.py` holds `_entry_sh_rootful_block`, `_make_stub_timeout`, and `_stub_self_cmd`; `tests/ec2_stub.py` gained `seed_running_instance`. Each is now imported by its former duplicate-definition sites (`test_claude_json_dir_mount.py`, `test_claude_json_mount.py`, `test_home_leerie_ownership.py`, `test_tmp_cache_writable.py` for the rootful block; six files for the timeout stub; three chain/group launcher test files for the self-cmd stub; five EC2 test files for the instance seeder). New regression guards (`tests/test_no_duplicate_stub_timeout.py` and a companion single-owner guard for `_entry_sh_rootful_block`) assert a future edit reintroducing a duplicate in a consumer file fails loudly rather than silently desyncing.

### Conformance notes

- **tests (failed axis):** `pytest` — `5 failed, 8238 passed, 115 skipped` in `tests/test_signal_cleanup.py` (`test_terminate_proc_tree_reaps_grandchildren`, `test_terminate_proc_tree_reaps_detached_session_grandchildren`, `test_descendant_tracker_reaps_orphaned_backgrounded_subprocess`, plus 2 others).
- **Residual:** "build/lint/tests must pass" not fixed — "Pre-existing on base tree per BASELINE block; the diff makes zero changes to test_signal_cleanup.py, so this run did not introduce the failures."

## Related issue

<!-- Closes #N -->
