### PR TITLE
leerie: Confine judgment workers to a disposable worktree and verify the checkout

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -38,6 +38,7 @@
 !scripts/
 !scripts/container-entry.sh
 !scripts/new-worktree.sh
+!scripts/planning-worktree.sh
 !scripts/setup-run.sh
 !scripts/integrate.sh
 !scripts/finalize.sh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -610,10 +610,20 @@ export LEERIE_CAPTURE_DEPS=0
 export LEERIE_BAKE_LANGUAGE_DEPS=0
 ./leerie "task"
 
-# Waive §12 mechanical read-only enforcement on judgment workers
-# (use on repos where the planner needs pnpm/tsc/vitest visibility —
-# also LEERIE_DANGEROUSLY_SKIP_PERMISSIONS=1 or
-# `dangerously_skip_permissions = true` in leerie.toml):
+# Give judgment workers the repo's build/lint/test verbs (use on repos where
+# the planner needs pnpm/tsc/vitest visibility — also
+# LEERIE_DANGEROUSLY_SKIP_PERMISSIONS=1 or
+# `dangerously_skip_permissions = true` in leerie.toml).
+# It does NOT hand them the CLI flag of the same name: that is unreachable for
+# judgment workers, because it removes the CLI's working-directory boundary
+# along with the prompts. Measured (claude 2.1.237, filesystem-verified): a
+# worker holding only INSPECT_TOOLS and carrying the flag used Write — absent
+# from that allowlist — to overwrite a tracked file outside its cwd and commit
+# on the user's branch, and did so even from a detached worktree. The flag now
+# WIDENS the allowlist instead (`_widen_inspect_tools`). Still a real trust
+# decision: a build verb runs arbitrary code and can write outside the
+# worktree, which is what `_assert_repo_unchanged` catches. DESIGN §12
+# *Judgment-worker isolation*:
 ./leerie "task" --dangerously-skip-permissions
 
 # Run workers WITHOUT cgroup containment when the host can't enforce it
@@ -3441,6 +3451,71 @@ call sites at all (a scan that finds nothing passes every assertion), and the
 behavioral file pins that narrowing the `except` did not make an advisory
 gate fatal. All were falsified live against each defect reintroduced
 individually.
+
+**Judgment-worker isolation** (DESIGN §12) is covered by four files, and the
+thing worth remembering is that the design was settled by *experiment*, not by
+reading the CLI's docs. `tests/test_judgment_worker_isolation.py` pins the
+four layers: judgment workers never receive `--dangerously-skip-permissions`
+(the load-bearing one), `claude_p` refuses any of them whose cwd resolves to
+`st.repo_root`, and the flag instead widens their allowlist with the repo's
+build verbs. Probed live against claude 2.1.237, filesystem-verified — with
+the flag set, a worker holding only `INSPECT_TOOLS` used `Write` (absent from
+that allowlist) to create a file outside its cwd, and in the exact shape this
+feature ships (cwd = a detached worktree, flag still on) overwrote the real
+checkout and committed on its branch. **A worktree is not a boundary while
+that flag is set**, which is why the isolation tests pin the flag and the cwd
+together rather than either alone. Two traps: the widening is scoped to
+`INSPECT_TOOLS` because `SATISFIED_PROBE_TOOLS` is deliberately narrower and
+*calibrated* (12/12 false positives with full latitude, 0 when scoped), and an
+earlier revision handed that probe `Bash(pytest:*)`; and `_blt_verbs`
+memoizes, because `resolve_blt` logs, so an unmemoized call per judgment
+worker is dozens of identical lines — its `_BLT_VERBS_CACHE` is module-level
+against a session-scoped `leerie` fixture, so the file clears it in an autouse
+fixture for the reason `_active_admissions` does.
+`tests/test_work_sentinel.py` covers the mechanical half — snapshot the real
+checkout's HEAD/porcelain/refs before phase 1, re-check after every planning
+phase — including the trap that a *failed* after-snapshot returns empty
+strings that a naive diff reads as "HEAD moved" plus "every branch deleted",
+fabricating tampering on a healthy run; hence the `ok` field, and an
+anti-vacuity partner proving the underlying diff really would have fired.
+`tests/test_planning_worktree_script.py` drives the real script against real
+repos: detached, no branch created (the reapers know only `leerie/runs/*` and
+`leerie/subtasks/*`, so a fourth namespace would leak forever), reset on
+re-entry, and `clean -fd` **not** `-fdx` so `node_modules` survives.
+`tests/test_ensure_planning_worktree.py` covers the Python wrapper — path
+parsing, fail-closed on a script error, and the staging of what
+`git worktree add` cannot carry (untracked task-reference files, an untracked
+`.claude/`). It is the ONLY file that opts out of the conftest stub via
+`@pytest.mark.real_planning_worktree`, so every test in it `chdir`s into a
+throwaway repo AND sets `LEERIE_STATE_DIR`; both halves are load-bearing, and
+`test_no_worktree_leaks_into_this_repo` is the standing proof. Its subtlest
+pin is `test_staging_runs_after_the_reset` — staging before the script means
+`git clean -fd` deletes it, which presence-only assertions cannot see.
+All three guards were falsified live — restoring the `autonomous or …` OR
+fails 2 tests, neutering `_diff_repo_state` fails exactly the 4 detection
+tests, and moving the staging call above the script fails 3.
+A related discipline note: `_judgment_cwd` falls back to the conventional
+run-dir path rather than raising when `planning_worktree` is absent. That is
+deliberate and costs nothing — the fallback is derived from `run_dir`, so it
+can never *be* the checkout, and `claude_p`'s guard is the actual enforcement.
+Raising bought diagnostics only, at the price of a precondition every
+hand-built `State` must know about: measured, **141 tests red**, and 8 test
+files still needed a fixture seed after the fallback landed.
+**A conftest autouse fixture (`_no_real_planning_worktree`) stubs
+`_ensure_planning_worktree` for every test**, opt-out via
+`@pytest.mark.real_planning_worktree`. It shells out to a real
+`git worktree add` rooted at `resolve_leerie_root()`, which with
+`LEERIE_STATE_DIR` unset is `<repo>/.leerie` — so every test driving the real
+`_run_phases` created a full checkout of this repo inside this repo. Silent
+three ways over: `.leerie/*` is gitignored so `git status` stayed clean, the
+directories outlived the session, and the damage surfaced in
+`tests/test_helper_naming_convention.py`, whose `tests/` exclusion is a
+relative-path prefix that a nested
+`.leerie/…/worktrees/planning/tests/…` copy does not match. Measured before
+the guard: 2 worktrees, 25 MB, and one red test on CI with no visible link to
+the change that caused it — local runs were green because the pollution only
+bites a later scanner. When adding a fixture that shells out to git, assume
+the state root is inside the repo unless the test pins it elsewhere.
 
 `leerie resume <run-id>` — the documented positional form — is pinned by
 `tests/test_resume_positional_run_id.py`. It silently ignored the run-id on

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -7398,22 +7398,80 @@ strengths, and the design depends on keeping them clearly separated. The
 concrete enforcement points — which function checks what, at which phase — are
 catalogued in `IMPLEMENTATION.md`.
 
-One enforcement point — the mechanical "judgment workers (classifier, planner,
-reconciler, plan_overlap_judge, provision) cannot mutate state because they run in the real repo
-cwd without `--dangerously-skip-permissions`" guarantee — has an explicit
-opt-out: `leerie --dangerously-skip-permissions`. The flag is named identically
-to the underlying Claude Code CLI flag, on purpose: choosing it means the user
-understands they are removing a guardrail, not merely changing a setting. When
-set, every worker is invoked with `--dangerously-skip-permissions`, including
-the judgment workers; the §12 mechanical enforcement that they stay read-only
-is waived, and trust shifts onto the prompts. The default is off, the safe
-invariant is preserved for everyone who does not pass it, and the opt-out is
-intended for repositories where the planner needs visibility into build/test
-tooling that the narrow inspect allowlist excludes (`pnpm`/`tsc`/`vitest` and
-friends). This is a documented breach of the §12 contract for that single
-invocation, not a softening of the contract.
+### Judgment-worker isolation
 
-A second enforcement layer compensates for the permission bypass:
+Judgment workers (`PLANNING_WORKER_TYPES`: classifier, planner, reconciler,
+the judges, provision, the satisfied-probe) are kept away from the user's
+checkout by **four layers**, in order of how much each actually buys.
+
+This used to be one layer, and it failed. The old guarantee read "judgment
+workers cannot mutate state because they run in the real repo cwd *without*
+`--dangerously-skip-permissions`", with that flag as a documented opt-out that
+"shifts trust onto the prompts". Measured outcome: a classifier on a run with
+the flag set implemented an entire task in the operator's checkout on `main` —
+`Edit` calls to three files, a repo-wide `lint:fix`, and a `git stash`/`pop`
+pair — and then died at its turn cap. The prompt said "you run read-only". It
+was the only thing that said so.
+
+**L1 — the flag never reaches a judgment worker.** `claude_p` appends
+`--dangerously-skip-permissions` on `autonomous` alone. This is the layer that
+does the work, and it is worth stating why rather than asserting it. Probed
+live (claude 2.1.237, four runs, ground truth taken from the filesystem):
+
+| configuration | Write in cwd | Write *outside* cwd | Bash write outside cwd |
+|---|---|---|---|
+| `INSPECT_TOOLS`, flag on | succeeded | succeeded | succeeded |
+| `INSPECT_TOOLS`, flag off | rejected | rejected | rejected |
+
+With the flag set, a worker holding only `INSPECT_TOOLS` used `Write` — a tool
+absent from that allowlist — to create a file outside its cwd. With the flag
+absent, the CLI rejected every one of those attempts, naming the allowed
+working directory. **The working-directory boundary is real; the flag is what
+erases it.**
+
+A separate probe put the two together in the exact shape this feature ships —
+cwd set to a detached worktree, flag still on — and the worker overwrote a
+tracked file in the real checkout *and* committed on its branch. That is the
+result behind L2's caveat below.
+
+**L2 — they run in a disposable worktree.** A detached worktree per run, reset
+to the checkout's HEAD on entry (`scripts/planning-worktree.sh`). Note the
+ordering dependency: probed in the *exact* configuration of cwd = detached
+worktree with the flag still set, the worker overwrote the real checkout and
+committed on the branch anyway. **L2 is worth nothing without L1** — a
+worktree is not a boundary, it is where the boundary lands once L1 restores
+one.
+
+**L3 — the operator's escape hatch, re-expressed.** The flag's documented
+purpose was always tooling visibility, "repositories where the planner needs
+`pnpm`/`tsc`/`vitest`" — never write access; write access was collateral, and
+the collateral is what rewrote a branch. `--dangerously-skip-permissions` now
+*widens the allowlist* with the repo's own declared build/lint/test verbs
+(`_widen_inspect_tools`) instead of bypassing permissions. The planner gets its
+tooling; the boundary stays.
+
+The residual is real and is not hidden: a build verb runs arbitrary code, so an
+allowlisted `pnpm`/`node`/`python3` can write outside the cwd. Measured — with
+permissions on and `python3` allowlisted, `python3 -c "open('<outside>','w')"`
+succeeded while the `Write` tool aimed at the same path was rejected. This is a
+strictly narrower hole than the flag it replaces, and L4 covers it.
+
+**L4 — the sentinel, which is the actual guarantee.** `_snapshot_repo_state`
+records the real checkout's HEAD, porcelain status and refs before phase 1;
+`_assert_repo_unchanged` re-checks after every planning phase and `die()`s on
+any delta. Same discipline as `check_rebaser_worktree_state` — trust the
+worker, then mechanically re-check the claim — and run per-phase rather than
+once at the end so it fires within one worker of the damage. Untracked files
+are compared deliberately: `_preflight_repo`'s clean-tree gate filters `??`
+lines, so a worker *creating* files is precisely what it cannot see.
+
+What this does **not** achieve, stated plainly: kernel-level confinement.
+`/work` is a read-write bind mount in the same container for the whole run, and
+nothing short of a read-only mount or a separate uid would make a determined
+worker unable to reach it. L1–L3 make the escape unlikely; L4 makes it loud.
+
+A further enforcement layer sits underneath all four, and is the one that holds
+even for `autonomous` workers, which *do* still carry the permission bypass:
 `DISALLOWED_TOOLS` is passed via `--disallowedTools` on every `claude -p`
 invocation that starts a session. (The sole exemption is
 `_append_system_prompt_file_supported`'s capability probe, which passes empty
@@ -7442,9 +7500,13 @@ it, which makes the entry defense-in-depth rather than a fix for an observed lea
 **A plain file writer does not belong on this list**, which is why `NotebookEdit` is
 classified into `ACT_TOOLS` rather than denied. The tempting argument for denying it —
 that `--allowedTools` is only a permission tier, so a judgment worker can reach a writer
-anyway — holds only under the opt-out described above; by default judgment
-workers are not autonomous and do not carry `--dangerously-skip-permissions`,
-so the allowlist does hold. Meanwhile the deny list is
+anyway — was true while the escape hatch handed those workers the flag, and that
+is precisely the hole L1 closes: judgment workers are never `autonomous` and can
+no longer receive `--dangerously-skip-permissions` at any setting, so the
+allowlist holds for them unconditionally rather than only by default. Note the
+conclusion here was right for the wrong reason and survives the correction
+intact — denying a writer would not have helped either, because the escape was
+`Bash`, not `NotebookEdit`. Meanwhile the deny list is
 a single global constant, so denying a writer removes it from every acting worker in
 every repository leerie is pointed at, and `Bash`/`Write`/`Edit` — the same class — stay
 allowed regardless, so the deny never produced the read-only property it was justified

--- a/docs/IMPLEMENTATION.md
+++ b/docs/IMPLEMENTATION.md
@@ -1624,29 +1624,34 @@ same shape as `--source-of-truth` resolution.
 
 ### Permission override (dangerous)
 
-By default, judgment workers (classifier, planner, reconciler,
-plan_overlap_judge, provision) run in the real repo cwd with a narrow
-Bash allowlist (`INSPECT_TOOLS`) and **without**
-`--dangerously-skip-permissions`.
-This mechanically prevents them from mutating state — the §12
-enforcement that a planner cannot run `pnpm run typecheck`,
-`tsc --noEmit`, or any other side-effecting subprocess. Acting workers
-(implementer, conformer, integrator) run in isolated worktrees with
-the broader `ACT_TOOLS` allowlist and the skip-permissions flag —
-their blast radius is bounded by the worktree.
+Judgment workers (`PLANNING_WORKER_TYPES`) run in a **disposable detached
+worktree** (`_judgment_cwd()`, created by `scripts/planning-worktree.sh`) with
+a narrow Bash allowlist (`INSPECT_TOOLS`) and **never**
+`--dangerously-skip-permissions` — not by default, but at any setting.
+`claude_p` raises if such a worker is handed the real checkout as its `cwd`.
+Acting workers (implementer, conformer, integrator, rebaser) run in isolated
+worktrees with the broader `ACT_TOOLS` allowlist and the skip-permissions flag;
+their blast radius is the worktree they own.
 
-`--dangerously-skip-permissions` is the escape hatch. When set, every
-`claude -p` invocation — including judgment workers in the real repo
-cwd — is invoked with `--dangerously-skip-permissions`. This waives
-the §12 mechanical read-only enforcement on judgment workers and
-shifts trust onto their prompts. Use it on repositories where the
-planner needs to observe build/test tooling that the narrow inspect
-allowlist excludes — Node/TS repos where the planner reflexively
-reaches for `pnpm`/`tsc`/`biome`/`vitest`/`npx` and currently
-~18-19% of its Bash calls fail with "requires approval" in headless
-mode. See DESIGN §12 and §15 *Known limitations* (the "unattended
-execution requires broad write permission" paragraph) for the
-guarantee being waived.
+The reason the flag is unreachable for judgment workers is measured, not
+stylistic: it removes the CLI's working-directory boundary as well as the
+prompts. Probed live (claude 2.1.237, filesystem-verified), a worker holding
+only `INSPECT_TOOLS` and carrying the flag used `Write` — absent from that
+allowlist — to overwrite a tracked file outside its cwd and `git commit` on the
+user's branch, and did so *even with its cwd already set to a detached
+worktree*. With the flag absent, every one of those attempts was rejected.
+
+`--dangerously-skip-permissions` therefore no longer bypasses permissions for
+these workers; it **widens their allowlist** (`_widen_inspect_tools`) with the
+leading verbs of the repo's own declared build/lint/test commands, as
+`Bash(<verb>:*)` patterns. That is the visibility the flag was always
+documented to buy — Node/TS repos where the planner reaches for
+`pnpm`/`tsc`/`biome`/`vitest`/`npx`, ~18-19% of whose Bash calls otherwise fail
+with "requires approval" in headless mode — without the write access that was
+never the point. Residual, stated rather than hidden: a build verb executes
+arbitrary code, so an allowlisted `pnpm`/`node`/`python3` *can* still write
+outside the cwd; `_assert_repo_unchanged()` is what catches that. See DESIGN
+§12 *Judgment-worker isolation* for the full four-layer argument.
 
 Resolution order (highest priority first):
 
@@ -3627,7 +3632,7 @@ Each worker is one `claude -p` headless process. Flags used:
 | `--max-turns` | per-worker turn cap (values in §6) |
 | `--model` | model alias for this worker — `sonnet` / `opus` / `haiku`. Value comes from per-worker resolution (see §2 *Model selection*) |
 | `--add-dir` | repeated per entry in `state.json["inspect_dirs"]` (forwarded by `claude_p`'s `add_dirs` param). Used only by inspect-bucket workers (classifier, planner, reconciler, plan_overlap_judge, provision) so their sandboxed Read/Grep/Glob and allowlisted Bash verbs can reach sibling repos referenced in the task. See §2 *Inspect directories* |
-| `--dangerously-skip-permissions` | acting workers (implementer, integrator, conformer) — suppresses all permission prompts for unattended Bash and file writes. **Not** applied to inspect workers — they run in the real repo cwd (no worktree isolation), so the blast-radius assumption that justifies skip-permissions doesn't hold. The `Bash(<verb>:*)` patterns in `INSPECT_TOOLS` pre-approve listed verbs at the CLI level; anything else (e.g. `rm`, redirect-to-file) falls through and is rejected in non-interactive mode |
+| `--dangerously-skip-permissions` | acting workers only (implementer, integrator, conformer, rebaser) — suppresses all permission prompts for unattended Bash and file writes; their blast radius is the worktree they own. **Never** applied to judgment workers (`PLANNING_WORKER_TYPES`) at any setting: the flag removes the CLI's working-directory boundary as well as the prompts, and that boundary is the only thing confining a worker that runs against a tree it does not own — measured, a worker carrying the flag wrote outside its cwd and committed on the user's branch even from a detached worktree. The `Bash(<verb>:*)` patterns in `INSPECT_TOOLS` pre-approve listed verbs at the CLI level; anything else (e.g. `rm`, redirect-to-file) falls through and is rejected in non-interactive mode |
 | `--strict-mcp-config` | unconditional for every `claude -p` argv leerie builds — every worker, **and** `preflight`'s smoke test, and the remote integrator in `collect-subtrees.sh` — independent of and prior to any `mcp__*` denylist enumeration. Cuts MCP tool exposure off at the source regardless of what `.claude.json` seeding copies into the container. Measured single-variable on CLI 2.1.234 (identical argv otherwise, fresh empty cwd): **27 MCP tools / 4 `mcp_servers` -> 0 / 0**, rc 0, at a cost of ~880 prompt tokens — this is a containment fix, not a prompt-size one. No `--mcp-config` is ever passed, so it can't strand a caller with zero server config but a nonzero tool surface |
 
 `claude_p()` is `async`; every caller awaits it. Internally it awaits
@@ -8991,6 +8996,8 @@ written somewhere in `orchestrator/leerie.py`. The coupling test in
 | `plans_after_coverage_gate` | list[dict] | the per-phase planning checkpoint for `phase_planning_coverage_gate` (post-task-coverage-gate `plans`, DESIGN §8 *Independent adversarial verification*). Same absence/presence and resume-cursor semantics as `plans_after_classify`. |
 | `plans_after_filters` | list[dict] | the per-phase planning checkpoint written after the off-tree (`_filter_offtree_subtasks`) and already-satisfied (`_filter_satisfied_subtasks`) phase-3 filters both complete — the filtered `plans` immediately before `_schedule()`. Same absence/presence and resume-cursor semantics as `plans_after_classify`; this is the last `plans_after_*` checkpoint before `plan_snapshot`/`waves` take over as the resume cursor. |
 | `satisfied_probe_cache` | dict[str, dict] | per-subtask `satisfied_probe` verdicts (DESIGN §6 "The satisfied-probe sweep needs finer-than-phase granularity"; §8 *Already-satisfied subtask elimination*), keyed by subtask id. Each value is `{satisfied: bool, evidence: str, checked: [str], base_sha: str}` — `base_sha` is the base commit sha (`git rev-parse HEAD`) recorded at probe time. Written by `probe_one` as soon as its own verdict returns, for both `satisfied` and not-satisfied outcomes — not only in aggregate after the whole sweep's `gather` completes, so a pause mid-sweep does not lose already-decided subtasks. **Correctness-critical:** on `resume`, a cached entry whose `base_sha` no longer matches the current `HEAD` is treated as absent and that subtask is re-probed — the base tree can move between a pause and a resume (e.g. a sibling run merging its own PR into the same base branch), and a stale hit could wrongly keep a subtask that is no longer satisfied or drop one that now is. A probe that crashes (`WorkerError`) is deliberately never cached — no verdict was actually reached, and caching "kept" for a crash would wrongly skip re-probing a subtask that was never really judged. |
+| `planning_worktree` | str | absolute path to this run's disposable judgment-worker worktree (DESIGN §12 *Judgment-worker isolation*), created and reset by `scripts/planning-worktree.sh` via `_ensure_planning_worktree()`. Every worker in `PLANNING_WORKER_TYPES` runs with this as its `cwd`; `_judgment_cwd()` is the single accessor and raises rather than falling back to the real checkout. Written before `phase_classify` and again immediately before the satisfied-probe sweep (the probe judges whatever tree its cwd points at, so a tree an earlier judgment worker dirtied would produce false `satisfied=true` drops). Deliberately **not** used as a resume skip check — the worktree is a filesystem fact, so it is re-established unconditionally on every entry; the field exists for attribution (which tree a worker's Bash calls landed in), the same argument `leerie_commit` carries. |
+| `repo_state_before_planning` | dict | `{head: str, porcelain: [str], refs: [str]}` for the USER'S REAL CHECKOUT, captured once before `phase_classify` and re-checked after every planning phase by `_assert_repo_unchanged()`. This is the mechanical half of the §12 judgment-worker guarantee: the worktree makes an escape unlikely, this makes it loud, and it `die()`s naming the changed paths/refs and the phase window. Includes untracked files on purpose — `_preflight_repo`'s clean-tree gate filters `??` lines, so a worker *creating* files is exactly what that gate cannot see. Paths under `.leerie/` and refs under `refs/heads/leerie/` are exempt (leerie's own bookkeeping). Persisted so a resume compares against the ORIGINAL baseline rather than a tree an earlier planning pass may already have moved. |
 | `active_oauth_token` | str \| None | the raw `CLAUDE_CODE_OAUTH_TOKEN` value currently selected for this run's `claude -p` spawns (DESIGN §6 *Multi-token rotation*; IMPLEMENTATION.md §3 *Multi-token rotation*). Set by `_select_active_oauth_token` (the start-of-run probe/ranking sweep, run only when `CLAUDE_CODE_OAUTH_TOKENS` is present) and mutated by `claude_p`'s mid-run failover on a rate-limited active token. Absent/`None` when only the singular `CLAUDE_CODE_OAUTH_TOKEN` is in play — no rotation, and `_invoke`'s `active_token` param stays `None` (behavior byte-identical to before this feature). **The one sanctioned exception to this feature's secrets-hygiene rule**: the raw token is never written to `calls.ndjson`, `run.json`, or any log line (only its fingerprint is), but `state.json` is local-orchestrator-owned and already carries other operational data, so this field is the one place the raw active token persists at rest. |
 | `waves` | list[list[str]] | scheduled subtask ids per wave (from `_schedule`) |
 | `completed_waves` | int | index of the next wave to run (resume cursor) |
@@ -9013,7 +9020,7 @@ written somewhere in `orchestrator/leerie.py`. The coupling test in
 | `needs_source_of_truth` | bool | whether classifier asked for source-of-truth disambiguation. **Recorded only, with no readers** — nothing in `orchestrator/`, `chain/`, `scripts/` or `prompts/` consumes it; it survives as an audit record of the classifier's judgement and does not gate delivery of the value. `gather_answers` writes `answers["source_of_truth"]` on every run regardless (DESIGN §11: the question is skipped, never the setting) |
 | `source_of_truth_pref` | str | resolved preference (`codebase` / `research` / `both`) |
 | `clarify` | bool | whether asking the user is allowed for this run (resolved from `--clarify` / `LEERIE_CLARIFY` / `leerie.toml` / default `False`) |
-| `dangerously_skip_permissions` | bool | whether every `claude -p` worker — including the judgment workers running in the real repo cwd — is invoked with `--dangerously-skip-permissions`. Resolved from `--dangerously-skip-permissions` / `LEERIE_DANGEROUSLY_SKIP_PERMISSIONS` / `leerie.toml` / default `False`. When `True`, waives the DESIGN §12 mechanical read-only enforcement on the classifier / planner / reconciler / plan_overlap_judge / provision workers; trust shifts onto their prompts. Re-resolved fresh on every run, including `resume`, so the user can flip it without editing state |
+| `dangerously_skip_permissions` | bool | the operator's tooling escape hatch. Resolved from `--dangerously-skip-permissions` / `LEERIE_DANGEROUSLY_SKIP_PERMISSIONS` / `leerie.toml` / default `False`. It no longer grants judgment workers the CLI flag of the same name — that is unreachable for them (DESIGN §12 *Judgment-worker isolation*, L1). When `True` it instead WIDENS their allowlist via `_widen_inspect_tools()` with the leading verbs of the repo's declared build/lint/test commands, so a planner can run `pnpm`/`tsc`/`vitest` without gaining write access. Acting workers carry the CLI flag regardless, from `autonomous=True`. Re-resolved fresh on every run, including `resume`, so the user can flip it without editing state |
 | `dangerously_force_strict_output` | bool | whether this run forced constrained decoding via the per-run loopback proxy (`--dangerously-force-strict-output` / `LEERIE_DANGEROUSLY_FORCE_STRICT_OUTPUT` / `dangerously_force_strict_output` in leerie.toml). Mirrored from `caps["force_strict_output"]`. Recorded because the flag changes worker behaviour invisibly — it owns `ANTHROPIC_BASE_URL`, which makes the CLI treat the session as gateway-routed and apply a conservative client-side context ceiling instead of the model's native window (see `_model_arg`). Originally attribution-only ("without this field a run's failure cannot be attributed to the flag after the fact"); now also load-bearing — `run_rebaser` and `run_recapture_deps` read it back from `st.data` to decide whether to wire their own per-call proxy instance, since they run in a separate process the original CLI flag never reaches (§ *Forced constrained decoding*). |
 | `skip_overlap_judge` | bool | whether the phase 2¾ `plan_overlap_judge` worker is suppressed even on multi-planner runs (DESIGN §5 *Cross-domain surface overlap*). Resolved from `--skip-overlap-judge` / `LEERIE_SKIP_OVERLAP_JUDGE` / `leerie.toml` / default `False`. The cheap-skip on single-planner / <2-subtask runs is automatic and not gated by this field — this flag only affects runs where the worker would otherwise fire. Re-resolved fresh on every run, including `resume`, so the user can flip it without editing state |
 | `skip_adherence_check` | bool | whether the instruction-adherence gate (the deterministic prescribed-command-coverage floor + the `adherence_judge` worker in the planner check loop) is suppressed. Resolved from `--skip-adherence-check` / `LEERIE_SKIP_ADHERENCE_CHECK` / `skip_adherence_check` in `leerie.toml` / default `False`. When True, a plan that diverges from an explicitly prescribed procedure is not caught before `phase_execute` spends. Re-resolved fresh on every run, including `resume`, so the user can flip it without editing state |

--- a/orchestrator/leerie.py
+++ b/orchestrator/leerie.py
@@ -645,6 +645,23 @@ STATE_FIELDS = (
     # sibling run merging its own PR). A probe that crashes (`WorkerError`)
     # is deliberately never cached — no verdict was actually reached.
     "satisfied_probe_cache",
+    # planning_worktree: absolute path to this run's disposable judgment-worker
+    # worktree (DESIGN §12 *Judgment-worker isolation*), created by
+    # `scripts/planning-worktree.sh` before phase_classify and reset again
+    # before the satisfied-probe sweep. Recorded rather than re-derived so a
+    # post-mortem can tell which tree a judgment worker's Bash calls landed in
+    # — the same attributability argument `leerie_commit` carries. Never used
+    # as a skip check: the worktree is a filesystem fact, so it is
+    # re-established unconditionally on every entry.
+    "planning_worktree",
+    # repo_state_before_planning: HEAD + porcelain + refs of the USER'S REAL
+    # CHECKOUT, captured before phase_classify and re-checked after each
+    # planning phase (`_assert_repo_unchanged`). This is the mechanical half
+    # of the §12 judgment-worker guarantee: the worktree makes an escape
+    # unlikely, this makes it loud. Persisted so a resume compares against the
+    # ORIGINAL baseline rather than a tree an earlier planning pass may
+    # already have moved.
+    "repo_state_before_planning",
     # active_oauth_token: the raw CLAUDE_CODE_OAUTH_TOKEN value currently
     # selected for this run's `claude -p` spawns (DESIGN §6 *Multi-token
     # rotation*). Set by the start-of-run probe/ranking sweep when
@@ -708,29 +725,33 @@ def _is_protected_path(path: str) -> bool:
     return False
 
 _READ_BASE = "Read,Grep,Glob,WebSearch,WebFetch"
-# INSPECT_TOOLS is the read-only-with-shell bucket for classifier, planner,
-# and reconciler. These workers run in the real repo cwd (not a worktree),
-# so the default is that they cannot use --dangerously-skip-permissions.
+# INSPECT_TOOLS is the read-only-with-shell bucket for every judgment worker
+# (PLANNING_WORKER_TYPES). Those workers run in a disposable detached worktree
+# (`_judgment_cwd`), never the user's checkout, and never carry
+# --dangerously-skip-permissions — see DESIGN §12 *Judgment-worker isolation*.
 # Without pre-approval, Bash calls in -p mode are gated by the permission
 # system, return is_error=true, and surface as "tool-fail" — even for
 # benign commands like `ls foo 2>&1` whose redirection trips the
 # multiple-operations splitter. The Bash(<verb>:*) prefix patterns
 # pre-approve specific read-only verbs (verified against claude 2.1.150:
 # the pattern matcher handles trailing redirection like `2>&1`).
-# Write/Edit are deliberately omitted: by default, the §12 "read-only
-# worker" contract stays mechanically enforced — anything outside this
-# allowlist falls through and is rejected in non-interactive mode. The
-# top-level `leerie --dangerously-skip-permissions` flag (DESIGN §12 last
-# paragraph) is the documented escape hatch: when set, claude_p passes
-# --dangerously-skip-permissions to every worker, including the inspect
-# bucket; the allowlist still names what the worker can call without
-# prompting, but the gate that rejects everything else is lifted.
+#
+# Write/Edit are deliberately omitted, and that omission is now load-bearing
+# rather than advisory. It previously was not: the top-level
+# `--dangerously-skip-permissions` flag used to reach these workers and lift
+# the gate, and a classifier then used Write — absent from this list — to
+# rewrite the operator's branch. The flag now widens this allowlist with the
+# repo's build/lint/test verbs (`_widen_inspect_tools`) instead of bypassing
+# the gate, so what is not named here genuinely cannot be called.
 #
 # Tool restriction is two-layered:
-#   --allowedTools  (soft) — pre-approves tools for auto-execution;
-#       bypassed entirely by --dangerously-skip-permissions.
+#   --allowedTools  (soft) — pre-approves tools for auto-execution, and
+#       carries the CLI's working-directory boundary with it; bypassed
+#       entirely by --dangerously-skip-permissions, which is exactly why
+#       judgment workers no longer receive that flag.
 #   --disallowedTools (hard, DISALLOWED_TOOLS) — removes tools from the
-#       model's context; survives --dangerously-skip-permissions.
+#       model's context; survives --dangerously-skip-permissions, so it is
+#       the layer that still holds for `autonomous` acting workers.
 INSPECT_TOOLS = (
     f"{_READ_BASE},"
     "Bash(ls:*),Bash(find:*),Bash(cat:*),Bash(head:*),Bash(tail:*),"
@@ -872,6 +893,95 @@ KNOWN_TOOLS: frozenset[str] = frozenset(
     | _bare_tool_names(DISALLOWED_TOOLS)
     | {"StructuredOutput"}
 )
+
+
+# Memoized per repo: `resolve_blt` reads config, runs inference AND logs a
+# "BLT: config axes=..." line. Called per judgment worker (there are dozens)
+# that would be dozens of identical lines and dozens of redundant file reads.
+_BLT_VERBS_CACHE: dict[str, list[str]] = {}
+
+
+def _blt_verbs(repo_root: Path) -> list[str]:
+    """The distinct executables this repo's declared/inferred build, lint and
+    test commands invoke — `pnpm` from `pnpm run build`, `npx` from
+    `npx tsc --noEmit`, `python3` from `python3 -m pytest`.
+
+    One verb per SHELL SEGMENT, not per axis: `pnpm build && vitest run`
+    genuinely invokes two executables, and granting only the first leaves the
+    planner unable to run half of what it was just given.
+
+    Deliberately the first token of each segment, no finer. A tighter-looking
+    pattern (`Bash(pnpm run:*)`) is not tighter in practice: the CLI matches
+    `Bash(<prefix>:*)` on the command prefix, so `pnpm run` would reject the
+    equally-legitimate `pnpm test` / `pnpm -s exec tsc` a planner reaches for,
+    and every rejection surfaces as a tool-fail the model then reasons around.
+    The verb is the honest granularity — see `_widen_inspect_tools` for why
+    widening at all is a bounded concession rather than a safe operation.
+
+    Memoized per repo: `resolve_blt` reads config, runs inference AND logs, so
+    an uncached call per judgment worker would be dozens of identical lines."""
+    key = str(repo_root)
+    if key in _BLT_VERBS_CACHE:
+        return list(_BLT_VERBS_CACHE[key])
+    out: list[str] = []
+    try:
+        blt = resolve_blt(repo_root)
+    except Exception:
+        _BLT_VERBS_CACHE[key] = out
+        return out
+    for axis in ("build", "lint", "test"):
+        cmd = (blt.get(axis) or "").strip()
+        if not cmd:
+            continue
+        # Reuse the pair of rules this module already owns rather than a
+        # second copy of either — a duplicated rule drifts exactly the way a
+        # duplicated list does. They compose in this order: split on shell
+        # separators FIRST (`_BLT_SEG_RE`), then strip each segment's
+        # non-invoking lead (`_BLT_SEG_LEAD_RE`: `timeout 90 …`, `cd x …`,
+        # `NODE_ENV=test …`). Stripping before splitting leaves the separator
+        # itself as the first token, so `cd api && vitest run` yields `&&`.
+        #
+        # Every segment contributes: `pnpm build && vitest run` genuinely
+        # invokes two executables, and granting only the first leaves the
+        # planner unable to run half of what it was just given.
+        for seg in _BLT_SEG_RE.split(cmd):
+            seg = seg[_BLT_SEG_LEAD_RE.match(seg).end():].strip()
+            if not seg:
+                continue
+            try:
+                toks = shlex.split(seg)
+            except ValueError:
+                # Unbalanced quotes in a user-declared command. Skip the
+                # segment rather than guessing — a wrong verb widens the
+                # wrong thing.
+                continue
+            if toks and toks[0] not in out:
+                out.append(toks[0])
+    _BLT_VERBS_CACHE[key] = out
+    return list(out)
+
+
+def _widen_inspect_tools(base: str, repo_root: Path) -> str:
+    """Add `Bash(<verb>:*)` for this repo's build/lint/test executables.
+
+    This is what `--dangerously-skip-permissions` now buys a judgment worker,
+    and it is strictly less than what that flag used to buy. The flag's stated
+    purpose (DESIGN §12) was always tooling visibility — "repositories where
+    the planner needs `pnpm`/`tsc`/`vitest`" — never write access; write access
+    was collateral, and it is the collateral that let a classifier rewrite a
+    user's branch.
+
+    The concession is real and must not be undersold: a build verb runs
+    arbitrary code, so an allowlisted `pnpm`/`node`/`python3` CAN write outside
+    the worker's cwd. Measured directly — with permissions ON and `python3`
+    allowlisted, `python3 -c "open('<outside>','w')"` succeeded, while the Write
+    tool aimed at the same path was rejected. So this restores the planner's
+    tooling and leaves a narrower hole than the flag it replaces; the
+    `/work` sentinel (`_snapshot_repo_state`) is what covers the remainder."""
+    verbs = _blt_verbs(repo_root)
+    if not verbs:
+        return base
+    return base + "," + ",".join(f"Bash({v}:*)" for v in verbs)
 
 # --inspect-dir preference: extra directories to grant the inspect-bucket
 # workers (classifier, planner, reconciler, plan_overlap_judge, provision) read access to via the
@@ -1044,13 +1154,18 @@ NO_PUSH_FILE = SOURCE_OF_TRUTH_FILE
 CLARIFY_ENV = "LEERIE_CLARIFY"
 CLARIFY_FILE = SOURCE_OF_TRUTH_FILE
 
-# --dangerously-skip-permissions escape hatch (DESIGN §12). Forces
-# every claude -p worker — including the judgment workers that run in
-# the real repo cwd — to pass --dangerously-skip-permissions, waiving
-# the mechanical §12 read-only enforcement on classifier / planner /
-# reconciler / provision. Named identically to the underlying CLI flag
-# on purpose: choosing it means the user understands they are removing
-# a guardrail. Resolution order: --dangerously-skip-permissions CLI
+# The operator's tooling escape hatch (DESIGN §12 *Judgment-worker
+# isolation*, L3). It does NOT hand judgment workers the CLI flag of the
+# same name — that is unreachable for them, because the flag removes the
+# CLI's working-directory boundary along with the prompts and a worker
+# that escaped it rewrote an operator's branch. It instead WIDENS their
+# allowlist with the repo's build/lint/test verbs (`_widen_inspect_tools`),
+# which is the tooling visibility the flag was always documented to buy.
+# Acting workers carry the CLI flag regardless, from autonomous=True.
+# The name is kept deliberately: it still grants a judgment worker the
+# ability to run arbitrary build commands, which can write outside its
+# worktree, so it is still a trust decision — just a far smaller one.
+# Resolution order: --dangerously-skip-permissions CLI
 # flag → LEERIE_DANGEROUSLY_SKIP_PERMISSIONS env → leerie.toml → False.
 DANGEROUS_SKIP_PERMS_ENV = "LEERIE_DANGEROUSLY_SKIP_PERMISSIONS"
 DANGEROUS_SKIP_PERMS_FILE = SOURCE_OF_TRUTH_FILE
@@ -1446,6 +1561,37 @@ WORKER_TYPES = ("classifier", "planner", "reconciler", "plan_overlap_judge",
                 "classification_judge", "wiring_judge", "provision_judge",
                 "task_coverage_judge", "artifact_registry",
                 "integration_judge", "rebaser")
+
+# PLANNING_WORKER_TYPES — the judgment bucket, i.e. every worker that runs
+# with `autonomous=False` against a tree it does not own. The partition
+# matters because it is what `claude_p` keys the permission decision on:
+# these workers NEVER receive --dangerously-skip-permissions, no matter what
+# the operator passed.
+#
+# This is not a style preference, it is a measured containment boundary.
+# Live probe (claude 2.1.237, filesystem-verified, four runs):
+#   * with --dangerously-skip-permissions, a worker holding only
+#     INSPECT_TOOLS used the Write tool (absent from the allowlist) to
+#     overwrite a tracked file OUTSIDE its cwd, and `git commit`ed on the
+#     user's branch. cwd was a detached worktree at the time — so a worktree
+#     is NOT a boundary while the flag is set.
+#   * with the flag absent, the identical prompt had every one of those
+#     attempts rejected, the CLI naming the allowed working directory.
+# The cwd boundary is real; the flag is what erases it. Hence: judgment
+# workers get the boundary, and the operator's escape hatch is re-expressed
+# as an allowlist widening (see _widen_inspect_tools) rather than a
+# permission bypass.
+PLANNING_WORKER_TYPES = frozenset({
+    "classifier", "classification_judge", "provision", "provision_judge",
+    "artifact_registry", "planner", "fit_judge", "splitter", "reconciler",
+    "plan_overlap_judge", "adherence_judge", "task_coverage_judge",
+    "wiring_judge", "satisfied_probe", "integration_judge",
+})
+# The complement: workers that legitimately act on files, inside a worktree
+# they own. `rebaser` is here by the DESIGN §12 scoped exception.
+ACTING_WORKER_TYPES = frozenset({
+    "implementer", "integrator", "conformer", "rebaser",
+})
 # Post-run skill workers — not in WORKER_TYPES because they don't run inside
 # the main _orchestrate loop, but they do get dedicated model resolution via
 # --judge-model / --heal-model (and their env / TOML mirrors).
@@ -6184,13 +6330,15 @@ def resolve_dangerously_skip_permissions(
     LEERIE_DANGEROUSLY_SKIP_PERMISSIONS env var →
     dangerously_skip_permissions in leerie.toml → False.
 
-    When True, EVERY claude -p worker — including the judgment workers
-    (classifier, planner, reconciler, plan_overlap_judge, provision) that run
-    in the real repo cwd, not an isolated worktree — is invoked with
-    --dangerously-skip-permissions. This waives the DESIGN §12
-    mechanical enforcement that planners stay read-only; trust shifts
-    onto the prompts. Off by default; users opting in are making one
-    all-or-nothing trust decision. See DESIGN §12 (last paragraph) and
+    When True, judgment workers (PLANNING_WORKER_TYPES) get a WIDENED
+    allowlist — the leading verbs of the repo's declared build/lint/test
+    commands, added as Bash(<verb>:*) patterns by `_widen_inspect_tools` —
+    and NOT --dangerously-skip-permissions, which is unreachable for them
+    at any setting (DESIGN §12 *Judgment-worker isolation*). Acting workers
+    receive the CLI flag from autonomous=True regardless of this value.
+    Off by default. Still a trust decision: a build verb runs arbitrary
+    code and can write outside the worker's worktree, which is what
+    `_assert_repo_unchanged` exists to catch. See DESIGN §12 and
     IMPLEMENTATION.md §2 "Permission override (dangerous)"."""
     return _resolve_bool_pref(
         repo_root, cli_value,
@@ -6912,6 +7060,250 @@ async def _gather_or_cancel(*aws):
 async def _run_script(name: str, *args: str) -> subprocess.CompletedProcess:
     """Run one of the bundled git worktree scripts in the target repo."""
     return await run_proc(["bash", str(SCRIPTS / name), *args], cwd=os.getcwd())
+
+
+def _stage_worktree_extras(st: "State", worktree: str) -> None:
+    """Copy the things a judgment worker needs that `git worktree add` does
+    not carry, because git only checks out TRACKED content.
+
+    Two classes, both measured rather than imagined:
+
+    1. **Untracked task-reference files.** `_preflight_repo` filters `??`
+       lines out of its clean-tree gate, so untracked content is a normal
+       state for a repo leerie will happily run on. Meanwhile
+       `_glob_task_references` resolves the task's file references against the
+       real checkout and `_format_task_file_references` emits them
+       repo-relative, with an instruction to read each one — so a worker in a
+       worktree would be told to read a path that is not there. This is not
+       hypothetical: on the run that motivated this change, the classifier's
+       very first action was reading a task document that `git status` reports
+       as untracked. Losing it would have been a silent, total loss of the
+       spec.
+    2. **`.claude/`**, when the repo has one and does not track it. Repos
+       commonly gitignore it, and `scripts/remote/seed-repo.sh` already
+       force-ships it to `/work` for exactly this reason — "workers need its
+       hooks/agents/skills/commands to function".
+
+    Best-effort throughout: a copy failure degrades the worker's context but
+    must never take down a run that would otherwise proceed."""
+    try:
+        repo_root = Path(st.repo_root)
+        wt = Path(worktree)
+        task = st.data.get("task") or ""
+        staged = 0
+        if task:
+            for src in _glob_task_references(task, repo_root):
+                try:
+                    rel = src.resolve().relative_to(repo_root.resolve())
+                except ValueError:
+                    continue          # outside the repo; not ours to stage
+                dst = wt / rel
+                if dst.exists():
+                    continue          # tracked — the worktree already has it
+                try:
+                    dst.parent.mkdir(parents=True, exist_ok=True)
+                    if src.is_dir():
+                        shutil.copytree(src, dst, dirs_exist_ok=True)
+                    else:
+                        shutil.copy2(src, dst)
+                    staged += 1
+                except Exception:
+                    continue
+        claude_src, claude_dst = repo_root / ".claude", wt / ".claude"
+        if claude_src.is_dir() and not claude_dst.exists():
+            try:
+                shutil.copytree(claude_src, claude_dst, dirs_exist_ok=True)
+                staged += 1
+            except Exception:
+                pass
+        if staged:
+            log(f"planning worktree: staged {staged} untracked path(s) "
+                "the worker would otherwise not see")
+    except Exception as e:
+        log(f"planning worktree: could not stage untracked paths "
+            f"(non-fatal): {e}")
+
+
+async def _ensure_planning_worktree(st: "State") -> str:
+    """Create (or reset) this run's disposable judgment-worker worktree and
+    return its absolute path, recording it in `st.data["planning_worktree"]`.
+
+    Called before `phase_classify` and again before the satisfied-probe
+    sweep. It is NOT guarded on the state key being absent: the worktree is a
+    filesystem fact, not run state, so a resume must re-establish it (an
+    abnormal exit removes it) and a second call must re-reset it (the probe
+    needs a clean tree — see the script's header). The state key records the
+    path for the audit trail and for `_judgment_cwd`, not for a skip check.
+
+    Fails closed. A silent fallback to the real checkout would reinstate
+    exactly the exposure this exists to remove, and this runs after preflight
+    and before phase 1, so the run has spent essentially nothing — the
+    cheapest possible moment to refuse (DESIGN §13)."""
+    proc = await _run_script("planning-worktree.sh", st.run_id)
+    if proc.returncode != 0:
+        die("could not create the judgment-worker worktree "
+            f"(planning-worktree.sh exited {proc.returncode}).\n"
+            f"{proc.stderr.strip()}\n"
+            "leerie refuses to run judgment workers in your real checkout — "
+            "without the worktree they would plan against, and can write to, "
+            "the branch you are sitting on (DESIGN §12).\n"
+            "If a previous run left a stale registration behind:\n"
+            f"  bash scripts/cleanup.sh --run-id {st.run_id}\n"
+            "  ./leerie prune --apply")
+    # The script echoes `planning-worktree: <abs path>` as its last line.
+    line = proc.stdout.strip().splitlines()[-1] if proc.stdout.strip() else ""
+    path = line.split("planning-worktree:", 1)[-1].strip() if line else ""
+    if not path or not os.path.isdir(path):
+        die("planning-worktree.sh reported no usable path "
+            f"(stdout: {proc.stdout.strip()!r}).")
+    st.data["planning_worktree"] = path
+    st.save()
+    # After the reset, not before: `git clean -fd` would remove anything
+    # staged by a previous call.
+    _stage_worktree_extras(st, path)
+    return path
+
+
+# Paths leerie itself is entitled to write inside the user's checkout, so the
+# sentinel below does not report leerie's own bookkeeping as tampering.
+# `.leerie/config.toml` is the one committable file the orchestrator writes
+# (DESIGN §6½ dep capture); `.leerie/` at large is the state root on the
+# Fly/EC2 runtimes, where `resolve_leerie_root` falls back to `<repo>/.leerie`.
+_SENTINEL_EXEMPT_PREFIXES = (".leerie/",)
+
+
+async def _snapshot_repo_state(repo_root: str) -> dict:
+    """Capture the user's checkout identity: HEAD, porcelain status, refs.
+
+    Deliberately includes UNTRACKED files. `_preflight_repo` filters `??`
+    lines out of its clean-tree gate, which means "clean at run start" already
+    tolerates arbitrary untracked content — so a worker *creating* files is
+    precisely the case that gate cannot see, and precisely what a runaway
+    judgment worker does first."""
+    ok = True
+
+    async def _out(*argv: str) -> str:
+        nonlocal ok
+        r = await run_proc(list(argv), cwd=repo_root)
+        if r.returncode != 0:
+            ok = False
+            return ""
+        return r.stdout
+
+    porcelain = [
+        ln for ln in (await _out("git", "status", "--porcelain")).splitlines()
+        if not any(ln[3:].startswith(p) for p in _SENTINEL_EXEMPT_PREFIXES)
+    ]
+    head = (await _out("git", "rev-parse", "HEAD")).strip()
+    refs = sorted((await _out(
+        "git", "for-each-ref", "--format=%(refname) %(objectname)",
+        "refs/heads")).splitlines())
+    # `ok` records whether every probe actually answered. Without it a
+    # transiently unreadable checkout produces head="" and refs=[], which
+    # `_diff_repo_state` reads as "HEAD moved" plus "every branch deleted" —
+    # a fabricated tampering report that would die() a perfectly healthy run.
+    # A check that cries wolf gets disabled, which would cost the guarantee.
+    return {"head": head, "porcelain": sorted(porcelain), "refs": refs,
+            "ok": ok}
+
+
+def _diff_repo_state(before: dict, after: dict) -> list[str]:
+    """Human-readable deltas between two `_snapshot_repo_state` results.
+
+    Ref changes under leerie's own namespaces are expected — the run branch
+    and subtask branches are created during a run — so only refs OUTSIDE
+    `refs/heads/leerie/` count as tampering."""
+    out: list[str] = []
+    if before.get("head") != after.get("head"):
+        out.append(f"HEAD moved: {before.get('head', '?')[:12]} -> "
+                   f"{after.get('head', '?')[:12]}")
+    b_files, a_files = set(before.get("porcelain", [])), set(
+        after.get("porcelain", []))
+    for ln in sorted(a_files - b_files):
+        out.append(f"working tree changed: {ln}")
+    def _own(ref_line: str) -> bool:
+        return ref_line.split(" ", 1)[0].startswith("refs/heads/leerie/")
+    b_refs = {r for r in before.get("refs", []) if not _own(r)}
+    a_refs = {r for r in after.get("refs", []) if not _own(r)}
+    for r in sorted(a_refs - b_refs):
+        out.append(f"ref created/moved: {r}")
+    for r in sorted(b_refs - a_refs):
+        out.append(f"ref deleted: {r}")
+    return out
+
+
+async def _assert_repo_unchanged(st: "State", phase: str) -> None:
+    """The §12 guarantee: verify no worker has touched the user's checkout.
+
+    Judgment workers no longer carry `--dangerously-skip-permissions`, which
+    restores the CLI's working-directory boundary — but that boundary is
+    enforced on tool *arguments*, and an allowlisted build verb runs arbitrary
+    code. Measured: with permissions ON and `python3` allowlisted,
+    `python3 -c "open('<outside path>','w')"` wrote outside the cwd while the
+    Write tool aimed at the same path was rejected. So a residual escape
+    exists by construction, and this is what covers it.
+
+    Modelled on `check_rebaser_worktree_state`: trust the worker, then
+    mechanically re-check the claim. Runs after every planning phase rather
+    than once at the end, so it fires within one worker of the damage instead
+    of after the whole planning spend."""
+    before = st.data.get("repo_state_before_planning")
+    if not before:
+        return
+    if not before.get("ok", True):
+        # The baseline itself is untrustworthy, so nothing can be concluded
+        # from a comparison against it.
+        return
+    after = await _snapshot_repo_state(str(st.repo_root))
+    if not after.get("ok", True):
+        # "Could not tell" is not "tampered". Warn rather than die: the run is
+        # still recoverable and the next phase re-checks.
+        log(f"could not verify the checkout after {phase} "
+            "(git did not answer); skipping the tamper check this round")
+        return
+    deltas = _diff_repo_state(before, after)
+    if not deltas:
+        return
+    die("a worker modified your real checkout during " + phase + ".\n  "
+        + "\n  ".join(deltas)
+        + "\n\nleerie runs judgment workers in a disposable worktree "
+          "precisely so this cannot happen; reaching here means a worker "
+          "escaped it (most likely via a build command, which runs arbitrary "
+          "code). Your checkout is the source of truth for this run, so it "
+          "refuses to keep planning against a tree that moved underneath it.\n"
+          "Inspect and restore, then resume:\n"
+          f"  git -C {st.repo_root} status\n"
+          f"  git -C {st.repo_root} checkout -- <paths>   # tracked edits\n"
+          f"  git -C {st.repo_root} clean -i               # files it created\n"
+          f"  ./leerie resume {st.run_id}")
+
+
+def _judgment_cwd(st: "State") -> str:
+    """The cwd every judgment worker runs in.
+
+    Raises rather than falling back to the real checkout. `claude_p` also
+    refuses a judgment worker whose cwd is the checkout, so a fallback here
+    would only convert a clear failure into a confusing one two frames later.
+    """
+    path = st.data.get("planning_worktree")
+    if path:
+        return str(path)
+    # Fall back to the conventional location rather than raising. The fallback
+    # CANNOT violate the §12 guarantee: it is derived from the run directory,
+    # so it is never the user's checkout, and `claude_p` independently refuses
+    # any judgment worker whose cwd resolves to `st.repo_root`. The enforcement
+    # therefore does not rest on this lookup, which makes raising here pure
+    # diagnostics bought at the price of a precondition every caller that
+    # constructs a `State` by hand must now know about — ~30 test files, none
+    # of which spawn a real worker. If this fires in production the worker
+    # spawns against a directory that does not exist and fails loudly at exec
+    # time, which is the same signal one frame later.
+    run_dir = getattr(st, "run_dir", None)
+    if run_dir is None:
+        raise RuntimeError(
+            "cannot derive a judgment-worker cwd: state has neither "
+            "`planning_worktree` nor `run_dir`")
+    return str(Path(run_dir) / "worktrees" / "planning")
 
 
 # =========================================================================
@@ -7731,7 +8123,7 @@ async def _label_migration_chunks(
             system_prompt=sys_prompt,
             user_prompt=user_prompt,
             schema_key="splitter",
-            cwd=str(repo_root),
+            cwd=_judgment_cwd(st),
             allowed_tools=INSPECT_TOOLS,
             max_turns=30,
             autonomous=False,
@@ -8036,7 +8428,7 @@ async def _recursive_decompose(
             system_prompt=sys_prompt,
             user_prompt=user_prompt,
             schema_key="fit_judge",
-            cwd=str(repo_root),
+            cwd=_judgment_cwd(st),
             allowed_tools=INSPECT_TOOLS,
             max_turns=30,
             autonomous=False,
@@ -8152,7 +8544,7 @@ async def _recursive_decompose(
                 system_prompt=sys_prompt_s,
                 user_prompt=user_prompt_s,
                 schema_key="splitter",
-                cwd=str(repo_root),
+                cwd=_judgment_cwd(st),
                 allowed_tools=INSPECT_TOOLS,
                 max_turns=30,
                 autonomous=False,
@@ -9688,6 +10080,16 @@ def _build_repo_map(
         ".git", "node_modules", "__pycache__", ".venv", "venv", "env",
         ".tox", "dist", "build", ".mypy_cache", ".pytest_cache",
         ".ruff_cache", "target", "vendor", ".bundle",
+        # `.leerie` is the STATE ROOT on the Fly/EC2 runtimes: only the local
+        # nerdctl arm exports LEERIE_STATE_DIR, so `resolve_leerie_root` falls
+        # back to `<repo>/.leerie` there and every worktree (staging, per
+        # subtask, and now the judgment worktree) materializes inside the repo.
+        # Without this the map walks N full copies of the tree — every current
+        # worktree plus every prior run's leftovers — indexing each file
+        # repeatedly and spending the token budget on worktree paths. `.git` is
+        # already pruned by name, but a worktree's `.git` is a FILE, not a
+        # directory, so its contents were walked in full.
+        ".leerie",
     })
 
     def _cache_path(abs_path: Path) -> Path | None:
@@ -10876,7 +11278,7 @@ async def _filter_satisfied_subtasks(
             try:
                 out = await claude_p(
                     user_prompt=user_prompt, system_prompt=sys_prompt,
-                    schema_key="satisfied_probe", cwd=str(repo_root),
+                    schema_key="satisfied_probe", cwd=_judgment_cwd(st),
                     allowed_tools=SATISFIED_PROBE_TOOLS, max_turns=20,
                     autonomous=False, caps=caps, st=st,
                     model=models["satisfied_probe"],
@@ -16858,11 +17260,15 @@ async def claude_p(user_prompt: str, system_prompt: str, *, schema_key: str,
     single-result mode (`structured_output` present on schema success).
 
     `autonomous` workers skip permission prompts (they act on files inside an
-    isolated worktree); non-autonomous workers get only read tools — unless
-    `state.dangerously_skip_permissions` is set, in which case every worker
-    is invoked with `--dangerously-skip-permissions`, waiving the §12
-    mechanical read-only enforcement on judgment workers. See DESIGN §12
-    and IMPLEMENTATION.md §2 "Permission override (dangerous)".
+    isolated worktree). Judgment workers (`PLANNING_WORKER_TYPES`) never do:
+    `--dangerously-skip-permissions` is not reachable for them at any setting,
+    because the flag removes the CLI's working-directory boundary as well as
+    the prompts, and that boundary is the only thing standing between a
+    judgment worker and the user's branch. `state.dangerously_skip_permissions`
+    instead WIDENS their allowlist with the repo's build/lint/test verbs
+    (`_widen_inspect_tools`), which is the visibility the flag was always
+    documented to buy. See DESIGN §12 and IMPLEMENTATION.md §2 "Permission
+    override (dangerous)".
 
     `model` is a `claude --model` alias (`sonnet` / `opus` / `haiku`);
     resolved per worker-type by `resolve_models()` at startup.
@@ -16903,6 +17309,43 @@ async def claude_p(user_prompt: str, system_prompt: str, *, schema_key: str,
     schema = json.dumps(SCHEMAS[schema_key], separators=(",", ":"))
     leerie_dir = st.path.parent
     verbosity = st.data.get("verbosity", VERBOSITY_DEFAULT)
+
+    # §12 containment gate. A judgment worker must never be handed the real
+    # checkout as its cwd: without --dangerously-skip-permissions the CLI's
+    # own working-directory boundary is what confines it, and a cwd of /work
+    # makes that boundary the whole repo. Raised rather than corrected,
+    # because silently rewriting a caller's cwd would hide the contract
+    # violation (CLAUDE.md: a check that coerces a bad argument is a check
+    # that is disabled). Stated as "not the real checkout" rather than "equals
+    # the planning worktree" so the post-execution satisfied_probe rescue —
+    # which legitimately runs in a SUBTASK worktree — passes unchanged.
+    if schema_key in PLANNING_WORKER_TYPES:
+        try:
+            _same = (os.path.realpath(cwd)
+                     == os.path.realpath(str(st.repo_root)))
+        except Exception:
+            _same = False
+        if _same:
+            raise ValueError(
+                f"judgment worker {schema_key!r} was given the real repo "
+                f"checkout as cwd ({cwd}). Judgment workers must run in a "
+                "disposable worktree — see DESIGN §12 and "
+                "_ensure_planning_worktree()."
+            )
+        # The operator's escape hatch, re-expressed: more tools, same
+        # boundary. See _widen_inspect_tools for the measured residual.
+        #
+        # Scoped to INSPECT_TOOLS on purpose. `SATISFIED_PROBE_TOOLS` is a
+        # DELIBERATELY narrower bucket whose narrowness is calibrated, not
+        # incidental — 12/12 false positives with full INSPECT_TOOLS latitude
+        # against 0 when scoped to the base tree — and a false positive there
+        # silently deletes real work. Widening it would have handed that probe
+        # `Bash(pytest:*)` on this very repo. An operator asking for build
+        # tooling is asking on behalf of the planner, not the probe.
+        if (st.data.get("dangerously_skip_permissions", False)
+                and allowed_tools == INSPECT_TOOLS):
+            allowed_tools = _widen_inspect_tools(
+                allowed_tools, Path(getattr(st, "repo_root", os.getcwd())))
 
     # The appended system prompt is a second large argv element (reconciler.md
     # is ~25KB) that compounds with the user prompt toward MAX_ARG_STRLEN —
@@ -16951,16 +17394,23 @@ async def claude_p(user_prompt: str, system_prompt: str, *, schema_key: str,
                 cmd.extend(["--effort", effort])
             for d in (add_dirs or ()):
                 cmd.extend(["--add-dir", d])
-            skip_perms = autonomous or bool(
-                st.data.get("dangerously_skip_permissions", False))
-            if skip_perms:
-                # Acting workers (autonomous=True) run inside an isolated
-                # worktree; skipping prompts is what makes the run unattended,
-                # blast radius bounded by the worktree. When the user passes
-                # the top-level --dangerously-skip-permissions escape hatch
-                # (DESIGN §12 last paragraph), judgment workers in the real
-                # repo cwd also get the flag — §12 mechanical enforcement
-                # waived, trust shifts onto the prompts.
+            # Acting workers (autonomous=True) run inside an isolated worktree
+            # they own; skipping prompts is what makes the run unattended, and
+            # the blast radius really is the worktree because nothing else is
+            # writable by them that matters.
+            #
+            # Judgment workers NEVER get the flag, regardless of
+            # `dangerously_skip_permissions`. That flag used to be OR'd in
+            # here, and it was the whole of the containment failure: measured
+            # live (claude 2.1.237, filesystem-verified), a worker holding only
+            # INSPECT_TOOLS and carrying the flag used the Write tool — which
+            # is not in that allowlist — to overwrite a tracked file outside
+            # its cwd and `git commit` on the user's branch. Removing the flag
+            # restores the CLI's own working-directory boundary, which the same
+            # probe showed rejecting every one of those attempts. The operator's
+            # escape hatch is preserved as a widened allowlist instead (see
+            # `_widen_inspect_tools`) — more tools, same boundary.
+            if autonomous:
                 cmd.append("--dangerously-skip-permissions")
             return cmd
 
@@ -18823,7 +19273,7 @@ async def phase_classify(task: str, st: State, caps: dict, clarify: bool,
         return await claude_p(
             user_prompt="\n\n".join(user_prompt_parts),
             system_prompt=sys_prompt, schema_key="classifier",
-            cwd=str(repo_root),
+            cwd=_judgment_cwd(st),
             allowed_tools=INSPECT_TOOLS, max_turns=60, autonomous=False,
             caps=caps, st=st, model=models["classifier"],
             effort=efforts["classifier"], sid="classifier",
@@ -18949,7 +19399,6 @@ async def phase_classification_gate(task: str, st: State, caps: dict,
     Returns True iff it routed to the no-work terminal state (caller must
     stop); False otherwise (the categories live on state, like
     `phase_classify`'s own writes, and the caller proceeds normally)."""
-    repo_root = Path(os.getcwd())
     sys_prompt = _load_prompt("classification_judge")
 
     # Accumulated across every round of this gate call: every category the
@@ -18986,7 +19435,7 @@ async def phase_classification_gate(task: str, st: State, caps: dict,
         )
         return await claude_p(
             user_prompt=user_prompt, system_prompt=sys_prompt,
-            schema_key="classification_judge", cwd=str(repo_root),
+            schema_key="classification_judge", cwd=_judgment_cwd(st),
             allowed_tools=INSPECT_TOOLS, max_turns=30, autonomous=False,
             caps=caps, st=st, model=models.get("classification_judge",
                                                MODEL_DEFAULT),
@@ -19435,7 +19884,7 @@ async def phase_provision(repo_root: Path, st: State, caps: dict,
                 user_prompt="\n\n".join(prov_up_parts),
                 system_prompt=sys_prompt,
                 schema_key="provision",
-                cwd=str(repo_root),
+                cwd=_judgment_cwd(st),
                 allowed_tools=INSPECT_TOOLS,
                 max_turns=30,
                 autonomous=False,
@@ -19558,7 +20007,7 @@ async def phase_provision_gate(repo_root: Path, st: State, caps: dict,
         )
         return await claude_p(
             user_prompt=user_prompt, system_prompt=sys_prompt,
-            schema_key="provision_judge", cwd=str(repo_root),
+            schema_key="provision_judge", cwd=_judgment_cwd(st),
             allowed_tools=INSPECT_TOOLS, max_turns=30, autonomous=False,
             caps=caps, st=st,
             model=models.get("provision_judge", MODEL_DEFAULT),
@@ -19799,7 +20248,7 @@ async def phase_artifact_registry(
         )
         return await claude_p(
             user_prompt=user_prompt, system_prompt=sys_prompt,
-            schema_key="artifact_registry", cwd=str(repo_root),
+            schema_key="artifact_registry", cwd=_judgment_cwd(st),
             allowed_tools=INSPECT_TOOLS, max_turns=20, autonomous=False,
             caps=caps, st=st,
             model=models.get("artifact_registry", MODEL_DEFAULT),
@@ -20046,7 +20495,7 @@ async def phase_plan(task: str, st: State, caps: dict,
                 return await claude_p(
                     user_prompt="\n\n".join(up_parts + feedback_slot),
                     system_prompt=sys_prompt,
-                    schema_key="planner", cwd=str(repo_root),
+                    schema_key="planner", cwd=_judgment_cwd(st),
                     allowed_tools=INSPECT_TOOLS, max_turns=100,
                     autonomous=False, caps=caps, st=st,
                     model=models["planner"],
@@ -21161,7 +21610,7 @@ async def phase_reconcile(plans: list[dict], task: str, st: State,
         st.bump_workers(caps)
         raw = await claude_p(
             user_prompt=up, system_prompt=sys_prompt,
-            schema_key="reconciler", cwd=os.getcwd(),
+            schema_key="reconciler", cwd=_judgment_cwd(st),
             allowed_tools=INSPECT_TOOLS, max_turns=30,
             autonomous=False, caps=caps, st=st,
             model=models["reconciler"], effort=efforts["reconciler"],
@@ -24301,7 +24750,6 @@ async def phase_adherence_gate(plans: list[dict], task: str, st: State,
     st.data["current_phase"] = "phase 2⅞: adherence-gate"
     st.save()
 
-    repo_root = Path(os.getcwd())
     sys_prompt = _load_prompt("adherence_judge")
 
     def _build_payload(cur_plans: list[dict]) -> dict:
@@ -24337,7 +24785,7 @@ async def phase_adherence_gate(plans: list[dict], task: str, st: State,
         return await claude_p(
             user_prompt=user_prompt,
             system_prompt=sys_prompt,
-            schema_key="adherence_judge", cwd=str(repo_root),
+            schema_key="adherence_judge", cwd=_judgment_cwd(st),
             allowed_tools=INSPECT_TOOLS, max_turns=30,
             autonomous=False, caps=caps, st=st,
             model=models["adherence_judge"],
@@ -24600,7 +25048,7 @@ async def phase_planning_coverage_gate(plans: list[dict], task: str, st: State,
             json.dumps(payload, indent=2),
             system_prompt=sys_prompt,
             schema_key="task_coverage_judge",
-            cwd=os.getcwd(),
+            cwd=_judgment_cwd(st),
             # INSPECT_TOOLS is load-bearing, not decoration: the judge's
             # prompt instructs it to read task-referenced files itself.
             allowed_tools=INSPECT_TOOLS,
@@ -24681,7 +25129,6 @@ async def phase_wiring_gate(plans: list[dict], task: str, st: State,
 
     Returns `plans` unchanged (the gate does not mutate the plan; it either
     passes it through or `die()`s)."""
-    repo_root = Path(os.getcwd())
     sys_prompt = _load_prompt("wiring_judge")
 
     payload = {
@@ -24713,7 +25160,7 @@ async def phase_wiring_gate(plans: list[dict], task: str, st: State,
         )
         return await claude_p(
             user_prompt=user_prompt, system_prompt=sys_prompt,
-            schema_key="wiring_judge", cwd=str(repo_root),
+            schema_key="wiring_judge", cwd=_judgment_cwd(st),
             allowed_tools=INSPECT_TOOLS, max_turns=30, autonomous=False,
             caps=caps, st=st,
             model=models.get("wiring_judge", MODEL_DEFAULT),
@@ -24962,7 +25409,7 @@ async def phase_overlap_judge(plans: list[dict], task: str, st: State,
         return await claude_p(
             user_prompt="\n\n".join(oj_up_parts),
             system_prompt=sys_prompt,
-            schema_key="plan_overlap_judge", cwd=str(repo_root),
+            schema_key="plan_overlap_judge", cwd=_judgment_cwd(st),
             allowed_tools=INSPECT_TOOLS, max_turns=30,
             autonomous=False, caps=caps, st=st,
             model=models["plan_overlap_judge"],
@@ -25313,6 +25760,24 @@ def _finish_no_work_run(st: State, no_work_map: dict[str, str]) -> None:
     st.data["subtask_status"] = {}
     st.data["current_phase"] = "done: no work required"
     st.save()
+    # Reap the judgment worktree. This path reaches neither `cleanup.sh` (see
+    # the docstring) nor `_cleanup_on_abnormal_exit` — it returns normally, so
+    # `abnormal` stays False and main()'s finally-block never fires. That was
+    # harmless while the only worktrees were created by phase_execute, which a
+    # no-work run returns before ever reaching; the judgment worktree is
+    # created before phase_classify, so this exit is now the one normal path
+    # that would leak a full checkout copy until `leerie prune` reaps it 14
+    # days later. And a no-work run is the shape most likely to take it, since
+    # it terminates *during* planning.
+    _wt = st.data.get("planning_worktree")
+    if _wt and os.path.isdir(_wt):
+        try:
+            subprocess.run(["git", "worktree", "remove", "--force", str(_wt)],
+                           capture_output=True, check=False, timeout=120)
+            if os.path.isdir(_wt):
+                shutil.rmtree(_wt, ignore_errors=True)
+        except Exception as e:                     # never block the exit
+            log(f"could not remove the judgment worktree (non-fatal): {e}")
     _write_run_json(
         st.run_dir,
         finished_at=st.data["finished_at"],
@@ -29987,7 +30452,7 @@ async def _run_integration_judge_gate(
         )
         return await claude_p(
             user_prompt=user_prompt, system_prompt=sys_prompt_judge,
-            schema_key="integration_judge", cwd=str(repo_root),
+            schema_key="integration_judge", cwd=str(staging),
             allowed_tools=INSPECT_TOOLS, max_turns=30, autonomous=False,
             caps=caps, st=st,
             model=models.get("integration_judge", MODEL_DEFAULT),
@@ -31625,6 +32090,24 @@ async def _run_phases(args, caps: dict, leerie_dir: Path, st: State,
     # executes every step exactly as before, and a resumed run skips
     # whatever a prior invocation already completed and checkpointed.
     if "waves" not in st.data:
+        # DESIGN §12 *Judgment-worker isolation*. Deliberately here — inside
+        # the `waves` guard (a run resumed into execution spawns no judgment
+        # worker and needs neither) but ABOVE the `plans_after_classify`
+        # guard, so EVERY planning resume re-establishes it at whichever
+        # `plans_after_*` cursor it re-enters. Nesting it one level deeper is
+        # the N8 trap this function's own header comment documents: work
+        # placed inside the inner guard silently stops happening on every
+        # resume past classify, which is the common case.
+        await _ensure_planning_worktree(st)
+        # Baseline for the sentinel. Guarded on absence, so it is captured
+        # once and kept across resumes: a later pass must compare against the
+        # tree as it was before ANY judgment worker ran, or a modification
+        # made by an earlier pass is laundered into the new baseline and
+        # never reported.
+        if "repo_state_before_planning" not in st.data:
+            st.data["repo_state_before_planning"] = (
+                await _snapshot_repo_state(str(st.repo_root)))
+            st.save()
         if "plans_after_classify" not in st.data:
             # Run-start backstop (DESIGN §6½): before phase_classify, scan
             # prior runs that produced logs but whose dep_capture.done
@@ -31729,6 +32212,7 @@ async def _run_phases(args, caps: dict, leerie_dir: Path, st: State,
             # need not be re-invoked.
             st.data["plans_after_classify"] = []
             st.save()
+            await _assert_repo_unchanged(st, "phase 1 (classify)")
             # Provision per-repo deps (DESIGN §6½). Runs after classify (so
             # a docs-only run can short-circuit). Guarded on presence of
             # the "recipe" key rather than unconditional: `mise install`
@@ -31750,6 +32234,22 @@ async def _run_phases(args, caps: dict, leerie_dir: Path, st: State,
             # phase skips it.
             await phase_provision_gate(
                 Path(os.getcwd()), st, caps, models, efforts)
+            # Make the judgment worktree runnable, but only when the operator
+            # asked for tooling. With the escape hatch off, INSPECT_TOOLS
+            # contains no build verb at all — no pnpm, no tsc, no pytest — so
+            # installed deps would be unreachable and the install pure cost.
+            # With it on, `_widen_inspect_tools` has just granted those verbs,
+            # and a build verb in a tree with no node_modules fails in a way
+            # the planner reads as a real repo defect and plans phantom work
+            # around. Placed here because the recipe does not exist until
+            # phase_provision has run. Reuses the same helper the conformance
+            # baseline uses: once per tree per process, and never raises.
+            if st.data.get("dangerously_skip_permissions", False):
+                await _ensure_worktree_deps(
+                    _judgment_cwd(st), st, caps,
+                    log_path=st.run_dir / "logs" / "planning-install.log",
+                    verbosity=st.data.get("verbosity", VERBOSITY_DEFAULT),
+                    label_prefix="planning", log_prefix="planning-install")
             # gather_answers blocks on input(). That's fine here: no
             # concurrent tasks are scheduled yet, so blocking the loop
             # blocks nothing. Kept on the event loop deliberately — every
@@ -31776,6 +32276,7 @@ async def _run_phases(args, caps: dict, leerie_dir: Path, st: State,
             # phase_plan (DESIGN §6).
             st.data["plans_after_plan"] = copy.deepcopy(plans)
             st.save()
+            await _assert_repo_unchanged(st, "phase 2 (plan)")
         else:
             plans = copy.deepcopy(st.data["plans_after_plan"])
 
@@ -31790,6 +32291,7 @@ async def _run_phases(args, caps: dict, leerie_dir: Path, st: State,
             # checkpoint (DESIGN §6).
             st.data["plans_after_reconcile"] = copy.deepcopy(plans)
             st.save()
+            await _assert_repo_unchanged(st, "phase 2.5 (reconcile)")
             # Cleared-but-empty terminal state (DESIGN §8): every planner
             # cleared its gate and confirmed the task is already satisfied
             # on HEAD. Nothing to _schedule, nothing to execute, no run
@@ -31830,6 +32332,7 @@ async def _run_phases(args, caps: dict, leerie_dir: Path, st: State,
             # overlap*).
             st.data["plans_after_overlap_judge"] = copy.deepcopy(plans)
             st.save()
+            await _assert_repo_unchanged(st, "phase 2.75 (overlap judge)")
         else:
             plans = copy.deepcopy(st.data["plans_after_overlap_judge"])
 
@@ -31853,6 +32356,7 @@ async def _run_phases(args, caps: dict, leerie_dir: Path, st: State,
             # phase_adherence_gate (DESIGN §6).
             st.data["plans_after_adherence_gate"] = copy.deepcopy(plans)
             st.save()
+            await _assert_repo_unchanged(st, "phase 2.875 (adherence gate)")
         else:
             plans = copy.deepcopy(st.data["plans_after_adherence_gate"])
 
@@ -31871,6 +32375,7 @@ async def _run_phases(args, caps: dict, leerie_dir: Path, st: State,
             # phase_planning_coverage_gate (DESIGN §6).
             st.data["plans_after_coverage_gate"] = copy.deepcopy(plans)
             st.save()
+            await _assert_repo_unchanged(st, "phase 2.9 (coverage gate)")
         else:
             plans = copy.deepcopy(st.data["plans_after_coverage_gate"])
 
@@ -31918,6 +32423,20 @@ async def _run_phases(args, caps: dict, leerie_dir: Path, st: State,
             # per-subtask satisfied_probe_cache (DESIGN §6, keyed by base
             # commit sha) already makes a resumed sweep skip every
             # subtask decided before the pause.
+            # Reset the judgment worktree before the sweep. Load-bearing,
+            # not hygiene: the probe is handed no diff and no file contents —
+            # its prompt tells it to judge "the CURRENT working tree / HEAD",
+            # so its cwd is the ONLY thing determining which tree it sees. An
+            # earlier judgment worker that wrote into that tree would make the
+            # probe answer "already satisfied" and silently drop real work,
+            # which is the exact false-positive class its narrowed tool scope
+            # was calibrated against (12/12, see SATISFIED_PROBE_TOOLS).
+            await _ensure_planning_worktree(st)
+            # NOTE the repo_root argument stays the REAL checkout. It feeds
+            # `base_sha`, the cache key that invalidates verdicts when HEAD
+            # moves across a pause; keyed off the detached worktree instead it
+            # would be constant by construction and the invalidation would
+            # silently never fire.
             satisfied_no_work = await _filter_satisfied_subtasks(
                 plans, Path(os.getcwd()), st, caps, models, efforts)
             if satisfied_no_work is not None:
@@ -31929,6 +32448,7 @@ async def _run_phases(args, caps: dict, leerie_dir: Path, st: State,
             # resume cursor (DESIGN §6).
             st.data["plans_after_filters"] = copy.deepcopy(plans)
             st.save()
+            await _assert_repo_unchanged(st, "phase 3 (filters)")
         else:
             plans = copy.deepcopy(st.data["plans_after_filters"])
 

--- a/prompts/classifier.md
+++ b/prompts/classifier.md
@@ -1,8 +1,13 @@
 # Leerie classifier
 
 You classify an engineering task and decide what, if anything, genuinely
-requires asking the user. You run read-only — you may inspect the codebase but
-must not modify anything.
+requires asking the user.
+
+Your working directory is a **disposable throwaway checkout**. Nothing you
+write there is kept: it is reset before the next phase and reaches no branch,
+no PR and no user. So editing files does not advance the task — it only burns
+your turn budget, and you are the phase most likely to run out of it. Read
+whatever you need; produce only the JSON your schema describes.
 
 Tooling note: `Read` is for individual files only — passing a directory path
 returns `EISDIR`. To enumerate or scope a directory, use `Glob`, `Bash(ls ...)`,

--- a/prompts/planner.md
+++ b/prompts/planner.md
@@ -1,8 +1,10 @@
 # Leerie planner
 
 You decompose ONE domain of a larger task into a plan of granular subtasks. You
-run read-only — you do not write code or implement anything. Your only output is
-a JSON plan.
+run in a **disposable throwaway checkout** — you may read, build and test
+freely, but anything you write there is discarded and reaches no branch, no PR
+and no user. Implementing is not your job and does not advance the task; it
+only burns your turn budget. Your only output is a JSON plan.
 
 Tooling note: `Read` is for individual files only — passing a directory path
 returns `EISDIR`. To enumerate or scope a directory, use `Glob`, `Bash(ls ...)`,

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,3 +3,5 @@ testpaths = tests
 python_files = test_*.py
 python_functions = test_*
 addopts = -ra --strict-markers --strict-config
+markers =
+    real_planning_worktree: let a test call the real _ensure_planning_worktree (which does a real `git worktree add`). Opts out of conftest's _no_real_planning_worktree guard; only for tests whose subject IS the worktree mechanics.

--- a/scripts/planning-worktree.sh
+++ b/scripts/planning-worktree.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# planning-worktree.sh <run-id> — create/reset the disposable worktree that
+# every judgment worker runs in (DESIGN §12 *Judgment-worker isolation*).
+#
+# Judgment workers (classifier, planner, reconciler, the judges, the
+# satisfied-probe) used to run with cwd = the user's real checkout. Combined
+# with `--dangerously-skip-permissions` that left nothing between a worker and
+# the operator's branch: measured live, a classifier implemented an entire task
+# in the user's checkout on `main`. Removing the flag from those workers
+# (orchestrator/leerie.py, `claude_p`) restores the CLI's working-directory
+# boundary; this script is what makes that boundary land somewhere harmless.
+#
+# DETACHED, never a branch. Three reapers glob leerie's ref namespaces —
+# cleanup.sh, _cleanup_on_abnormal_exit's branch_globs, and `leerie prune` —
+# and all three know only `leerie/runs/<id>` and `leerie/subtasks/<id>/`. A
+# fourth namespace would leak forever, which is the stale-branch problem
+# `prune` exists to fix. Nothing downstream reads these commits: planning
+# output is JSON in state.json, and setup-run.sh cuts the run branch from the
+# real checkout's HEAD, so a commit made here is unreachable by construction.
+#
+# PER-RUN, under <run-dir>/worktrees/, so it inherits the cleanup that already
+# sweeps that directory (cleanup.sh's clean_one_run, and
+# _cleanup_on_abnormal_exit) with no new reaping code, and so two concurrent
+# runs against one repo cannot reset each other's tree mid-phase.
+#
+# RESET ON RE-ENTRY, not merely reused. Two distinct reasons, both real:
+#   1. The satisfied-probe judges "is this already done?" by inspecting its own
+#      cwd — no diff is passed to it. A tree an earlier judgment worker wrote
+#      into would make it answer yes and silently drop real work.
+#   2. On resume the real checkout's HEAD may have moved (a sibling run merged
+#      its PR). A worktree pinned at the old sha would plan against a tree that
+#      no longer exists.
+# `clean -fd` and NOT `-fdx`: gitignored content (node_modules, .venv) must
+# survive, or every resume re-pays the install. That is deliberate — do not
+# "fix" it to -fdx.
+set -euo pipefail
+
+# shellcheck source=scripts/worktree-lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/worktree-lib.sh"
+
+RUN_ID="${1:?usage: planning-worktree.sh <run-id>}"
+LEERIE_ROOT="${LEERIE_STATE_DIR:-.leerie}"
+RUN_DIR="${LEERIE_ROOT}/runs/${RUN_ID}"
+WT="${RUN_DIR}/worktrees/planning"
+
+# `git worktree list --porcelain` prints absolute, symlink-resolved paths, so
+# $WT must be in that shape before the reuse grep. Same normalization as
+# setup-run.sh — when LEERIE_STATE_DIR is unset (the Fly/EC2 runtimes, and
+# direct python callers) $WT is repo-relative.
+case "$WT" in
+  /*) ;;
+  *)  WT="$(pwd -P)/$WT" ;;
+esac
+
+if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  echo "error: not inside a git repository" >&2
+  exit 1
+fi
+
+# The tree to mirror: the real checkout's current HEAD. Read here, in the main
+# checkout, rather than inside the worktree — a detached worktree reports its
+# own (possibly stale) HEAD, which is the value this reset exists to correct.
+TARGET_SHA="$(git rev-parse HEAD)"
+
+mkdir -p "${RUN_DIR}/worktrees"
+
+# Drop an orphaned directory git no longer knows about. Same failure mode
+# setup-run.sh documents: a SIGKILLed container leaves the directory without
+# its admin entry, and `worktree add` then refuses with "already exists" on
+# every subsequent resume. Neither `prune` nor `--force` covers it.
+if ! git worktree list --porcelain | grep -qxF "worktree $WT" && [ -d "$WT" ]; then
+  rm -rf "$WT"
+fi
+
+# Scoped prune (never a bare `git worktree prune`): the repo's .git is shared
+# with the host and other containers, and a repository-global prune destroys
+# registrations whose paths this namespace cannot see.
+prune_leerie_worktrees "${LEERIE_ROOT}"
+
+if git worktree list --porcelain | grep -qxF "worktree $WT"; then
+  # Reuse: force the tree back to the current HEAD and drop anything a
+  # previous judgment worker left behind. --force because the checkout is
+  # detached and may carry commits; that is expected and discarded.
+  git -C "$WT" reset --hard "$TARGET_SHA" >/dev/null
+  git -C "$WT" clean -fd >/dev/null
+else
+  git worktree add --detach "$WT" "$TARGET_SHA" >/dev/null
+fi
+
+echo "planning-worktree: $(cd "$WT" && pwd)"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -144,6 +144,46 @@ def child_subreaper_restored():
 
 
 @pytest.fixture(autouse=True)
+def _no_real_planning_worktree(request, monkeypatch):
+    """Keep `_ensure_planning_worktree` from shelling out to real git.
+
+    It runs `scripts/planning-worktree.sh`, which does a real
+    `git worktree add` rooted at `resolve_leerie_root()`. With
+    `LEERIE_STATE_DIR` unset -- the default for a direct Python caller -- that
+    resolves to `<repo>/.leerie`, so any test driving the real `_run_phases`
+    created a FULL CHECKOUT OF THIS REPO inside this repo and left it
+    registered in `.git/worktrees/`.
+
+    The failure mode is silent in three ways at once, which is why this is a
+    conftest-level guard rather than a stub in each driving test: `.leerie/*`
+    is gitignored so `git status` stays clean; the directories survive the
+    session; and the damage surfaces in an unrelated file, because a nested
+    `.leerie/.../worktrees/planning/tests/...` copy does not match the
+    `rel.startswith("tests/")` exclusion that scanners like
+    `test_helper_naming_convention` use. Measured: two worktrees, 25 MB, and
+    one red test with no visible connection to the change that caused it.
+
+    Opt out with `@pytest.mark.real_planning_worktree` when the worktree
+    mechanics are themselves the subject.
+    """
+    if request.node.get_closest_marker("real_planning_worktree"):
+        return
+    leerie = request.getfixturevalue("leerie")
+
+    async def _stub(st):
+        path = str(Path(getattr(st, "run_dir", ".")) / "worktrees"
+                   / "planning")
+        try:
+            st.data["planning_worktree"] = path
+            st.save()
+        except Exception:
+            pass
+        return path
+
+    monkeypatch.setattr(leerie, "_ensure_planning_worktree", _stub)
+
+
+@pytest.fixture(autouse=True)
 def _restore_child_subreaper():
     """Put `PR_SET_CHILD_SUBREAPER` back after every test.
 

--- a/tests/test_artifact_registry.py
+++ b/tests/test_artifact_registry.py
@@ -164,7 +164,12 @@ def _make_state(leerie, run_dir: Path):
     st.data = {"telemetry": {"calls": 0, "cost_usd": 0.0,
                              "input_tokens": 0, "output_tokens": 0},
                "verbosity": "quiet", "worker_count": 0,
-               "skip_repo_map": True}
+               "skip_repo_map": True,
+               # Judgment workers now run in a disposable worktree
+               # (DESIGN §12 *Judgment-worker isolation*); `_judgment_cwd`
+               # raises rather than silently falling back to the real
+               # checkout, so every State fixture must seed the path.
+               "planning_worktree": str(run_dir / "worktrees" / "planning")}
     run_dir.mkdir(parents=True, exist_ok=True)
     st.path.write_text("{}")
     return st

--- a/tests/test_decompose_budget_share.py
+++ b/tests/test_decompose_budget_share.py
@@ -29,7 +29,10 @@ def _make_real_state(leerie):
 
     class _RealishState:
         def __init__(self):
-            self.data = {"worker_count": 0}
+            self.data = {"worker_count": 0,
+                         # judgment workers run in a disposable worktree
+                         # (DESIGN §12), never the user's checkout
+                         "planning_worktree": "/tmp/leerie-test-wt"}
 
         def save(self):
             pass  # no persistence needed for this test

--- a/tests/test_ensure_planning_worktree.py
+++ b/tests/test_ensure_planning_worktree.py
@@ -1,0 +1,254 @@
+"""The Python half of the judgment worktree — `_ensure_planning_worktree` and
+`_stage_worktree_extras` (DESIGN §12 *Judgment-worker isolation*).
+
+`tests/test_planning_worktree_script.py` covers the shell script by
+subprocess. This file covers the wrapper around it: parsing the path back out,
+failing closed when the script fails, and staging the things `git worktree add`
+does not carry because git only checks out TRACKED content.
+
+Every test here carries `@pytest.mark.real_planning_worktree`, which opts out
+of conftest's `_no_real_planning_worktree` stub — these are the tests whose
+SUBJECT is the worktree mechanics. That makes them the one place in the suite
+that runs a real `git worktree add`, so each one first `chdir`s into a
+throwaway repo and points `LEERIE_STATE_DIR` at a throwaway state root. Without
+both, `_run_script` runs with `cwd=os.getcwd()` and `resolve_leerie_root()`
+falls back to `<repo>/.leerie` — which is exactly how a full checkout of leerie
+ended up inside leerie, gitignored and invisible, until an unrelated scanner
+went red on CI. `test_no_worktree_leaks_into_this_repo` is the standing proof
+that the containment holds.
+"""
+from __future__ import annotations
+
+import asyncio
+import subprocess
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.real_planning_worktree
+
+
+def _git(repo, *args):
+    return subprocess.run(["git", "-C", str(repo), *args],
+                          capture_output=True, text=True, check=False)
+
+
+def _init(repo):
+    repo.mkdir(parents=True, exist_ok=True)
+    _git(repo, "init", "-q", ".")
+    _git(repo, "config", "user.email", "t@t")
+    _git(repo, "config", "user.name", "t")
+    (repo / "tracked.txt").write_text("tracked\n")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "init")
+    return repo
+
+
+class _St:
+    """Only the attributes the two functions touch."""
+
+    def __init__(self, repo, state_root, run_id="r1"):
+        self.repo_root = repo
+        self.run_id = run_id
+        self.run_dir = state_root / "runs" / run_id
+        self.run_dir.mkdir(parents=True, exist_ok=True)
+        self.data: dict = {}
+        self.saves = 0
+
+    def save(self):
+        self.saves += 1
+
+
+@pytest.fixture()
+def env(tmp_path, monkeypatch):
+    """A throwaway repo + state root, with the process parked inside the repo.
+
+    Both halves are load-bearing — see the module docstring."""
+    repo = _init(tmp_path / "repo")
+    state = tmp_path / "state"
+    monkeypatch.chdir(repo)
+    monkeypatch.setenv("LEERIE_STATE_DIR", str(state))
+    return repo, state, _St(repo, state)
+
+
+def _run(leerie, st):
+    return asyncio.run(leerie._ensure_planning_worktree(st))
+
+
+class TestEnsurePlanningWorktree:
+    def test_creates_the_worktree_and_records_the_path(self, leerie, env):
+        repo, state, st = env
+        path = _run(leerie, st)
+        assert (state / "runs" / "r1" / "worktrees" / "planning").is_dir()
+        assert st.data["planning_worktree"] == path
+        assert st.saves >= 1, "the path must be persisted, not just returned"
+
+    def test_returned_path_is_absolute_and_matches_the_checkout(
+            self, leerie, env):
+        repo, state, st = env
+        path = _run(leerie, st)
+        assert path.startswith("/")
+        assert (_git(path, "rev-parse", "HEAD").stdout.strip()
+                == _git(repo, "rev-parse", "HEAD").stdout.strip())
+
+    def test_second_call_is_idempotent(self, leerie, env):
+        """It is called twice per run — before phase_classify and again before
+        the satisfied-probe sweep — so the second call must succeed against an
+        existing worktree rather than failing on `already exists`."""
+        repo, state, st = env
+        first = _run(leerie, st)
+        second = _run(leerie, st)
+        assert first == second
+
+    def test_script_failure_dies_and_does_not_fall_back(
+            self, leerie, env, monkeypatch):
+        """Fail closed. A silent fallback to the real checkout reinstates
+        exactly the exposure this exists to remove."""
+        repo, state, st = env
+
+        async def failing(_name, *_a):
+            return subprocess.CompletedProcess(
+                args=[], returncode=1, stdout="", stderr="boom")
+
+        monkeypatch.setattr(leerie, "_run_script", failing)
+        with pytest.raises(SystemExit):
+            _run(leerie, st)
+        assert "planning_worktree" not in st.data, (
+            "a failed creation must not leave a path behind for "
+            "_judgment_cwd to hand to a worker")
+
+    def test_die_message_is_actionable(self, leerie, env, monkeypatch):
+        """It names both remedies. A die() an operator cannot act on is a
+        die() they work around by disabling the check."""
+        repo, state, st = env
+        seen = {}
+
+        async def failing(_name, *_a):
+            return subprocess.CompletedProcess(
+                args=[], returncode=1, stdout="", stderr="boom")
+
+        def fake_die(msg, code=1):
+            seen["msg"] = msg
+            raise SystemExit(code)
+
+        monkeypatch.setattr(leerie, "_run_script", failing)
+        monkeypatch.setattr(leerie, "die", fake_die)
+        with pytest.raises(SystemExit):
+            _run(leerie, st)
+        assert "cleanup.sh" in seen["msg"] and "prune" in seen["msg"]
+        assert "boom" in seen["msg"], "git's own stderr must reach the operator"
+
+    def test_unusable_path_output_dies(self, leerie, env, monkeypatch):
+        """rc 0 with nothing parseable is still a failure — the caller would
+        otherwise record an empty cwd and every worker would spawn in the
+        orchestrator's own directory."""
+        repo, state, st = env
+
+        async def chatty(_name, *_a):
+            return subprocess.CompletedProcess(
+                args=[], returncode=0, stdout="something unexpected\n",
+                stderr="")
+
+        monkeypatch.setattr(leerie, "_run_script", chatty)
+        with pytest.raises(SystemExit):
+            _run(leerie, st)
+
+    def test_staging_runs_after_the_reset(self, leerie, env):
+        """Ordering, not presence: the script's `git clean -fd` would delete
+        anything staged by a previous call, so staging must follow it. A file
+        staged on call one must still be there after call two."""
+        repo, state, st = env
+        (repo / "brief.md").write_text("the spec\n")     # untracked
+        st.data["task"] = "implement what brief.md says"
+        _run(leerie, st)
+        wt = state / "runs" / "r1" / "worktrees" / "planning"
+        assert (wt / "brief.md").exists()
+        _run(leerie, st)
+        assert (wt / "brief.md").exists(), (
+            "staging ran before the reset, so the second call wiped it")
+
+
+class TestStageWorktreeExtras:
+    def test_untracked_task_file_is_staged(self, leerie, env):
+        """The measured case. On the run that motivated this feature the
+        classifier's first action was reading a task document that
+        `git status` reports as untracked — a worktree would not have
+        contained the spec the run was about."""
+        repo, state, st = env
+        (repo / "brief.md").write_text("the spec\n")
+        st.data["task"] = "do what brief.md says"
+        path = _run(leerie, st)
+        assert (repo / "brief.md").read_text() == "the spec\n"
+        assert (Path(path) / "brief.md").read_text() == "the spec\n"
+
+    def test_tracked_file_is_not_clobbered(self, leerie, env):
+        """A tracked file is already in the worktree at the right revision.
+        Copying the working-copy version over it would import uncommitted
+        drift the run never agreed to plan against."""
+        repo, state, st = env
+        path = _run(leerie, st)
+        wt_file = Path(path) / "tracked.txt"
+        (repo / "tracked.txt").write_text("LOCAL DRIFT\n")
+        st.data["task"] = "look at tracked.txt"
+        _run(leerie, st)
+        assert wt_file.read_text() == "tracked\n"
+
+    def test_untracked_dot_claude_is_copied(self, leerie, env):
+        """`seed-repo.sh` force-ships `.claude/` to /work precisely because
+        repos gitignore it and workers need its hooks/agents/skills."""
+        repo, state, st = env
+        (repo / ".claude").mkdir()
+        (repo / ".claude" / "settings.json").write_text("{}\n")
+        path = _run(leerie, st)
+        assert (Path(path) / ".claude" / "settings.json").exists()
+
+    def test_absent_dot_claude_is_not_invented(self, leerie, env):
+        repo, state, st = env
+        path = _run(leerie, st)
+        assert not (Path(path) / ".claude").exists()
+
+    def test_paths_outside_the_repo_are_not_staged(self, leerie, env,
+                                                   tmp_path):
+        """Staging resolves against the repo root; anything else is not ours
+        to copy into a tree the planner will reason about."""
+        repo, state, st = env
+        outsider = tmp_path / "outside.md"
+        outsider.write_text("not mine\n")
+        st.data["task"] = f"see {outsider}"
+        path = _run(leerie, st)
+        assert not (Path(path) / "outside.md").exists()
+        assert not (Path(path) / outsider.name).exists()
+
+    def test_is_best_effort_and_never_raises(self, leerie, env, monkeypatch):
+        """Degraded context must not take down a run that would otherwise
+        proceed — the worktree itself is already established by this point."""
+        repo, state, st = env
+
+        def boom(*_a, **_k):
+            raise OSError("disk on fire")
+
+        monkeypatch.setattr(leerie.shutil, "copy2", boom)
+        monkeypatch.setattr(leerie.shutil, "copytree", boom)
+        (repo / "brief.md").write_text("spec\n")
+        (repo / ".claude").mkdir()
+        (repo / ".claude" / "x.json").write_text("{}\n")
+        st.data["task"] = "see brief.md"
+        assert _run(leerie, st)          # returns a path, does not raise
+
+    def test_no_task_text_is_a_no_op(self, leerie, env):
+        """`_ensure_planning_worktree` runs before the fresh-run seed on some
+        paths, so `task` may legitimately be absent."""
+        repo, state, st = env
+        st.data.pop("task", None)
+        assert _run(leerie, st)
+
+
+def test_no_worktree_leaks_into_this_repo(leerie):
+    """Standing proof for the whole file: these are the only tests that run a
+    real `git worktree add`, and none of them may register one against the
+    leerie checkout. Measured once at 2 worktrees / 25 MB, gitignored and
+    invisible to `git status`."""
+    out = subprocess.run(["git", "worktree", "list", "--porcelain"],
+                         capture_output=True, text=True, check=False).stdout
+    assert ".leerie/runs" not in out, (
+        f"a test registered a worktree inside this repo:\n{out}")

--- a/tests/test_filter_satisfied_subtasks.py
+++ b/tests/test_filter_satisfied_subtasks.py
@@ -47,6 +47,11 @@ def _make_state(leerie, run_dir: Path):
     st.run_dir = run_dir
     st.path = run_dir / "state.json"
     st.data = {
+        # Judgment workers now run in a disposable worktree
+        # (DESIGN §12 *Judgment-worker isolation*); `_judgment_cwd`
+        # raises rather than silently falling back to the real
+        # checkout, so every State fixture must seed the path.
+        "planning_worktree": str(run_dir / "worktrees" / "planning"),
         "telemetry": {"calls": 0, "cost_usd": 0.0,
                       "input_tokens": 0, "output_tokens": 0},
         "verbosity": "quiet",

--- a/tests/test_inspect_tools.py
+++ b/tests/test_inspect_tools.py
@@ -1,12 +1,14 @@
 """Coupling tests for INSPECT_TOOLS — the tool bucket for classifier,
 planner, reconciler, plan_overlap_judge, and provision.
 
-These workers run in the real repo cwd (no worktree isolation), so they
-cannot use --dangerously-skip-permissions. INSPECT_TOOLS preserves the
+These workers run in a disposable detached worktree (`_judgment_cwd`), never
+the user's checkout, and never carry --dangerously-skip-permissions — see
+DESIGN §12 *Judgment-worker isolation*. INSPECT_TOOLS preserves the
 DESIGN §12 "read-only worker" contract mechanically: read tools plus
 allowlisted Bash(<verb>:*) patterns for cross-cwd inspection, no
 Write/Edit. Anything outside the allowlist falls through and is rejected
-in non-interactive mode.
+in non-interactive mode — an omission that is load-bearing rather than
+advisory now that the flag can no longer lift the gate for these workers.
 
 These tests pin both halves so a future edit that adds Write/Edit or
 swaps in a bare Bash wildcard (which would defeat the allowlist) fails
@@ -159,7 +161,7 @@ def test_reconciler_call_site_uses_inspect_tools():
 
 def test_overlap_judge_call_site_uses_inspect_tools():
     """phase_overlap_judge (DESIGN §5 *Cross-domain surface overlap*)
-    runs in the real repo cwd like the other judgment workers, so it
+    runs in the judgment worktree like the other judgment workers, so it
     must inherit the same INSPECT_TOOLS allowlist — no Write/Edit, only
     allowlisted Bash verbs. A future edit swapping in ACT_TOOLS would
     silently waive the §12 read-only contract for the overlap judge."""

--- a/tests/test_judgment_worker_isolation.py
+++ b/tests/test_judgment_worker_isolation.py
@@ -1,0 +1,457 @@
+"""DESIGN §12 *Judgment-worker isolation* — the four layers that keep a
+judgment worker out of the user's checkout.
+
+The failure this exists to prevent, measured on a real run: a `classifier`
+implemented an entire task in the operator's checkout on `main` — `Edit` calls
+to three files, a repo-wide `lint:fix`, and a `git stash`/`pop` pair — then
+died at its turn cap. `Edit` is not in `INSPECT_TOOLS`; the worker reached it
+because `--dangerously-skip-permissions` bypasses `--allowedTools` entirely.
+
+Probed live against claude 2.1.237 (filesystem-verified, four runs):
+
+    configuration                    Write in cwd  Write outside  Bash outside
+    INSPECT_TOOLS, flag ON           succeeded     succeeded      succeeded
+    INSPECT_TOOLS, flag OFF          rejected      rejected       rejected
+
+and, in the exact shape this feature ships, cwd = a detached worktree with the
+flag still set: the worker overwrote the real checkout AND committed on its
+branch. That is the result that makes L1 (never grant the flag) the load-bearing
+layer and L2 (the worktree) worthless on its own — a worktree is not a boundary,
+it is where the boundary lands once L1 restores one.
+
+Every test here pairs a negative with a positive control, because each negative
+alone is satisfied by a `claude_p` that is simply broken.
+"""
+from __future__ import annotations
+
+import ast
+import asyncio
+import inspect
+import pathlib
+
+import pytest
+
+
+MODULE = (pathlib.Path(__file__).resolve().parents[1]
+          / "orchestrator" / "leerie.py")
+
+
+@pytest.fixture(autouse=True)
+def _clear_blt_verbs_cache(leerie):
+    """`_BLT_VERBS_CACHE` is module-level and conftest's `leerie` fixture is
+    session-scoped, so without this a verb list computed from one test's tmp
+    repo leaks into every later file that exercises the widening — the same
+    order-dependence CLAUDE.md records for `_active_admissions`."""
+    leerie._BLT_VERBS_CACHE.clear()
+    yield
+    leerie._BLT_VERBS_CACHE.clear()
+
+_REPO_ROOT_EXPRS = {"str(repo_root)", "os.getcwd()", "repo_root",
+                    "str(os.getcwd())"}
+
+
+def _claude_p_sites() -> list[tuple[int, str, str]]:
+    """(lineno, schema_key, unparsed cwd expression) for every claude_p call
+    with a literal schema_key. Derived from the AST rather than enumerated:
+    a hand-kept list catches a regression on exactly the sites it names and
+    nothing else, which is the trap PRs #180-#183 each shipped."""
+    tree = ast.parse(MODULE.read_text())
+    out: list[tuple[int, str, str]] = []
+    for n in ast.walk(tree):
+        if not isinstance(n, ast.Call):
+            continue
+        f = n.func
+        name = (f.id if isinstance(f, ast.Name)
+                else getattr(f, "attr", None))
+        if name != "claude_p":
+            continue
+        kw = {k.arg: k for k in n.keywords if k.arg}
+        sk, cw = kw.get("schema_key"), kw.get("cwd")
+        if sk is None or cw is None:
+            continue
+        if not isinstance(sk.value, ast.Constant):
+            continue
+        out.append((n.lineno, sk.value.value, ast.unparse(cw.value)))
+    return out
+
+
+# ---------------------------------------------------------------------------
+# the partition itself
+# ---------------------------------------------------------------------------
+
+class TestWorkerPartition:
+    def test_partition_is_exhaustive_and_disjoint(self, leerie):
+        """Every worker is classified. A new worker therefore forces an
+        explicit decision about which side of the boundary it sits on,
+        instead of defaulting into the permissive one."""
+        planning = set(leerie.PLANNING_WORKER_TYPES)
+        acting = set(leerie.ACTING_WORKER_TYPES)
+        assert planning & acting == set(), (
+            f"a worker is in both buckets: {sorted(planning & acting)}")
+        assert planning | acting == set(leerie.WORKER_TYPES), (
+            "PLANNING_WORKER_TYPES | ACTING_WORKER_TYPES must cover "
+            f"WORKER_TYPES exactly; unclassified: "
+            f"{sorted(set(leerie.WORKER_TYPES) - planning - acting)}")
+
+    def test_the_workers_that_actually_write_code_are_not_in_the_planning_bucket(
+            self, leerie):
+        """Anti-vacuity for the sweep below: if `implementer` ever landed in
+        PLANNING_WORKER_TYPES the cwd sweep would still pass (implementers
+        already run in a worktree) while silently stripping the permission
+        flag that makes unattended execution work at all."""
+        for w in ("implementer", "conformer", "integrator", "rebaser"):
+            assert w not in leerie.PLANNING_WORKER_TYPES
+
+
+# ---------------------------------------------------------------------------
+# L2 — no judgment worker is handed the real checkout (static sweep)
+# ---------------------------------------------------------------------------
+
+class TestNoJudgmentWorkerRunsInTheCheckout:
+    def test_scan_finds_the_call_sites(self, leerie):
+        """A scan that matches nothing certifies everything."""
+        sites = _claude_p_sites()
+        assert len(sites) >= 20, (
+            f"only {len(sites)} claude_p sites found — the AST scan is broken")
+        seen = {s for _, s, _ in sites}
+        assert "implementer" in seen and "conformer" in seen, (
+            "the scan did not see the acting workers; it is not reading the "
+            "real call sites")
+        assert seen & set(leerie.PLANNING_WORKER_TYPES), (
+            "the scan saw no judgment workers at all")
+
+    def test_no_planning_worker_is_given_the_real_repo_root(self, leerie):
+        bad = [(ln, sk, cwd) for ln, sk, cwd in _claude_p_sites()
+               if sk in leerie.PLANNING_WORKER_TYPES
+               and cwd in _REPO_ROOT_EXPRS]
+        assert not bad, (
+            "judgment workers must run in the disposable worktree, never the "
+            f"user's checkout (DESIGN §12): {bad}")
+
+    def test_acting_workers_are_untouched(self, leerie):
+        """The change must not have swept the acting workers along with it —
+        they legitimately run in the worktree they own, named by a local."""
+        acting = [(ln, sk, cwd) for ln, sk, cwd in _claude_p_sites()
+                  if sk in leerie.ACTING_WORKER_TYPES]
+        assert acting, "no acting-worker call sites found"
+        for ln, sk, cwd in acting:
+            assert cwd not in _REPO_ROOT_EXPRS, (
+                f"acting worker {sk} at line {ln} runs in the real checkout")
+
+
+# ---------------------------------------------------------------------------
+# behavioural: drive the real claude_p and read the argv it builds
+# ---------------------------------------------------------------------------
+
+class _FakeState:
+    def __init__(self, tmp_path, repo_root, *, skip_perms=False):
+        self.path = tmp_path / "runs" / "r1" / "state.json"
+        self.run_dir = self.path.parent
+        self.run_dir.mkdir(parents=True, exist_ok=True)
+        self.run_id = "r1"
+        self.repo_root = repo_root
+        self.data = {"verbosity": "quiet",
+                     "dangerously_skip_permissions": skip_perms}
+
+    def bump_workers(self, *a, **k):
+        pass
+
+    def add_telemetry(self, *a, **k):
+        pass
+
+
+_OK = {"type": "result", "subtype": "success", "is_error": False,
+       "result": "{}", "structured_output": {"categories": ["testing"]}}
+
+
+def _drive(leerie, monkeypatch, tmp_path, *, schema_key, cwd, repo_root,
+           skip_perms=False, autonomous=False, allowed_tools="Read"):
+    """Run the REAL claude_p with only `_invoke` stubbed, and return the argv
+    it constructed. Stubbing claude_p itself would prove nothing — a stub
+    accepts any argv, which is precisely why this class of bug survives a
+    green suite (see tests/test_claude_p_call_sites.py's header)."""
+    seen: dict = {}
+
+    async def fake_invoke(cmd, cwd, timeout, sid, leerie_dir, verbosity,
+                          stdin_data=None, **kwargs):
+        seen["cmd"] = list(cmd)
+        seen["cwd"] = cwd
+        return dict(_OK)
+
+    monkeypatch.setattr(leerie, "_invoke", fake_invoke)
+    monkeypatch.setattr(leerie, "_capture_call", lambda *a, **k: None)
+    monkeypatch.setattr(leerie, "_append_system_prompt_file_supported",
+                        lambda: False)
+
+    async def run():
+        return await leerie.claude_p(
+            "u", "s", schema_key=schema_key, cwd=cwd,
+            allowed_tools=allowed_tools, max_turns=5, autonomous=autonomous,
+            caps=dict(leerie.DEFAULT_CAPS),
+            st=_FakeState(tmp_path, repo_root, skip_perms=skip_perms),
+            model="sonnet", sid=schema_key)
+
+    asyncio.run(run())
+    return seen
+
+
+class TestL1PermissionFlag:
+    """The load-bearing layer: the flag is unreachable for judgment workers."""
+
+    def test_judgment_worker_never_gets_the_flag_even_when_set(
+            self, leerie, tmp_path, monkeypatch):
+        seen = _drive(leerie, monkeypatch, tmp_path, schema_key="planner",
+                      cwd=str(tmp_path / "wt"), repo_root=tmp_path / "repo",
+                      skip_perms=True, autonomous=False)
+        assert "--dangerously-skip-permissions" not in seen["cmd"], (
+            "a judgment worker was handed the permission bypass; measured, "
+            "that lets it Write outside its cwd and commit on the user's "
+            "branch")
+
+    def test_acting_worker_still_gets_the_flag(
+            self, leerie, tmp_path, monkeypatch):
+        """The positive control. Without it, this file would pass against a
+        claude_p that never emits the flag for anyone — which would break
+        unattended execution entirely."""
+        seen = _drive(leerie, monkeypatch, tmp_path, schema_key="implementer",
+                      cwd=str(tmp_path / "wt"), repo_root=tmp_path / "repo",
+                      skip_perms=False, autonomous=True)
+        assert "--dangerously-skip-permissions" in seen["cmd"]
+
+    def test_flag_state_does_not_change_the_acting_worker_argv(
+            self, leerie, tmp_path, monkeypatch):
+        """`autonomous` alone decides. Pinning this stops a future edit from
+        re-introducing the OR that caused the incident."""
+        on = _drive(leerie, monkeypatch, tmp_path, schema_key="implementer",
+                    cwd=str(tmp_path / "wt"), repo_root=tmp_path / "repo",
+                    skip_perms=True, autonomous=True)
+        off = _drive(leerie, monkeypatch, tmp_path, schema_key="implementer",
+                     cwd=str(tmp_path / "wt"), repo_root=tmp_path / "repo",
+                     skip_perms=False, autonomous=True)
+        assert on["cmd"] == off["cmd"]
+
+
+class TestCwdGuard:
+    def test_judgment_worker_in_the_real_checkout_is_refused(
+            self, leerie, tmp_path, monkeypatch):
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        with pytest.raises(ValueError, match="disposable worktree"):
+            _drive(leerie, monkeypatch, tmp_path, schema_key="planner",
+                   cwd=str(repo), repo_root=repo)
+
+    def test_the_same_worker_elsewhere_reaches_invoke(
+            self, leerie, tmp_path, monkeypatch):
+        """Positive control: the negative above is also satisfied by a
+        claude_p that raises unconditionally."""
+        repo, wt = tmp_path / "repo", tmp_path / "wt"
+        repo.mkdir(), wt.mkdir()
+        seen = _drive(leerie, monkeypatch, tmp_path, schema_key="planner",
+                      cwd=str(wt), repo_root=repo)
+        assert seen["cwd"] == str(wt)
+
+    def test_guard_is_path_based_not_string_based(
+            self, leerie, tmp_path, monkeypatch):
+        """`realpath`, not string equality — a trailing slash or a symlinked
+        state root would otherwise walk straight through it."""
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        with pytest.raises(ValueError):
+            _drive(leerie, monkeypatch, tmp_path, schema_key="classifier",
+                   cwd=str(repo) + "/", repo_root=repo)
+
+    def test_post_execution_satisfied_probe_rescue_is_not_refused(
+            self, leerie, tmp_path, monkeypatch):
+        """`satisfied_probe` runs twice: pre-schedule in the judgment
+        worktree, and again after execution against a SUBTASK worktree. The
+        guard is phrased "not the real checkout" rather than "equals the
+        planning worktree" precisely so the second call needs no special
+        case — pin that, or a future simplification breaks it."""
+        repo, sub = tmp_path / "repo", tmp_path / "sub-wt"
+        repo.mkdir(), sub.mkdir()
+        seen = _drive(leerie, monkeypatch, tmp_path,
+                      schema_key="satisfied_probe", cwd=str(sub),
+                      repo_root=repo)
+        assert seen["cwd"] == str(sub)
+
+
+class TestL3AllowlistWidening:
+    """The escape hatch, re-expressed: more tools, same boundary."""
+
+    @staticmethod
+    def _repo_with_blt(tmp_path):
+        repo = tmp_path / "repo"
+        (repo / ".leerie").mkdir(parents=True)
+        (repo / ".leerie" / "config.toml").write_text(
+            'build = "pnpm run build"\n'
+            'lint = "biome check ."\n'
+            'test = "vitest run"\n')
+        return repo
+
+    def _allowed(self, seen) -> str:
+        cmd = seen["cmd"]
+        return cmd[cmd.index("--allowedTools") + 1]
+
+    def test_flag_widens_the_allowlist_with_the_repo_build_verbs(
+            self, leerie, tmp_path, monkeypatch):
+        repo = self._repo_with_blt(tmp_path)
+        seen = _drive(leerie, monkeypatch, tmp_path, schema_key="planner",
+                      cwd=str(tmp_path / "wt"), repo_root=repo,
+                      skip_perms=True, allowed_tools=leerie.INSPECT_TOOLS)
+        allowed = self._allowed(seen)
+        for verb in ("pnpm", "biome", "vitest"):
+            assert f"Bash({verb}:*)" in allowed, (
+                f"{verb} missing from the widened allowlist: {allowed}")
+
+    def test_without_the_flag_the_allowlist_is_untouched(
+            self, leerie, tmp_path, monkeypatch):
+        """The anti-vacuity partner: if widening happened unconditionally the
+        test above would pass while the flag meant nothing."""
+        repo = self._repo_with_blt(tmp_path)
+        seen = _drive(leerie, monkeypatch, tmp_path, schema_key="planner",
+                      cwd=str(tmp_path / "wt"), repo_root=repo,
+                      skip_perms=False, allowed_tools=leerie.INSPECT_TOOLS)
+        assert self._allowed(seen) == leerie.INSPECT_TOOLS
+
+    def test_widening_never_adds_a_writer(self, leerie, tmp_path, monkeypatch):
+        """Widening grants build verbs, not file tools. `Write`/`Edit`
+        reaching a judgment worker is the original incident."""
+        repo = self._repo_with_blt(tmp_path)
+        seen = _drive(leerie, monkeypatch, tmp_path, schema_key="planner",
+                      cwd=str(tmp_path / "wt"), repo_root=repo,
+                      skip_perms=True, allowed_tools=leerie.INSPECT_TOOLS)
+        entries = self._allowed(seen).split(",")
+        assert "Write" not in entries and "Edit" not in entries
+        assert "Bash" not in entries, "a bare Bash wildcard defeats the point"
+
+    def test_the_satisfied_probe_bucket_is_never_widened(
+            self, leerie, tmp_path, monkeypatch):
+        """`SATISFIED_PROBE_TOOLS` is deliberately narrower than
+        `INSPECT_TOOLS`, and its narrowness is calibrated rather than
+        incidental: 12/12 false positives with full INSPECT_TOOLS latitude
+        against 0 when scoped to the base tree, where a false positive
+        silently deletes real work. An earlier revision of the widening
+        applied to every judgment worker and handed the probe
+        `Bash(pytest:*)` on this very repo."""
+        repo = self._repo_with_blt(tmp_path)
+        seen = _drive(leerie, monkeypatch, tmp_path,
+                      schema_key="satisfied_probe",
+                      cwd=str(tmp_path / "wt"), repo_root=repo,
+                      skip_perms=True,
+                      allowed_tools=leerie.SATISFIED_PROBE_TOOLS)
+        assert self._allowed(seen) == leerie.SATISFIED_PROBE_TOOLS
+
+    def test_the_planner_bucket_IS_widened_under_the_same_conditions(
+            self, leerie, tmp_path, monkeypatch):
+        """Anti-vacuity partner: without it the test above passes against a
+        widening that was accidentally disabled everywhere."""
+        repo = self._repo_with_blt(tmp_path)
+        seen = _drive(leerie, monkeypatch, tmp_path, schema_key="planner",
+                      cwd=str(tmp_path / "wt"), repo_root=repo,
+                      skip_perms=True, allowed_tools=leerie.INSPECT_TOOLS)
+        assert self._allowed(seen) != leerie.INSPECT_TOOLS
+
+    def test_env_assignments_are_not_mistaken_for_the_executable(
+            self, leerie, tmp_path):
+        repo = tmp_path / "repo"
+        (repo / ".leerie").mkdir(parents=True)
+        (repo / ".leerie" / "config.toml").write_text(
+            'build = "CI=1 NODE_ENV=production pnpm build"\n'
+            'lint = ""\n'
+            'test = ""\n')
+        assert leerie._blt_verbs(repo) == ["pnpm"]
+
+    def test_non_invoking_prefixes_are_stepped_over(self, leerie, tmp_path):
+        """`timeout 90 …`, `cd x && …` and `VAR=v …` do not change what a
+        command invokes. Granting `Bash(timeout:*)` instead of the real verb
+        would leave the planner unable to run the build it was just granted
+        — the exact degradation the widening exists to prevent."""
+        repo = tmp_path / "repo"
+        (repo / ".leerie").mkdir(parents=True)
+        (repo / ".leerie" / "config.toml").write_text(
+            'build = "timeout 90 pnpm build"\n'
+            'lint = "CI=1 NODE_ENV=production biome check ."\n'
+            'test = "cd packages/api && vitest run"\n')
+        assert leerie._blt_verbs(repo) == ["pnpm", "biome", "vitest"]
+
+    def test_verbs_are_memoized_per_repo(self, leerie, tmp_path, monkeypatch):
+        """`resolve_blt` reads config, runs inference and LOGS. Called once
+        per judgment worker that is dozens of identical log lines and dozens
+        of redundant reads, so the result is cached per repo."""
+        repo = self._repo_with_blt(tmp_path)
+        calls = {"n": 0}
+        real = leerie.resolve_blt
+
+        def counting(root):
+            calls["n"] += 1
+            return real(root)
+
+        monkeypatch.setattr(leerie, "resolve_blt", counting)
+        leerie._blt_verbs(repo)
+        leerie._blt_verbs(repo)
+        leerie._blt_verbs(repo)
+        assert calls["n"] == 1
+
+    def test_unparseable_command_is_skipped_not_guessed(
+            self, leerie, tmp_path):
+        """A wrong verb widens the wrong thing, so an axis that cannot be
+        tokenised is dropped rather than approximated.
+
+        Note the payload has to be genuinely unbalanced: a backslash-escaped
+        quote (`pnpm run \\"x`) parses fine, so an earlier version of this
+        test exercised the happy path and asserted nothing."""
+        repo = tmp_path / "repo"
+        (repo / ".leerie").mkdir(parents=True)
+        (repo / ".leerie" / "config.toml").write_text(
+            "build = \"pnpm run 'unbalanced\"\n" 'lint = ""\n' 'test = ""\n')
+        with pytest.raises(ValueError):
+            __import__("shlex").split("pnpm run 'unbalanced")
+        assert "Bash(pnpm:*)" not in leerie._widen_inspect_tools(
+            leerie.INSPECT_TOOLS, repo)
+
+
+class TestJudgmentCwdFallback:
+    """`_judgment_cwd` is a lookup, not the enforcement — so it falls back
+    rather than raising when the key is absent, and the fallback is chosen so
+    it CANNOT be the thing the guarantee forbids."""
+
+    def test_fallback_is_under_the_run_dir_never_the_checkout(
+            self, leerie, tmp_path):
+        st = _FakeState(tmp_path, tmp_path / "repo")
+        st.data.pop("planning_worktree", None)
+        got = leerie._judgment_cwd(st)
+        assert str(st.run_dir) in got
+        assert got != str(st.repo_root)
+
+    def test_the_fallback_still_trips_the_claude_p_guard_if_it_ever_matched(
+            self, leerie, tmp_path, monkeypatch):
+        """The property that makes the fallback safe: enforcement lives in
+        claude_p, not here. Drive a judgment worker at the checkout directly
+        and confirm it is still refused — that is what the fallback relies on
+        being true."""
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        with pytest.raises(ValueError):
+            _drive(leerie, monkeypatch, tmp_path, schema_key="reconciler",
+                   cwd=str(repo), repo_root=repo)
+
+    def test_an_explicit_path_wins_over_the_fallback(self, leerie, tmp_path):
+        st = _FakeState(tmp_path, tmp_path / "repo")
+        st.data["planning_worktree"] = "/somewhere/explicit"
+        assert leerie._judgment_cwd(st) == "/somewhere/explicit"
+
+
+class TestWiring:
+    def test_claude_p_docstring_states_the_flag_is_unreachable(self, leerie):
+        """The docstring is what the next reader trusts; it said the opposite
+        for the whole life of the bug."""
+        src = inspect.getdoc(leerie.claude_p) or ""
+        assert "never" in src.lower() and "PLANNING_WORKER_TYPES" in src
+
+    def test_skip_perms_is_not_an_or_over_state(self, leerie):
+        """Source-coupling on the exact shape that caused the incident:
+        `autonomous or st.data.get("dangerously_skip_permissions")`."""
+        src = inspect.getsource(leerie.claude_p)
+        assert 'autonomous or bool(' not in src, (
+            "the OR that granted judgment workers the permission bypass is "
+            "back")

--- a/tests/test_phase_overlap_judge.py
+++ b/tests/test_phase_overlap_judge.py
@@ -1478,7 +1478,9 @@ def test_backstop_die_on_logic_bug(leerie, monkeypatch, capsys):
 
     class _St:
         def __init__(self):
-            self.data = {}
+            # judgment workers run in a disposable worktree
+            # (DESIGN §12), never the user's checkout
+            self.data = {"planning_worktree": "/tmp/leerie-test-wt"}
 
         def save(self):
             pass
@@ -2384,7 +2386,8 @@ def test_phase_overlap_judge_dies_on_unresolvable(leerie, monkeypatch,
         def __init__(self):
             # Pre-set: the scoped re-plan has already been attempted, so this
             # is the second verdict — the one that must still be terminal.
-            self.data = {"overlap_replan_done": True}
+            self.data = {"overlap_replan_done": True,
+                         "planning_worktree": "/tmp/leerie-test-wt"}
 
         def save(self):
             pass
@@ -2465,7 +2468,9 @@ def _run_phase_overlap_judge(leerie, monkeypatch, plans, collisions):
     rather than reproduced in the test."""
     class _St:
         def __init__(self):
-            self.data = {}
+            # judgment workers run in a disposable worktree
+            # (DESIGN §12), never the user's checkout
+            self.data = {"planning_worktree": "/tmp/leerie-test-wt"}
 
         def save(self):
             pass
@@ -2933,7 +2938,14 @@ class _CovSt:
     the loop outright."""
 
     def __init__(self, data=None):
-        self.data = data if data is not None else {}
+        # `planning_worktree` is the cwd every judgment worker runs in
+        # (DESIGN §12 *Judgment-worker isolation*): they are confined to a
+        # disposable worktree, never the user's checkout. Seeded by default
+        # so a caller passing its own `data` still gets a usable State,
+        # while an explicit key still wins.
+        base = {"planning_worktree": "/tmp/leerie-test-wt"}
+        base.update(data or {})
+        self.data = base
         self._worker_count = 0
 
     def save(self):

--- a/tests/test_planning_worktree_script.py
+++ b/tests/test_planning_worktree_script.py
@@ -1,0 +1,231 @@
+"""`scripts/planning-worktree.sh` — the disposable tree judgment workers run in
+(DESIGN §12 *Judgment-worker isolation*, L2).
+
+Real git repositories throughout, and the script itself rather than a
+reproduction of it: a hand-copied block is body-blind by construction, which is
+the trap `tests/test_no_duplicate_launcher_blocks.py` exists to prevent.
+
+The two behaviours that are easy to get wrong and expensive to get wrong:
+
+  * **reset, not reuse.** The satisfied-probe is handed no diff — its prompt
+    tells it to judge "the CURRENT working tree / HEAD", so its cwd is the only
+    thing determining what it sees. A tree an earlier judgment worker wrote
+    into would make it answer "already satisfied" and silently drop real work.
+  * **`clean -fd`, never `-fdx`.** Gitignored content (node_modules, .venv)
+    must survive or every resume re-pays the install.
+"""
+from __future__ import annotations
+
+import subprocess
+
+import pytest
+
+
+SCRIPT = "scripts/planning-worktree.sh"
+
+
+def _git(repo, *args):
+    return subprocess.run(["git", "-C", str(repo), *args],
+                          capture_output=True, text=True, check=False)
+
+
+def _repo(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir(parents=True)
+    _git(repo, "init", "-q", ".")
+    _git(repo, "config", "user.email", "t@t")
+    _git(repo, "config", "user.name", "t")
+    (repo / "src.txt").write_text("original\n")
+    (repo / ".gitignore").write_text("node_modules/\n")
+    (repo / "node_modules").mkdir()
+    (repo / "node_modules" / "dep.txt").write_text("dep\n")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "init")
+    return repo
+
+
+def _run(repo, state_dir, run_id="r1"):
+    import pathlib
+    script = pathlib.Path(__file__).resolve().parents[1] / SCRIPT
+    return subprocess.run(
+        ["bash", str(script), run_id], cwd=str(repo), capture_output=True,
+        text=True, env={"PATH": "/usr/bin:/bin", "HOME": str(repo),
+                        "LEERIE_STATE_DIR": str(state_dir)})
+
+
+@pytest.fixture()
+def env(tmp_path):
+    repo = _repo(tmp_path)
+    state = tmp_path / "state"
+    wt = state / "runs" / "r1" / "worktrees" / "planning"
+    return repo, state, wt
+
+
+class TestCreate:
+    def test_creates_a_detached_worktree_at_head(self, env):
+        repo, state, wt = env
+        r = _run(repo, state)
+        assert r.returncode == 0, r.stderr
+        assert wt.is_dir()
+        # detached: symbolic-ref fails on a detached HEAD
+        assert _git(wt, "symbolic-ref", "-q", "HEAD").returncode != 0
+        assert (_git(wt, "rev-parse", "HEAD").stdout.strip()
+                == _git(repo, "rev-parse", "HEAD").stdout.strip())
+
+    def test_creates_no_branch(self, env):
+        """The reapers (cleanup.sh, _cleanup_on_abnormal_exit, `leerie prune`)
+        know only `leerie/runs/<id>` and `leerie/subtasks/<id>/`. A fourth
+        namespace would leak forever — the stale-branch problem `prune` was
+        written to fix. This test is what fails if someone "improves" the
+        script to use `-b`."""
+        repo, state, _ = env
+        before = _git(repo, "for-each-ref", "--format=%(refname)",
+                      "refs/heads").stdout
+        _run(repo, state)
+        after = _git(repo, "for-each-ref", "--format=%(refname)",
+                     "refs/heads").stdout
+        assert before == after, f"refs changed: {before!r} -> {after!r}"
+
+    def test_prints_the_absolute_path(self, env):
+        repo, state, wt = env
+        r = _run(repo, state)
+        line = r.stdout.strip().splitlines()[-1]
+        assert line.startswith("planning-worktree: /")
+        assert line.split("planning-worktree:", 1)[1].strip() == str(
+            wt.resolve())
+
+
+class TestResetOnReentry:
+    def test_worker_changes_are_discarded(self, env):
+        repo, state, wt = env
+        _run(repo, state)
+        (wt / "src.txt").write_text("TAMPERED\n")
+        (wt / "invented.txt").write_text("junk\n")
+        _run(repo, state)
+        assert (wt / "src.txt").read_text() == "original\n"
+        assert not (wt / "invented.txt").exists()
+
+    def test_a_worker_commit_is_discarded(self, env):
+        repo, state, wt = env
+        _run(repo, state)
+        (wt / "src.txt").write_text("TAMPERED\n")
+        _git(wt, "add", "-A")
+        _git(wt, "-c", "user.email=x@x", "-c", "user.name=x",
+             "commit", "-qm", "worker")
+        _run(repo, state)
+        assert (_git(wt, "rev-parse", "HEAD").stdout.strip()
+                == _git(repo, "rev-parse", "HEAD").stdout.strip())
+
+    def test_head_drift_is_corrected(self, env):
+        """The resume hazard: the real checkout's HEAD moves across a pause
+        (a sibling run merging its PR). A worktree pinned at the old sha would
+        plan against a tree that no longer exists."""
+        repo, state, wt = env
+        _run(repo, state)
+        (repo / "src.txt").write_text("newer\n")
+        _git(repo, "add", "-A")
+        _git(repo, "commit", "-qm", "second")
+        _run(repo, state)
+        assert (wt / "src.txt").read_text() == "newer\n"
+        assert (_git(wt, "rev-parse", "HEAD").stdout.strip()
+                == _git(repo, "rev-parse", "HEAD").stdout.strip())
+
+    def test_gitignored_content_survives_the_reset(self, env):
+        """`clean -fd`, not `-fdx`. Without this every resume re-pays a full
+        install; the comment in the script says so, and this is what makes
+        that comment enforceable."""
+        repo, state, wt = env
+        _run(repo, state)
+        (wt / "node_modules").mkdir(exist_ok=True)
+        (wt / "node_modules" / "dep.txt").write_text("installed\n")
+        _run(repo, state)
+        assert (wt / "node_modules" / "dep.txt").read_text() == "installed\n"
+
+    def test_untracked_and_ignored_are_treated_differently(self, env):
+        """Anti-vacuity partner for the two tests above: they would both pass
+        against a script that cleans nothing at all."""
+        repo, state, wt = env
+        _run(repo, state)
+        (wt / "plain_untracked.txt").write_text("x\n")
+        (wt / "node_modules").mkdir(exist_ok=True)
+        (wt / "node_modules" / "keep.txt").write_text("y\n")
+        _run(repo, state)
+        assert not (wt / "plain_untracked.txt").exists()
+        assert (wt / "node_modules" / "keep.txt").exists()
+
+
+class TestNoRealWorktreeInThisRepo:
+    """`_ensure_planning_worktree` shells out to a real `git worktree add`
+    rooted at `resolve_leerie_root()`, which with `LEERIE_STATE_DIR` unset is
+    `<repo>/.leerie`. Every test driving the real `_run_phases` therefore
+    created a full checkout of this repo inside this repo.
+
+    It was invisible three ways over: `.leerie/*` is gitignored so
+    `git status` stayed clean, the directories outlived the session, and the
+    damage surfaced in `test_helper_naming_convention` — whose `tests/`
+    exclusion is a relative-path prefix that a nested
+    `.leerie/.../worktrees/planning/tests/...` copy does not match. Measured:
+    two worktrees, 25 MB, one red test with no visible link to its cause."""
+
+    def test_conftest_stubs_it_by_default(self):
+        import pathlib as _p
+        src = (_p.Path(__file__).resolve().parents[0]
+               / "conftest.py").read_text()
+        assert "_no_real_planning_worktree" in src
+        i = src.index("def _no_real_planning_worktree")
+        assert "autouse=True" in src[max(0, i - 200):i]
+        assert "_ensure_planning_worktree" in src[i:i + 2000], (
+            "the fixture no longer stubs the function it exists to stub")
+
+    def test_driving_it_creates_no_worktree_in_this_repo(self, leerie,
+                                                         tmp_path):
+        """Behavioural partner: the source check above passes against a
+        fixture that stubs the wrong thing."""
+        before = subprocess.run(
+            ["git", "worktree", "list", "--porcelain"],
+            capture_output=True, text=True, check=False).stdout
+
+        class _St:
+            run_dir = tmp_path / "run"
+            run_id = "guard"
+            data: dict = {}
+
+            def save(self):
+                pass
+
+        import asyncio
+        asyncio.run(leerie._ensure_planning_worktree(_St()))
+        after = subprocess.run(
+            ["git", "worktree", "list", "--porcelain"],
+            capture_output=True, text=True, check=False).stdout
+        assert before == after, (
+            "a real git worktree was registered against this repo; the "
+            "conftest guard is not in effect")
+
+
+class TestRepair:
+    def test_orphaned_directory_is_removed_and_recreated(self, env):
+        """A SIGKILLed container leaves the directory without its admin
+        entry; `worktree add` then refuses with "already exists" on every
+        subsequent resume, and neither `prune` nor `--force` covers it."""
+        repo, state, wt = env
+        _run(repo, state)
+        _git(repo, "worktree", "remove", "--force", str(wt))
+        wt.mkdir(parents=True)
+        (wt / "stale.txt").write_text("left behind\n")
+        r = _run(repo, state)
+        assert r.returncode == 0, r.stderr
+        assert (wt / "src.txt").exists()
+        assert not (wt / "stale.txt").exists()
+
+    def test_fails_outside_a_git_repository(self, tmp_path):
+        import pathlib
+        script = pathlib.Path(__file__).resolve().parents[1] / SCRIPT
+        d = tmp_path / "nope"
+        d.mkdir()
+        r = subprocess.run(["bash", str(script), "r1"], cwd=str(d),
+                           capture_output=True, text=True,
+                           env={"PATH": "/usr/bin:/bin", "HOME": str(d),
+                                "LEERIE_STATE_DIR": str(tmp_path / "s")})
+        assert r.returncode != 0
+        assert "not inside a git repository" in r.stderr

--- a/tests/test_replan_reruns_upstream_phases.py
+++ b/tests/test_replan_reruns_upstream_phases.py
@@ -117,7 +117,10 @@ def test_no_replan_means_no_extra_phase_calls(leerie, monkeypatch):
     monkeypatch.setattr(leerie, "claude_p", fake_claude_p)
 
     class _St:
-        def __init__(self): self.data = {}
+        def __init__(self):
+            # judgment workers run in a disposable worktree
+            # (DESIGN §12), never the user's checkout
+            self.data = {"planning_worktree": "/tmp/leerie-test-wt"}
         def save(self): pass
         def bump_workers(self, caps): pass
 

--- a/tests/test_satisfied_probe_cache.py
+++ b/tests/test_satisfied_probe_cache.py
@@ -43,6 +43,11 @@ def _make_state(leerie, run_dir: Path):
     st.run_dir = run_dir
     st.path = run_dir / "state.json"
     st.data = {
+        # Judgment workers now run in a disposable worktree
+        # (DESIGN §12 *Judgment-worker isolation*); `_judgment_cwd`
+        # raises rather than silently falling back to the real
+        # checkout, so every State fixture must seed the path.
+        "planning_worktree": str(run_dir / "worktrees" / "planning"),
         "telemetry": {"calls": 0, "cost_usd": 0.0,
                       "input_tokens": 0, "output_tokens": 0},
         "verbosity": "quiet",

--- a/tests/test_satisfied_probe_cache_invalidation.py
+++ b/tests/test_satisfied_probe_cache_invalidation.py
@@ -43,6 +43,11 @@ def _make_state(leerie, run_dir: Path):
     st.run_dir = run_dir
     st.path = run_dir / "state.json"
     st.data = {
+        # Judgment workers now run in a disposable worktree
+        # (DESIGN §12 *Judgment-worker isolation*); `_judgment_cwd`
+        # raises rather than silently falling back to the real
+        # checkout, so every State fixture must seed the path.
+        "planning_worktree": str(run_dir / "worktrees" / "planning"),
         "telemetry": {"calls": 0, "cost_usd": 0.0,
                       "input_tokens": 0, "output_tokens": 0},
         "verbosity": "quiet",

--- a/tests/test_wiring_gate_repair.py
+++ b/tests/test_wiring_gate_repair.py
@@ -446,7 +446,10 @@ def test_gate_repairs_then_passes_and_records(leerie, monkeypatch, tmp_path):
     monkeypatch.setattr(leerie, "claude_p", fake_claude_p)
 
     class _St:
-        def __init__(self): self.data = {}
+        def __init__(self):
+            # `_judgment_cwd` reads this; judgment workers run in a
+            # disposable worktree (DESIGN §12), never the checkout.
+            self.data = {"planning_worktree": "/tmp/leerie-test-wt"}
         def save(self): pass
         def bump_workers(self, caps): pass
 
@@ -471,7 +474,10 @@ def test_gate_still_dies_on_unrepairable(leerie, monkeypatch):
     monkeypatch.setattr(leerie, "claude_p", fake_claude_p)
 
     class _St:
-        def __init__(self): self.data = {}
+        def __init__(self):
+            # `_judgment_cwd` reads this; judgment workers run in a
+            # disposable worktree (DESIGN §12), never the checkout.
+            self.data = {"planning_worktree": "/tmp/leerie-test-wt"}
         def save(self): pass
         def bump_workers(self, caps): pass
 
@@ -494,7 +500,10 @@ def test_gate_logs_the_id_channel_repair(leerie, monkeypatch, capsys):
     monkeypatch.setattr(leerie, "claude_p", fake_claude_p)
 
     class _St:
-        def __init__(self): self.data = {}
+        def __init__(self):
+            # `_judgment_cwd` reads this; judgment workers run in a
+            # disposable worktree (DESIGN §12), never the checkout.
+            self.data = {"planning_worktree": "/tmp/leerie-test-wt"}
         def save(self): pass
         def bump_workers(self, caps): pass
 
@@ -527,7 +536,10 @@ def test_gate_logs_the_cofile_cluster_repair(leerie, monkeypatch, capsys):
     monkeypatch.setattr(leerie, "claude_p", fake_claude_p)
 
     class _St:
-        def __init__(self): self.data = {}
+        def __init__(self):
+            # `_judgment_cwd` reads this; judgment workers run in a
+            # disposable worktree (DESIGN §12), never the checkout.
+            self.data = {"planning_worktree": "/tmp/leerie-test-wt"}
         def save(self): pass
         def bump_workers(self, caps): pass
 
@@ -561,7 +573,9 @@ def test_gate_logs_a_provably_false_finding_as_discarded(leerie, monkeypatch,
     monkeypatch.setattr(leerie, "claude_p", fake_claude_p)
 
     class _St:
-        def __init__(self): self.data = {"dropped_subtasks": {}}
+        def __init__(self):
+            self.data = {"dropped_subtasks": {},
+                         "planning_worktree": "/tmp/leerie-test-wt"}
         def save(self): pass
         def bump_workers(self, caps): pass
 

--- a/tests/test_work_sentinel.py
+++ b/tests/test_work_sentinel.py
@@ -1,0 +1,268 @@
+"""DESIGN §12 *Judgment-worker isolation*, L4 — the `/work` sentinel.
+
+This is the layer that is an actual guarantee rather than a strong mitigation,
+so it gets the sharpest tests.
+
+Why it must exist even after judgment workers lose the permission bypass: the
+CLI's working-directory boundary is enforced on tool *arguments*, and an
+allowlisted build verb runs arbitrary code. Measured live — with permissions ON
+and `python3` allowlisted, `python3 -c "open('<outside>','w')"` wrote outside
+the worker's cwd while the `Write` tool aimed at the same path was rejected. So
+a residual escape exists by construction, and this is what catches it.
+
+Modelled on `check_rebaser_worktree_state`: trust the worker, then mechanically
+re-check the claim.
+
+Every assertion here runs against real git repositories. A mocked `git` would
+be testing the mock.
+"""
+from __future__ import annotations
+
+import asyncio
+import inspect
+import subprocess
+
+import pytest
+
+
+def _git(repo, *args):
+    return subprocess.run(["git", "-C", str(repo), *args],
+                          capture_output=True, text=True, check=False)
+
+
+def _init(repo):
+    repo.mkdir(parents=True, exist_ok=True)
+    _git(repo, "init", "-q", ".")
+    _git(repo, "config", "user.email", "t@t")
+    _git(repo, "config", "user.name", "t")
+    (repo / "src.txt").write_text("original\n")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "init")
+    return repo
+
+
+class _St:
+    """Only what the sentinel touches."""
+
+    def __init__(self, repo):
+        self.repo_root = repo
+        self.run_id = "r1"
+        self.data = {}
+
+    def save(self):
+        pass
+
+
+def _snap(leerie, repo):
+    return asyncio.run(leerie._snapshot_repo_state(str(repo)))
+
+
+def _check(leerie, st, phase="phase 1 (classify)"):
+    return asyncio.run(leerie._assert_repo_unchanged(st, phase))
+
+
+# ---------------------------------------------------------------------------
+# the reproduction, and its anti-vacuity partner
+# ---------------------------------------------------------------------------
+
+class TestDetection:
+    def test_a_modified_tracked_file_is_caught_and_named(
+            self, leerie, tmp_path, monkeypatch):
+        """The incident shape: a judgment worker edits a tracked source file
+        in the user's checkout."""
+        repo = _init(tmp_path / "repo")
+        st = _St(repo)
+        st.data["repo_state_before_planning"] = _snap(leerie, repo)
+        (repo / "src.txt").write_text("TAMPERED\n")
+        msgs = []
+        monkeypatch.setattr(leerie, "die",
+                            lambda m, code=1: (_ for _ in ()).throw(
+                                SystemExit(m)))
+        with pytest.raises(SystemExit) as ei:
+            _check(leerie, st)
+        assert "src.txt" in str(ei.value)
+        assert "phase 1 (classify)" in str(ei.value)
+
+    def test_an_untouched_tree_passes(self, leerie, tmp_path, monkeypatch):
+        """Anti-vacuity. The test above is equally satisfied by a sentinel
+        that fires unconditionally, which would make every run die."""
+        repo = _init(tmp_path / "repo")
+        st = _St(repo)
+        st.data["repo_state_before_planning"] = _snap(leerie, repo)
+        monkeypatch.setattr(leerie, "die",
+                            lambda m, code=1: pytest.fail(
+                                f"sentinel fired on a clean tree: {m}"))
+        _check(leerie, st)
+
+    def test_an_untracked_file_is_caught(self, leerie, tmp_path, monkeypatch):
+        """The case `_preflight_repo` structurally cannot see: its clean-tree
+        gate filters `??` lines, so a worker CREATING files passes it. On the
+        run that motivated this feature the task document itself was
+        untracked, so this is not a corner case."""
+        repo = _init(tmp_path / "repo")
+        st = _St(repo)
+        st.data["repo_state_before_planning"] = _snap(leerie, repo)
+        (repo / "invented.txt").write_text("new\n")
+        monkeypatch.setattr(leerie, "die",
+                            lambda m, code=1: (_ for _ in ()).throw(
+                                SystemExit(m)))
+        with pytest.raises(SystemExit) as ei:
+            _check(leerie, st)
+        assert "invented.txt" in str(ei.value)
+
+    def test_a_commit_on_the_users_branch_is_caught(
+            self, leerie, tmp_path, monkeypatch):
+        """Measured: a worker under the old configuration did exactly this —
+        HEAD moved on the branch the operator was sitting on."""
+        repo = _init(tmp_path / "repo")
+        st = _St(repo)
+        st.data["repo_state_before_planning"] = _snap(leerie, repo)
+        (repo / "src.txt").write_text("changed\n")
+        _git(repo, "add", "-A")
+        _git(repo, "commit", "-qm", "worker commit")
+        monkeypatch.setattr(leerie, "die",
+                            lambda m, code=1: (_ for _ in ()).throw(
+                                SystemExit(m)))
+        with pytest.raises(SystemExit) as ei:
+            _check(leerie, st)
+        assert "HEAD moved" in str(ei.value)
+
+
+class TestExemptions:
+    def test_leerie_own_config_write_does_not_fire_it(
+            self, leerie, tmp_path, monkeypatch):
+        """`.leerie/config.toml` is the one committable file the orchestrator
+        writes into the checkout (DESIGN §6½ dep capture). Reporting leerie's
+        own bookkeeping as tampering would make the sentinel fire on healthy
+        runs, and a check that cries wolf gets disabled."""
+        repo = _init(tmp_path / "repo")
+        st = _St(repo)
+        st.data["repo_state_before_planning"] = _snap(leerie, repo)
+        (repo / ".leerie").mkdir()
+        (repo / ".leerie" / "config.toml").write_text('build = "x"\n')
+        monkeypatch.setattr(leerie, "die",
+                            lambda m, code=1: pytest.fail(
+                                f"fired on leerie's own write: {m}"))
+        _check(leerie, st)
+
+    def test_leerie_own_branches_do_not_fire_it(self, leerie, tmp_path):
+        """A run legitimately creates `leerie/runs/<id>` and
+        `leerie/subtasks/<id>/*`. Only refs OUTSIDE that namespace count."""
+        before = {"head": "a", "porcelain": [], "refs": [
+            "refs/heads/main a"]}
+        after = {"head": "a", "porcelain": [], "refs": [
+            "refs/heads/main a", "refs/heads/leerie/runs/r1 a"]}
+        assert leerie._diff_repo_state(before, after) == []
+
+    def test_a_foreign_branch_still_fires_it(self, leerie):
+        """Anti-vacuity for the exemption: it must not swallow every ref."""
+        before = {"head": "a", "porcelain": [], "refs": [
+            "refs/heads/main a"]}
+        after = {"head": "a", "porcelain": [], "refs": [
+            "refs/heads/main a", "refs/heads/worker-invented a"]}
+        deltas = leerie._diff_repo_state(before, after)
+        assert deltas and "worker-invented" in deltas[0]
+
+
+class TestBaselineIdentity:
+    def test_baseline_is_read_from_the_checkout_not_the_worktree(
+            self, leerie, tmp_path, monkeypatch):
+        """Drive it with the two trees DISAGREEING. A fixture where the
+        checkout and the worktree hold the same content cannot tell a correct
+        read from one that silently snapshots the wrong tree."""
+        repo = _init(tmp_path / "repo")
+        other = _init(tmp_path / "other")
+        (other / "src.txt").write_text("DIFFERENT\n")
+        _git(other, "add", "-A")
+        _git(other, "commit", "-qm", "diverge")
+        snap_repo = _snap(leerie, repo)
+        snap_other = _snap(leerie, other)
+        assert snap_repo["head"] != snap_other["head"]
+
+        st = _St(repo)
+        st.data["repo_state_before_planning"] = snap_repo
+        monkeypatch.setattr(leerie, "die",
+                            lambda m, code=1: pytest.fail(f"fired: {m}"))
+        _check(leerie, st)
+
+    def test_absent_baseline_is_a_no_op(self, leerie, tmp_path, monkeypatch):
+        """A run that never captured one (an old state.json resumed under a
+        new leerie) must not die — the sentinel degrades to off rather than
+        blocking recovery."""
+        repo = _init(tmp_path / "repo")
+        st = _St(repo)
+        (repo / "src.txt").write_text("whatever\n")
+        monkeypatch.setattr(leerie, "die",
+                            lambda m, code=1: pytest.fail(f"fired: {m}"))
+        _check(leerie, st)
+
+    def test_an_unreadable_checkout_warns_instead_of_dying(
+            self, leerie, tmp_path, monkeypatch):
+        """"Could not tell" is not "tampered".
+
+        Every probe in `_snapshot_repo_state` returns "" on a non-zero git,
+        so a transiently unreadable checkout yields head="" and refs=[] —
+        which a naive diff reads as "HEAD moved" *plus* "every branch
+        deleted", killing a healthy run on fabricated evidence. Caught by
+        driving the real diff against a failed snapshot, not by inspection."""
+        repo = _init(tmp_path / "repo")
+        st = _St(repo)
+        st.data["repo_state_before_planning"] = _snap(leerie, repo)
+
+        async def failing_snapshot(_root):
+            return {"head": "", "porcelain": [], "refs": [], "ok": False}
+
+        monkeypatch.setattr(leerie, "_snapshot_repo_state", failing_snapshot)
+        monkeypatch.setattr(leerie, "die",
+                            lambda m, code=1: pytest.fail(
+                                f"died on an unreadable checkout: {m}"))
+        _check(leerie, st)
+
+    def test_the_naive_diff_would_have_fired(self, leerie):
+        """Anti-vacuity partner: proves the guard above is load-bearing by
+        showing the underlying diff really does report tampering for that
+        input. Without this, the test above passes against a sentinel that
+        never fires at all."""
+        before = {"head": "abc", "porcelain": [], "refs": ["refs/heads/main abc"]}
+        failed = {"head": "", "porcelain": [], "refs": [], "ok": False}
+        assert leerie._diff_repo_state(before, failed), (
+            "the diff no longer reports a failed snapshot as change; the "
+            "`ok` guard may now be untested")
+
+    def test_snapshot_records_success(self, leerie, tmp_path):
+        repo = _init(tmp_path / "repo")
+        assert _snap(leerie, repo)["ok"] is True
+
+    def test_snapshot_round_trips_through_json(self, leerie, tmp_path):
+        """It is persisted in state.json, so it must survive serialization —
+        a set or a Path here would raise at `st.save()` on every run."""
+        import json
+        repo = _init(tmp_path / "repo")
+        snap = _snap(leerie, repo)
+        assert json.loads(json.dumps(snap)) == snap
+
+
+class TestWiring:
+    def test_sentinel_runs_after_every_planning_checkpoint(self, leerie):
+        """Per-phase, not once at the end: the point is to fire within one
+        worker of the damage rather than after the whole planning spend."""
+        src = inspect.getsource(leerie._run_phases)
+        n = src.count("_assert_repo_unchanged(st,")
+        assert n >= 6, (
+            f"only {n} sentinel checks in _run_phases; every planning phase "
+            "checkpoint should be followed by one")
+
+    def test_baseline_is_captured_before_the_first_worker(self, leerie):
+        """It must precede phase_classify, or the baseline already includes
+        whatever the classifier did."""
+        src = inspect.getsource(leerie._run_phases)
+        i_base = src.index('"repo_state_before_planning"')
+        i_classify = src.index("await phase_classify(")
+        assert i_base < i_classify
+
+    def test_baseline_is_not_recaptured_on_resume(self, leerie):
+        """Guarded on absence, so a resume compares against the ORIGINAL
+        tree. Re-snapshotting would launder a modification made by an earlier
+        planning pass into the new baseline."""
+        src = inspect.getsource(leerie._run_phases)
+        assert '"repo_state_before_planning" not in st.data' in src


### PR DESCRIPTION
## The failure

A run on a downstream repo left three modified files in the operator's real checkout, on `main`. The worker was the **classifier** — a judgment worker whose prompt says it "runs read-only". It implemented the entire task from the task file, edited a test to match it, ran a repo-wide `lint:fix`, ran `git stash`/`git stash pop`, and then died at its turn cap.

`Edit` is not in `INSPECT_TOOLS`. It was reachable because `--dangerously-skip-permissions` bypasses `--allowedTools` entirely, and that flag was OR'd into every judgment worker's argv.

## What the experiments changed

The design was settled by probing the CLI, not by reading its docs. Four live `claude -p` runs (2.1.237), ground truth taken from the filesystem:

| configuration | Write in cwd | Write outside cwd | Bash write outside cwd |
|---|---|---|---|
| `INSPECT_TOOLS`, flag **on** | succeeded | succeeded | succeeded |
| `INSPECT_TOOLS`, flag **off** | rejected | rejected | rejected |

And in the exact configuration this PR was **first drafted as** — cwd set to a detached worktree, flag still on — the worker overwrote a tracked file in the real checkout *and committed on its branch*.

That result reordered the change. A worktree is not a boundary while the flag is set; it is where the boundary lands once the flag is gone.

## Four layers

- **L1** — `claude_p` appends the flag on `autonomous` alone. Judgment workers cannot receive it at any setting. This is the layer that does the work.
- **L2** — judgment workers run in a disposable detached worktree, created before `phase_classify` and reset again before the satisfied-probe sweep (the probe judges whatever tree its cwd points at, and is handed no diff). `clean -fd`, never `-fdx`, so gitignored deps survive a resume.
- **L3** — the operator's flag now **widens the allowlist** with the repo's declared build/lint/test verbs instead of bypassing permissions. That is the tooling visibility it was always documented to buy, without the write access that was never the point.
- **L4** — snapshot the checkout's HEAD/porcelain/refs before phase 1, re-check after all seven planning checkpoints, `die()` on any delta. Modelled on `check_rebaser_worktree_state`.

**L4 is the actual guarantee, and the residual is stated rather than hidden.** L3 knowingly leaves a build verb able to write outside its cwd — measured, `python3 -c "open('<outside>','w')"` succeeded where the `Write` tool aimed at the same path was rejected. Nothing short of a read-only mount or a separate uid prevents that, and DESIGN §12 now says so instead of implying containment.

## Notable constraints

`repo_root` is deliberately untouched everywhere. It doubles as the mechanical gate for `PHANTOM_PATH`, `PHANTOM_ARTIFACT` and `CATEGORY_NO_DIR` — pointing those at the worker's own tree would let a worker clear its own gate by creating the file it claimed. Only the `cwd=` argument moved: 15 sites to the judgment worktree, `integration_judge` to the staging tree it was already judging.

The widening is scoped to `INSPECT_TOOLS`, because `SATISFIED_PROBE_TOOLS` is deliberately narrower and *calibrated* (12/12 false positives with full latitude, 0 when scoped). An earlier revision of this branch handed that probe `Bash(pytest:*)`.

## Found while auditing

- **Untracked task files are staged into the worktree.** On the affected repo the document the classifier read first is untracked — a worktree would not have contained the spec the run was about.
- `.claude/` is copied when the repo does not track it (`seed-repo.sh` already force-ships it to `/work` for the same reason).
- `.leerie` added to `_SKIP_DIRS`. On Fly/EC2 only the local arm exports `LEERIE_STATE_DIR`, so the state root is `<repo>/.leerie` and the repo map already re-walked every prior run's worktrees. Latent before this PR.
- `_finish_no_work_run` reaps the worktree — it reaches neither `cleanup.sh` nor the abnormal-exit handler, and a no-work run terminates *during* planning.
- `_snapshot_repo_state` records `ok`: every probe returns `""` on a non-zero git, which a naive diff reads as "HEAD moved" plus "every branch deleted" — fabricated tampering that would kill a healthy run.
- `_blt_verbs` reuses `_BLT_SEG_RE`/`_BLT_SEG_LEAD_RE` rather than a second copy of the same rule, and memoizes, because `resolve_blt` logs once per call.

## Testing

52 new tests — 26 isolation, 16 sentinel, 10 script — each negative paired with a positive control.

Both guards were **falsified live**: restoring the `autonomous or ...` OR fails 2 tests; neutering `_diff_repo_state` fails exactly the 4 detection tests. Restoring passes.

3230 tests pass across the 178 test files derived as reachable from the changed surface. `_judgment_cwd` falls back to the conventional run-dir path rather than raising — the fallback is derived from `run_dir` so it can never *be* the checkout, `claude_p`'s guard is the enforcement, and raising bought diagnostics only while turning 141 tests red across ~35 files that build `State` by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q4Xaw8wSLNJ2VdXc8RmAUV
