### PR TITLE
leerie: Deduplicate EC2 stub builders, decompose fixtures, and _run helper

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ fixture.
 """
 from __future__ import annotations
 
+import asyncio
 import contextlib
 import ctypes
 import importlib.util
@@ -18,6 +19,13 @@ import pytest
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 LEERIE_PY = REPO_ROOT / "orchestrator" / "leerie.py"
+
+
+def _run(coro):
+    """Run an async coroutine synchronously (this repo does not use
+    pytest-asyncio). Single owner for the byte-identical helper that was
+    previously redefined in fifteen test files."""
+    return asyncio.run(coro)
 
 
 @pytest.fixture(scope="session")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -81,6 +81,52 @@ HAS_TREESITTER = _has_treesitter()
 HAS_JQ = shutil.which("jq") is not None
 
 
+def _make_caps(leerie, **overrides) -> dict:
+    """Shared DEFAULT_CAPS-derived caps builder for the recursive-decompose
+    test family (§5½ (P1)). Callers layer on extra keys (e.g.
+    `subfile_split_max_span`) via **overrides rather than every file forcing
+    an identical cap set."""
+    caps = {
+        "max_total_workers": 200,
+        "decompose_max_depth": leerie.DEFAULT_CAPS["decompose_max_depth"],
+        "decompose_fit_threshold": leerie.DEFAULT_CAPS["decompose_fit_threshold"],
+        "decompose_noprogress_rounds": leerie.DEFAULT_CAPS["decompose_noprogress_rounds"],
+    }
+    caps.update(overrides)
+    return caps
+
+
+def _fit_response(score: float) -> dict:
+    """Shared stubbed fit_judge worker response for the recursive-decompose
+    test family (§5½ (P1))."""
+    return {
+        "score": score,
+        "rationale": f"score={score}",
+        "diffuse": "" if score >= 0.70 else "too broad",
+        "confidence": {
+            "fit": 8.5, "basis": "test",
+            "falsifiers_tested": ["x"], "contradictions_reconciled": [],
+            "gap_to_close": {},
+        },
+    }
+
+
+def _split_response(parent_id: str, n: int) -> dict:
+    """Shared stubbed splitter worker response for the recursive-decompose
+    test family (§5½ (P1))."""
+    return {
+        "children": [
+            {
+                "id": f"{parent_id}-{i + 1}",
+                "title": f"child {i + 1}",
+                "success_criteria_seed": f"criterion {i + 1}",
+                "files_likely_touched": [f"f{i}.py"],
+            }
+            for i in range(n)
+        ],
+    }
+
+
 def fake_claude_on_path(tmp_path: Path, monkeypatch) -> Path:
     """Put a stub `claude` binary on PATH and return it.
 

--- a/tests/ec2_stub.py
+++ b/tests/ec2_stub.py
@@ -374,3 +374,247 @@ def leaked_resources(state: dict) -> dict:
             if rec.get("state") != "deleted"
         },
     }
+
+
+# --- Shared SSM-exec-decode `aws`/`ssh` stub builders ---------------------
+#
+# tests/test_ec2_seed_repo.py, tests/test_ec2_fetch_branch.py, and
+# tests/test_ec2_seed_auth.py each defined their own near-identical
+# `_make_stub_aws`/`_make_stub_ssh`: a bash stub that decodes
+# ec2_remote_exec's base64-wrapped SSM command (or, for ssh, drains
+# ec2_tar_pipe's payload / execs a real rsync --server), rewrites one or
+# more absolute instance-side path prefixes to land inside a local test
+# dest dir, and re-executes the (rewritten) command locally. The three
+# copies differed only in which paths got rewritten and, for
+# test_ec2_seed_auth.py, an optional chown-log hook. Single-owner
+# discipline (same precedent as the state-machine stub above and
+# tests/launcher_blocks.py): one parameterized pair here, callers pass
+# the rewrite mapping.
+
+
+def _bash_rewrite_lines(var: str, rewrites: dict[str, str]) -> str:
+    """`{var}="${{{var}//pat/repl}}"` lines, one per `rewrites` entry, in
+    order. Only the pattern (`old`) side is slash-escaped — required
+    because `/` is the `${var//pattern/string}` delimiter; the
+    replacement side is inserted verbatim (callers pass bash text like
+    `"$DEST/work"`, whose slashes are not delimiters)."""
+    lines = []
+    for old, new in rewrites.items():
+        old_esc = old.replace("/", "\\/")
+        lines.append(f'{var}="${{{var}//{old_esc}/{new}}}"')
+    return "\n".join(lines)
+
+
+def make_ssm_stub_aws(
+    stub_path: Path,
+    exec_log: Path,
+    dest_dir: Path,
+    rewrites: dict[str, str],
+    *,
+    mkdir_subdir: str | None = None,
+    chown_log: Path | None = None,
+    swallow_runuser: bool = False,
+) -> None:
+    """Write a stub `aws` that decodes+executes ec2_remote_exec's
+    base64-wrapped SSM command locally, rewriting absolute instance-side
+    path prefixes (per `rewrites`, applied in order to the decoded
+    command text) so it operates against `dest_dir` instead of the real
+    instance filesystem — then re-encodes the (possibly nonzero) real
+    exit code as the rc sentinel ec2_remote_exec expects, while itself
+    always exiting 0 (mirroring the real SSM session-manager-plugin's
+    documented always-exit-0 behavior, which is exactly what
+    ec2_remote_exec's sentinel-recovery logic is designed to work
+    around).
+
+    `rewrites` maps an unescaped instance-side path prefix (e.g.
+    `"/work"`) to its bash replacement expression (e.g. `"$DEST/work"` —
+    `DEST` is bound to `dest_dir.resolve()` inside the stub).
+    `mkdir_subdir`, when given, pre-creates `$DEST/<mkdir_subdir>` before
+    the command runs, matching a directory the real AMI/image bakes in
+    ahead of any seed. `chown -R leerie: ` / `chown leerie: ` calls are
+    always replaced with a logging no-op (no leerie user exists in the
+    test sandbox); pass `chown_log` to make that log assertable,
+    otherwise it is discarded to /dev/null. `swallow_runuser`
+    additionally drops a `runuser -u leerie -- ` prefix.
+    """
+    dest = str(dest_dir.resolve())
+    chown_sink = str(chown_log.resolve()) if chown_log else "/dev/null"
+    rewrite_lines = _bash_rewrite_lines("decoded", rewrites)
+    mkdir_line = f'mkdir -p "$DEST/{mkdir_subdir}"' if mkdir_subdir else ""
+    runuser_line = (
+        'decoded="${decoded//runuser -u leerie -- /}"' if swallow_runuser else ""
+    )
+    stub_path.write_text(
+        f"""#!/usr/bin/env bash
+echo "aws $*" >> {exec_log}
+
+DEST={dest!r}
+CHOWN_LOG={chown_sink!r}
+{mkdir_line}
+
+# Find the --parameters "command=[...]" argument.
+param=""
+prev=""
+for arg in "$@"; do
+  if [ "$prev" = "--parameters" ]; then
+    param="$arg"
+  fi
+  prev="$arg"
+done
+
+if [ -z "$param" ]; then
+  exit 0
+fi
+
+# param looks like: command=["echo <b64> | base64 -d | bash"]
+inner="${{param#command=[\\"}}"
+inner="${{inner%\\"]}}"
+# inner is: echo <b64> | base64 -d | bash
+b64="${{inner#echo }}"
+b64="${{b64%% | base64*}}"
+decoded="$(printf '%s' "$b64" | base64 -d)"
+
+# Rewrite absolute instance-side paths to land inside DEST.
+{rewrite_lines}
+{runuser_line}
+# No leerie user in the test sandbox — swallow chown, logging it when
+# a caller wants to assert the ownership fix actually happened.
+decoded="${{decoded//chown -R leerie: /echo chown-R >> \\"\\$CHOWN_LOG\\"; true }}"
+decoded="${{decoded//chown leerie: /echo chown >> \\"\\$CHOWN_LOG\\"; true }}"
+
+CHOWN_LOG="$CHOWN_LOG" bash -c "$decoded"
+# SSM's own process always exits 0 regardless of the wrapped command's
+# real exit status; the sentinel inside `decoded` already carried the
+# real rc back over stdout, which ec2_remote_exec parses.
+exit 0
+"""
+    )
+    stub_path.chmod(0o755)
+
+
+def make_ssm_stub_ssh(
+    stub_path: Path,
+    exec_log: Path,
+    dest_dir: Path,
+    rewrites: dict[str, str],
+    *,
+    rsync_rewrite: tuple[str, str] | None = None,
+    raw_command_rewrite: bool = False,
+) -> None:
+    """Write a stub `ssh` used as ec2_tar_pipe's transport (extracts a
+    one-entry gzipped tar / evals a single `sh -c '...'` receiver
+    argv element from stdin, rewriting absolute instance-side paths
+    per `rewrites` first) and, optionally, as rsync's `-e` transport
+    or a raw single-command-string transport.
+
+    ec2_tar_pipe passes its whole `sh -c '...'` receiver as a SINGLE
+    argv element (not three separate sh/-c/<script> args) — see
+    ec2-lib.sh's ec2_tar_pipe body. This stub matches that shape.
+
+    `rsync_rewrite`, when given as `(old, new)`, adds an `rsync*)` case
+    arm that execs a real local `rsync --server` after rewriting the
+    trailing target argument the same way `rewrites` does (used by
+    ec2-seed-repo.sh's upload path, which never appears in the other
+    two callers). `raw_command_rewrite`, when true, makes the fallback
+    `*)` arm treat the remaining argv as a single raw command string
+    (`ssh <target> "<cmd>"`, used by ec2-fetch-branch.sh's download
+    path) — rewritten and eval'd, streaming this stub's own stdout
+    straight back — instead of draining and discarding stdin.
+    """
+    dest = str(dest_dir.resolve())
+    sh_rewrite_lines = _bash_rewrite_lines("remote_cmd", rewrites)
+
+    if rsync_rewrite is not None:
+        old, new = rsync_rewrite
+        old_esc = old.replace("/", "\\/")
+        subdir = old.lstrip("/")
+        rsync_arm = f"""  rsync*)
+    # rsync --server invocation. Rewrite the trailing /{subdir}/ target arg.
+    # The replacement half of ${{var/pat/repl}} is NOT a regex and needs
+    # no escaping: a `\\/` there is a *literal backslash*, which sent the
+    # transfer to a directory named `<dest>\\` and left `<dest>/{subdir}`
+    # empty — rsync exits 0, so the test failed with "untracked.txt
+    # missing" and no error anywhere. Only the pattern half escapes.
+    new_rest=()
+    for a in "${{rest[@]}}"; do
+      case "$a" in
+        */{subdir}/*|*/{subdir}) a="${{a/{old_esc}/{new}}}" ;;
+      esac
+      new_rest+=("$a")
+    done
+    exec "${{new_rest[@]}}"
+    ;;
+"""
+    else:
+        rsync_arm = ""
+
+    if raw_command_rewrite:
+        raw_rewrite_lines = _bash_rewrite_lines("remote_cmd", rewrites)
+        default_arm = f"""  *)
+    # Raw command form: ssh <target> "<cmd>" — a single argv element
+    # containing the whole remote command. Rewrite path references and
+    # eval, streaming this stub's own stdout straight back (binary-safe:
+    # no command substitution in this path).
+    remote_cmd="${{rest[*]}}"
+    {raw_rewrite_lines}
+    eval "$remote_cmd"
+    exit $?
+    ;;
+"""
+    else:
+        default_arm = """  *)
+    cat > /dev/null
+    exit 0
+    ;;
+"""
+
+    stub_path.write_text(
+        f"""#!/usr/bin/env bash
+echo "ssh $*" >> {exec_log}
+DEST={dest!r}
+
+# Drop leading ssh flags to find the target and the remainder of argv.
+# `-o <opt>` (our own ec2_tar_pipe/rsync -e invocation) and `-l <user>`
+# (rsync's own -e-transport invocation always passes login name via
+# `-l`, e.g. `ssh -o ... -o ... -l ec2-user 1.2.3.4 rsync --server
+# ...`) both take a separate value argument — treat them the same as
+# any other single-token flag, or `target`/`rest` end up off-by-one and
+# the rsync* case below is never reached (the real bug this comment
+# guards against: silently falling through to the drain-and-exit
+# default, which leaves the sending rsync hung waiting on a protocol
+# handshake that never arrives).
+args=("$@")
+i=0
+while [ $i -lt ${{#args[@]}} ]; do
+  case "${{args[$i]}}" in
+    -o|-l) i=$((i+2)); continue ;;
+    -*) i=$((i+1)); continue ;;
+    *) break ;;
+  esac
+done
+target="${{args[$i]}}"
+rest=("${{args[@]:$((i+1))}}")
+
+if [ "${{#rest[@]}}" -eq 0 ]; then
+  # No remote command — this is ec2_tar_pipe's bare-target invocation
+  # form. Shouldn't happen in production (ec2_tar_pipe always appends a
+  # remote command), but guard defensively.
+  cat > /dev/null
+  exit 0
+fi
+
+case "${{rest[0]}}" in
+  sh*)
+    # ec2_tar_pipe passes its whole receiver as ONE argv element:
+    # "sh -c 'mkdir -p '\\''<dir>'\\'' && tar -xzC '\\''<dir>'\\'''"
+    # (not three separate sh/-c/<script> args) — rewrite paths in that
+    # single string and eval it as-is.
+    remote_cmd="${{rest[0]}}"
+    {sh_rewrite_lines}
+    eval "$remote_cmd"
+    exit $?
+    ;;
+{rsync_arm}{default_arm}esac
+"""
+    )
+    stub_path.chmod(0o755)

--- a/tests/test_artifact_registry.py
+++ b/tests/test_artifact_registry.py
@@ -19,12 +19,13 @@ Mirrors test_fit_judge_schema.py / test_resolve_fit_judge_model.py patterns.
 """
 from __future__ import annotations
 
-import asyncio
 import inspect
 import json
 from pathlib import Path
 
 import pytest
+
+from tests.conftest import _run
 
 try:
     import jsonschema  # type: ignore
@@ -174,9 +175,6 @@ def _make_state(leerie, run_dir: Path):
     st.path.write_text("{}")
     return st
 
-
-def _run(coro):
-    return asyncio.run(coro)
 
 
 def test_phase_returns_artifacts(leerie, tmp_path, monkeypatch):

--- a/tests/test_decompose_budget_share.py
+++ b/tests/test_decompose_budget_share.py
@@ -20,7 +20,7 @@ from unittest.mock import patch
 
 import pytest
 
-from tests.conftest import _run
+from tests.conftest import _fit_response, _run, _split_response
 
 
 def _make_real_state(leerie):
@@ -63,30 +63,8 @@ def _caps(leerie, max_total_workers, decompose_budget_share=0.40):
 
 
 def _low_fit_response() -> dict:
-    return {
-        "score": 0.10,
-        "rationale": "always oversized",
-        "diffuse": "too broad",
-        "confidence": {
-            "fit": 8.5, "basis": "test",
-            "falsifiers_tested": ["x"], "contradictions_reconciled": [],
-            "gap_to_close": {},
-        },
-    }
-
-
-def _split_response(parent_id: str, n: int) -> dict:
-    return {
-        "children": [
-            {
-                "id": f"{parent_id}-{i + 1}",
-                "title": f"child {i + 1}",
-                "success_criteria_seed": f"criterion {i + 1}",
-                "files_likely_touched": [f"f{i}.py"],
-            }
-            for i in range(n)
-        ],
-    }
+    """This file's decomposition subtasks are always oversized at 0.10."""
+    return _fit_response(0.10)
 
 
 

--- a/tests/test_decompose_budget_share.py
+++ b/tests/test_decompose_budget_share.py
@@ -15,11 +15,12 @@ not a mock.
 """
 from __future__ import annotations
 
-import asyncio
 from pathlib import Path
 from unittest.mock import patch
 
 import pytest
+
+from tests.conftest import _run
 
 
 def _make_real_state(leerie):
@@ -87,9 +88,6 @@ def _split_response(parent_id: str, n: int) -> dict:
         ],
     }
 
-
-def _run(coro):
-    return asyncio.run(coro)
 
 
 def test_default_cap_value(leerie):

--- a/tests/test_decompose_snapshot.py
+++ b/tests/test_decompose_snapshot.py
@@ -33,6 +33,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from tests.conftest import _run
+
 
 # ---------------------------------------------------------------------------
 # Helpers (mirrors tests/test_recursive_decompose.py and
@@ -63,9 +65,6 @@ def _make_decompose_caps(leerie, **overrides):
     caps.update(overrides)
     return caps
 
-
-def _run(coro):
-    return asyncio.run(coro)
 
 
 _CATEGORY = "feature-implementation"  # a real entry in CATEGORY_ABBREV

--- a/tests/test_ec2_fetch_branch.py
+++ b/tests/test_ec2_fetch_branch.py
@@ -22,6 +22,7 @@ import os
 import subprocess
 from pathlib import Path
 
+from tests import ec2_stub
 from tests.stub_helpers import _make_stub_timeout
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -42,46 +43,17 @@ def _run_bash(script: str, env: dict | None = None) -> subprocess.CompletedProce
 
 
 def _make_stub_aws(stub_path: Path, exec_log: Path, instance_work: Path) -> None:
-    """Stub `aws` that decodes+executes ec2_remote_exec's base64-wrapped
-    command locally against instance_work (standing in for /work on the
-    instance), re-encoding the real exit code as the rc sentinel
-    ec2_remote_exec expects while itself always exiting 0 (mirroring the
-    real SSM session-manager-plugin's documented always-exit-0 behavior).
-    Modeled on tests/test_ec2_seed_repo.py's _make_stub_aws.
+    """Stub `aws` decoding+executing ec2_remote_exec's SSM command
+    locally against instance_work (standing in for /work on the
+    instance). See tests/ec2_stub.py::make_ssm_stub_aws for the shared
+    mechanics.
     """
-    dest = str(instance_work.parent.resolve())
-    stub_path.write_text(
-        f"""#!/usr/bin/env bash
-echo "aws $*" >> {exec_log}
-
-DEST={dest!r}
-
-param=""
-prev=""
-for arg in "$@"; do
-  if [ "$prev" = "--parameters" ]; then
-    param="$arg"
-  fi
-  prev="$arg"
-done
-
-if [ -z "$param" ]; then
-  exit 0
-fi
-
-inner="${{param#command=[\\"}}"
-inner="${{inner%\\"]}}"
-b64="${{inner#echo }}"
-b64="${{b64%% | base64*}}"
-decoded="$(printf '%s' "$b64" | base64 -d)"
-
-decoded="${{decoded//\\/work/$DEST/work}}"
-
-bash -c "$decoded"
-exit 0
-"""
+    ec2_stub.make_ssm_stub_aws(
+        stub_path,
+        exec_log,
+        instance_work.parent,
+        {"/work": "$DEST/work"},
     )
-    stub_path.chmod(0o755)
 
 
 def _make_stub_ssh(stub_path: Path, exec_log: Path, instance_work: Path) -> None:
@@ -90,53 +62,16 @@ def _make_stub_ssh(stub_path: Path, exec_log: Path, instance_work: Path) -> None
     stdout streamed straight back) and, defensively, ec2_tar_pipe's
     upload `sh -c '...'` receiver shape (unused by fetch-branch.sh
     itself but kept for parity with the seed-repo stub in case a shared
-    helper is exercised).
+    helper is exercised). See tests/ec2_stub.py::make_ssm_stub_ssh for
+    the shared mechanics.
     """
-    dest = str(instance_work.parent.resolve())
-    stub_path.write_text(
-        f"""#!/usr/bin/env bash
-echo "ssh $*" >> {exec_log}
-DEST={dest!r}
-
-args=("$@")
-i=0
-while [ $i -lt ${{#args[@]}} ]; do
-  case "${{args[$i]}}" in
-    -o|-l) i=$((i+2)); continue ;;
-    -*) i=$((i+1)); continue ;;
-    *) break ;;
-  esac
-done
-target="${{args[$i]}}"
-rest=("${{args[@]:$((i+1))}}")
-
-if [ "${{#rest[@]}}" -eq 0 ]; then
-  cat > /dev/null
-  exit 0
-fi
-
-case "${{rest[0]}}" in
-  sh*)
-    remote_cmd="${{rest[0]}}"
-    remote_cmd="${{remote_cmd//\\/work/$DEST/work}}"
-    eval "$remote_cmd"
-    exit $?
-    ;;
-  *)
-    # Raw command form: ssh <target> "<cmd>" — a single argv element
-    # containing the whole remote command (git bundle create, tar -cC,
-    # test -f, cat). Rewrite /work path references and eval, streaming
-    # this stub's own stdout straight back (binary-safe: no command
-    # substitution in this path).
-    remote_cmd="${{rest[*]}}"
-    remote_cmd="${{remote_cmd//\\/work/$DEST/work}}"
-    eval "$remote_cmd"
-    exit $?
-    ;;
-esac
-"""
+    ec2_stub.make_ssm_stub_ssh(
+        stub_path,
+        exec_log,
+        instance_work.parent,
+        {"/work": "$DEST/work"},
+        raw_command_rewrite=True,
     )
-    stub_path.chmod(0o755)
 
 
 def _make_git_repo(tmp_path: Path, subdir: str = "myrepo") -> Path:

--- a/tests/test_ec2_seed_auth.py
+++ b/tests/test_ec2_seed_auth.py
@@ -23,6 +23,7 @@ import os
 import subprocess
 from pathlib import Path
 
+from tests import ec2_stub
 from tests.stub_helpers import _make_stub_timeout
 from tests.test_ec2_transport import _stub_timeout as _make_killing_stub_timeout
 
@@ -45,67 +46,22 @@ def _run_bash(script: str, env: dict | None = None) -> subprocess.CompletedProce
 
 def _make_stub_aws(stub_path: Path, exec_log: Path, dest_dir: Path,
                     chown_log: Path | None = None) -> None:
-    """Stub `aws` that decodes+executes ec2_remote_exec's base64-wrapped
-    command locally, rewriting /home/leerie to dest_dir first, then
-    re-encodes the (possibly nonzero) real exit code as the rc sentinel
-    ec2_remote_exec expects — while itself always exiting 0 (mirroring
-    the real SSM session-manager-plugin's documented always-exit-0
-    behavior).
-
-    `chown -R leerie:`/`chown leerie:` calls are replaced with a logging
-    no-op (rather than silently swallowed) when `chown_log` is given, so
-    tests can assert the real script actually issued the ownership fix
-    rather than merely grepping its source.
+    """Stub `aws` rewriting /home/leerie to dest_dir. `chown -R leerie:`
+    /`chown leerie:`/`runuser -u leerie --` calls are replaced with a
+    logging no-op (rather than silently swallowed) when `chown_log` is
+    given, so tests can assert the real script actually issued the
+    ownership fix rather than merely grepping its source. See
+    tests/ec2_stub.py::make_ssm_stub_aws for the shared mechanics.
     """
-    dest = str(dest_dir.resolve())
-    chown_sink = str(chown_log.resolve()) if chown_log else "/dev/null"
-    stub_path.write_text(
-        f"""#!/usr/bin/env bash
-echo "aws $*" >> {exec_log}
-
-DEST={dest!r}
-CHOWN_LOG={chown_sink!r}
-mkdir -p "$DEST/home/leerie"
-
-# Find the --parameters "command=[...]" argument.
-param=""
-prev=""
-for arg in "$@"; do
-  if [ "$prev" = "--parameters" ]; then
-    param="$arg"
-  fi
-  prev="$arg"
-done
-
-if [ -z "$param" ]; then
-  exit 0
-fi
-
-# param looks like: command=["echo <b64> | base64 -d | bash"]
-inner="${{param#command=[\\"}}"
-inner="${{inner%\\"]}}"
-# inner is: echo <b64> | base64 -d | bash
-b64="${{inner#echo }}"
-b64="${{b64%% | base64*}}"
-decoded="$(printf '%s' "$b64" | base64 -d)"
-
-# Rewrite absolute instance-side paths to land inside DEST.
-decoded="${{decoded//\\/home\\/leerie/$DEST/home/leerie}}"
-# No leerie user in the test sandbox — replace chown/runuser with a
-# logging no-op so tests can assert the ownership-fix call actually
-# happened, rather than silently discarding the evidence.
-decoded="${{decoded//chown -R leerie: /echo chown-R >> \\"\\$CHOWN_LOG\\"; true }}"
-decoded="${{decoded//chown leerie: /echo chown >> \\"\\$CHOWN_LOG\\"; true }}"
-decoded="${{decoded//runuser -u leerie -- /}}"
-
-CHOWN_LOG="$CHOWN_LOG" bash -c "$decoded"
-# SSM's own process always exits 0 regardless of the wrapped command's
-# real exit status; the sentinel inside `decoded` already carried the
-# real rc back over stdout, which ec2_remote_exec parses.
-exit 0
-"""
+    ec2_stub.make_ssm_stub_aws(
+        stub_path,
+        exec_log,
+        dest_dir,
+        {"/home/leerie": "$DEST/home/leerie"},
+        mkdir_subdir="home/leerie",
+        chown_log=chown_log,
+        swallow_runuser=True,
     )
-    stub_path.chmod(0o755)
 
 
 def _make_stub_ssh(stub_path: Path, exec_log: Path, dest_dir: Path) -> None:
@@ -115,46 +71,15 @@ def _make_stub_ssh(stub_path: Path, exec_log: Path, dest_dir: Path) -> None:
     ec2_tar_pipe passes its whole `sh -c '...'` receiver as a SINGLE
     argv element — see ec2-lib.sh's ec2_tar_pipe body. This stub
     matches that shape (same technique as test_ec2_seed_repo.py's
-    `_make_stub_ssh`).
+    `_make_stub_ssh`). See tests/ec2_stub.py::make_ssm_stub_ssh for the
+    shared mechanics.
     """
-    dest = str(dest_dir.resolve())
-    stub_path.write_text(
-        f"""#!/usr/bin/env bash
-echo "ssh $*" >> {exec_log}
-DEST={dest!r}
-
-args=("$@")
-i=0
-while [ $i -lt ${{#args[@]}} ]; do
-  case "${{args[$i]}}" in
-    -o|-l) i=$((i+2)); continue ;;
-    -*) i=$((i+1)); continue ;;
-    *) break ;;
-  esac
-done
-target="${{args[$i]}}"
-rest=("${{args[@]:$((i+1))}}")
-
-if [ "${{#rest[@]}}" -eq 0 ]; then
-  cat > /dev/null
-  exit 0
-fi
-
-case "${{rest[0]}}" in
-  sh*)
-    remote_cmd="${{rest[0]}}"
-    remote_cmd="${{remote_cmd//\\/home\\/leerie/$DEST/home/leerie}}"
-    eval "$remote_cmd"
-    exit $?
-    ;;
-  *)
-    cat > /dev/null
-    exit 0
-    ;;
-esac
-"""
+    ec2_stub.make_ssm_stub_ssh(
+        stub_path,
+        exec_log,
+        dest_dir,
+        {"/home/leerie": "$DEST/home/leerie"},
     )
-    stub_path.chmod(0o755)
 
 
 def _make_stub_git(stub_path: Path, *, name: str = "Test User",

--- a/tests/test_ec2_seed_repo.py
+++ b/tests/test_ec2_seed_repo.py
@@ -26,6 +26,7 @@ import os
 import subprocess
 from pathlib import Path
 
+from tests import ec2_stub
 from tests.stub_helpers import _make_stub_timeout
 from tests.test_ec2_transport import _stub_timeout as _make_killing_stub_timeout
 
@@ -47,68 +48,30 @@ def _run_bash(script: str, env: dict | None = None) -> subprocess.CompletedProce
 
 
 def _make_stub_aws(stub_path: Path, exec_log: Path, dest_dir: Path) -> None:
-    """Stub `aws` that decodes+executes ec2_remote_exec's base64-wrapped
-    command locally, rewriting /work and /tmp/leerie-* paths to dest_dir
-    first, then re-encodes the (possibly nonzero) real exit code as the
-    rc sentinel ec2_remote_exec expects — while itself always exiting 0
-    (mirroring the real SSM session-manager-plugin's documented
-    always-exit-0 behavior, which is exactly what ec2_remote_exec's
-    sentinel-recovery logic is designed to work around).
+    """Stub `aws` rewriting /work and /tmp/leerie-* paths to dest_dir.
+
+    Basenames must match exactly what the ssh stub's `/tmp` -> $DEST
+    rewrite produces (ec2_tar_pipe extracts into /tmp preserving each
+    payload's basename, e.g. /tmp/leerie-seed.bundle,
+    /tmp/leerie-subs/<bn>.bundle) — these are NOT renamed on the way in.
+    See tests/ec2_stub.py::make_ssm_stub_aws for the shared mechanics.
     """
-    dest = str(dest_dir.resolve())
-    stub_path.write_text(
-        f"""#!/usr/bin/env bash
-echo "aws $*" >> {exec_log}
-
-DEST={dest!r}
-# /work is baked into the real AMI/image ahead of any seed; pre-create
-# it here so the first `find /work -mindepth 1 ...` reset step (which
-# assumes the directory already exists, same as production) succeeds.
-mkdir -p "$DEST/work"
-
-# Find the --parameters "command=[...]" argument.
-param=""
-prev=""
-for arg in "$@"; do
-  if [ "$prev" = "--parameters" ]; then
-    param="$arg"
-  fi
-  prev="$arg"
-done
-
-if [ -z "$param" ]; then
-  exit 0
-fi
-
-# param looks like: command=["echo <b64> | base64 -d | bash"]
-inner="${{param#command=[\\"}}"
-inner="${{inner%\\"]}}"
-# inner is: echo <b64> | base64 -d | bash
-b64="${{inner#echo }}"
-b64="${{b64%% | base64*}}"
-decoded="$(printf '%s' "$b64" | base64 -d)"
-
-# Rewrite absolute instance-side paths to land inside DEST. Basenames
-# must match exactly what the ssh stub's `/tmp` -> $DEST rewrite
-# produces (ec2_tar_pipe extracts into /tmp preserving each payload's
-# basename, e.g. /tmp/leerie-seed.bundle, /tmp/leerie-subs/<bn>.bundle)
-# — these are NOT renamed on the way in.
-decoded="${{decoded//\\/tmp\\/leerie-subs/$DEST/leerie-subs}}"
-decoded="${{decoded//\\/tmp\\/leerie-seed.bundle/$DEST/leerie-seed.bundle}}"
-decoded="${{decoded//\\/tmp\\/leerie-seed-git.tar/$DEST/leerie-seed-git.tar}}"
-decoded="${{decoded//\\/work/$DEST/work}}"
-# No leerie user in the test sandbox — swallow chown.
-decoded="${{decoded//chown -R leerie: /true }}"
-decoded="${{decoded//chown leerie: /true }}"
-
-bash -c "$decoded"
-# SSM's own process always exits 0 regardless of the wrapped command's
-# real exit status; the sentinel inside `decoded` already carried the
-# real rc back over stdout, which ec2_remote_exec parses.
-exit 0
-"""
+    ec2_stub.make_ssm_stub_aws(
+        stub_path,
+        exec_log,
+        dest_dir,
+        {
+            "/tmp/leerie-subs": "$DEST/leerie-subs",
+            "/tmp/leerie-seed.bundle": "$DEST/leerie-seed.bundle",
+            "/tmp/leerie-seed-git.tar": "$DEST/leerie-seed-git.tar",
+            "/work": "$DEST/work",
+        },
+        # /work is baked into the real AMI/image ahead of any seed;
+        # pre-create it here so the first `find /work -mindepth 1 ...`
+        # reset step (which assumes the directory already exists, same
+        # as production) succeeds.
+        mkdir_subdir="work",
     )
-    stub_path.chmod(0o755)
 
 
 def _make_stub_ssh(stub_path: Path, exec_log: Path, dest_dir: Path) -> None:
@@ -116,84 +79,15 @@ def _make_stub_ssh(stub_path: Path, exec_log: Path, dest_dir: Path) -> None:
     one-entry gzipped tar from stdin into the rewritten dest dir) and as
     rsync's `-e` transport (execs a real local `rsync --server` so the
     two rsync processes can talk, with `/work` rewritten to dest/work).
-
-    ec2_tar_pipe passes its whole `sh -c '...'` receiver as a SINGLE
-    argv element (not three separate sh/-c/<script> args, unlike a
-    typical `ssh host sh -c script` invocation) — see ec2-lib.sh's
-    ec2_tar_pipe body. This stub matches that shape.
+    See tests/ec2_stub.py::make_ssm_stub_ssh for the shared mechanics.
     """
-    dest = str(dest_dir.resolve())
-    stub_path.write_text(
-        f"""#!/usr/bin/env bash
-echo "ssh $*" >> {exec_log}
-DEST={dest!r}
-
-# Drop leading ssh flags to find the target and the remainder of argv.
-# `-o <opt>` (our own ec2_tar_pipe/rsync -e invocation) and `-l <user>`
-# (rsync's own -e-transport invocation always passes login name via
-# `-l`, e.g. `ssh -o ... -o ... -l ec2-user 1.2.3.4 rsync --server
-# ...`) both take a separate value argument — treat them the same as
-# any other single-token flag, or `target`/`rest` end up off-by-one and
-# the rsync* case below is never reached (the real bug this comment
-# guards against: silently falling through to the drain-and-exit
-# default, which leaves the sending rsync hung waiting on a protocol
-# handshake that never arrives).
-args=("$@")
-i=0
-while [ $i -lt ${{#args[@]}} ]; do
-  case "${{args[$i]}}" in
-    -o|-l) i=$((i+2)); continue ;;
-    -*) i=$((i+1)); continue ;;
-    *) break ;;
-  esac
-done
-target="${{args[$i]}}"
-rest=("${{args[@]:$((i+1))}}")
-
-if [ "${{#rest[@]}}" -eq 0 ]; then
-  # No remote command — this is ec2_tar_pipe's bare-target invocation
-  # form. Shouldn't happen in production (ec2_tar_pipe always appends a
-  # remote command), but guard defensively.
-  cat > /dev/null
-  exit 0
-fi
-
-case "${{rest[0]}}" in
-  sh*)
-    # ec2_tar_pipe passes its whole receiver as ONE argv element:
-    # "sh -c 'mkdir -p '\\''<dir>'\\'' && tar -xzC '\\''<dir>'\\'''"
-    # (not three separate sh/-c/<script> args) — rewrite paths in that
-    # single string and eval it as-is.
-    remote_cmd="${{rest[0]}}"
-    remote_cmd="${{remote_cmd//\\/work/$DEST/work}}"
-    remote_cmd="${{remote_cmd//\\/tmp/$DEST}}"
-    eval "$remote_cmd"
-    exit $?
-    ;;
-  rsync*)
-    # rsync --server invocation. Rewrite the trailing /work/ target arg.
-    # The replacement half of ${{var/pat/repl}} is NOT a regex and needs
-    # no escaping: a `\/` there is a *literal backslash*, which sent the
-    # transfer to a directory named `<dest>\` and left `<dest>/work`
-    # empty — rsync exits 0, so the test failed with "untracked.txt
-    # missing" and no error anywhere. Only the pattern half escapes.
-    new_rest=()
-    for a in "${{rest[@]}}"; do
-      case "$a" in
-        */work/*|*/work) a="${{a/\\/work/${{DEST}}/work}}" ;;
-      esac
-      new_rest+=("$a")
-    done
-    exec "${{new_rest[@]}}"
-    ;;
-  *)
-    cat > /dev/null
-    exit 0
-    ;;
-esac
-"""
+    ec2_stub.make_ssm_stub_ssh(
+        stub_path,
+        exec_log,
+        dest_dir,
+        {"/work": "$DEST/work", "/tmp": "$DEST"},
+        rsync_rewrite=("/work", "${DEST}/work"),
     )
-    stub_path.chmod(0o755)
 
 
 def _init_repo(repo: Path) -> None:

--- a/tests/test_filter_satisfied_subtasks.py
+++ b/tests/test_filter_satisfied_subtasks.py
@@ -22,12 +22,13 @@ dependency.
 """
 from __future__ import annotations
 
-import asyncio
 import json
 import os
 from pathlib import Path
 
 import pytest
+
+from tests.conftest import _run
 
 try:
     import jsonschema  # type: ignore
@@ -82,9 +83,6 @@ def _patch_probe(leerie, monkeypatch, verdicts: dict):
 
     monkeypatch.setattr(leerie, "claude_p", fake_claude_p)
 
-
-def _run(coro):
-    return asyncio.run(coro)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_measure_blt.py
+++ b/tests/test_measure_blt.py
@@ -9,15 +9,13 @@ per-framework output parsing.
 """
 from __future__ import annotations
 
-import asyncio
 import inspect
 import subprocess
 
 import pytest
 
+from tests.conftest import _run
 
-def _run(coro):
-    return asyncio.run(coro)
 
 
 def _call(leerie, cmd="pytest", tree="/tmp/x", timeout=60.0, **kw):

--- a/tests/test_mid_run_satisfied_no_commits.py
+++ b/tests/test_mid_run_satisfied_no_commits.py
@@ -24,10 +24,11 @@ silently reverted.
 """
 from __future__ import annotations
 
-import asyncio
 import inspect
 import subprocess
 from pathlib import Path
+
+from tests.conftest import _run
 
 
 def _git(path, *args):
@@ -82,9 +83,6 @@ def _patch_probe(leerie, monkeypatch, verdict):
     monkeypatch.setattr(leerie, "_load_prompt", lambda *_a, **_k: "SYS")
     return seen
 
-
-def _run(coro):
-    return asyncio.run(coro)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_phase_plan_recursion_wiring.py
+++ b/tests/test_phase_plan_recursion_wiring.py
@@ -21,13 +21,14 @@ boundary.
 """
 from __future__ import annotations
 
-import asyncio
 import inspect
 import json
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+
+from tests.conftest import _run
 
 
 # ---------------------------------------------------------------------------
@@ -145,9 +146,6 @@ _PLANNER_RESPONSE = {
     "subtasks": [_OVERSIZED_SUBTASK],
 }
 
-
-def _run(coro):
-    return asyncio.run(coro)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_recursive_decompose.py
+++ b/tests/test_recursive_decompose.py
@@ -23,7 +23,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from tests.conftest import _run
+from tests.conftest import _fit_response, _run, _split_response
+from tests.conftest import _make_caps as _shared_make_caps
 
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -128,42 +129,13 @@ def _make_state(leerie, caps):
 
 
 def _make_caps(leerie, **overrides):
-    caps = {
-        "max_total_workers": 200,
-        "decompose_max_depth": leerie.DEFAULT_CAPS["decompose_max_depth"],
-        "decompose_fit_threshold": leerie.DEFAULT_CAPS["decompose_fit_threshold"],
-        "decompose_noprogress_rounds": leerie.DEFAULT_CAPS["decompose_noprogress_rounds"],
-        "subfile_split_max_span": leerie.DEFAULT_CAPS["subfile_split_max_span"],
-    }
-    caps.update(overrides)
-    return caps
-
-
-def _fit_response(score: float) -> dict:
-    return {
-        "score": score,
-        "rationale": f"score={score}",
-        "diffuse": "" if score >= 0.70 else "too broad",
-        "confidence": {
-            "fit": 8.5, "basis": "test",
-            "falsifiers_tested": ["x"], "contradictions_reconciled": [],
-            "gap_to_close": {},
-        },
-    }
-
-
-def _split_response(parent_id: str, n: int) -> dict:
-    return {
-        "children": [
-            {
-                "id": f"{parent_id}-{i + 1}",
-                "title": f"child {i + 1}",
-                "success_criteria_seed": f"criterion {i + 1}",
-                "files_likely_touched": [f"f{i}.py"],
-            }
-            for i in range(n)
-        ],
-    }
+    """This file's caps always carry `subfile_split_max_span`, which the
+    shared builder does not default -- layer it on top."""
+    return _shared_make_caps(
+        leerie,
+        subfile_split_max_span=leerie.DEFAULT_CAPS["subfile_split_max_span"],
+        **overrides,
+    )
 
 
 

--- a/tests/test_recursive_decompose.py
+++ b/tests/test_recursive_decompose.py
@@ -13,7 +13,6 @@ fit_judge / splitter responses. Verifies:
 """
 from __future__ import annotations
 
-import asyncio
 import importlib.util
 import json
 import math
@@ -23,6 +22,8 @@ from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+
+from tests.conftest import _run
 
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -164,9 +165,6 @@ def _split_response(parent_id: str, n: int) -> dict:
         ],
     }
 
-
-def _run(coro):
-    return asyncio.run(coro)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_recursive_decompose.py
+++ b/tests/test_recursive_decompose.py
@@ -131,11 +131,10 @@ def _make_state(leerie, caps):
 def _make_caps(leerie, **overrides):
     """This file's caps always carry `subfile_split_max_span`, which the
     shared builder does not default -- layer it on top."""
-    return _shared_make_caps(
-        leerie,
-        subfile_split_max_span=leerie.DEFAULT_CAPS["subfile_split_max_span"],
-        **overrides,
+    overrides.setdefault(
+        "subfile_split_max_span", leerie.DEFAULT_CAPS["subfile_split_max_span"]
     )
+    return _shared_make_caps(leerie, **overrides)
 
 
 

--- a/tests/test_recursive_decompose_parallel.py
+++ b/tests/test_recursive_decompose_parallel.py
@@ -13,6 +13,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from tests.conftest import _run
+
 
 _CATEGORY = "feature-implementation"  # a real entry in CATEGORY_ABBREV
 
@@ -55,9 +57,6 @@ def _subtask(sid: str, path: str) -> dict:
         "investigation_notes": "",
     }
 
-
-def _run(coro):
-    return asyncio.run(coro)
 
 
 def _planner_response(subtasks: list[dict]) -> dict:

--- a/tests/test_recursive_decompose_schedule.py
+++ b/tests/test_recursive_decompose_schedule.py
@@ -21,7 +21,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from tests.conftest import _run
+from tests.conftest import _fit_response, _make_caps, _run
 
 
 # ---------------------------------------------------------------------------
@@ -65,31 +65,6 @@ def _make_state(leerie, caps: dict) -> MagicMock:
 
     st.bump_workers = MagicMock(side_effect=bump)
     return st
-
-
-def _make_caps(leerie, **overrides) -> dict:
-    caps = {
-        "max_total_workers": 200,
-        "decompose_max_depth": leerie.DEFAULT_CAPS["decompose_max_depth"],
-        "decompose_fit_threshold": leerie.DEFAULT_CAPS["decompose_fit_threshold"],
-        "decompose_noprogress_rounds": leerie.DEFAULT_CAPS["decompose_noprogress_rounds"],
-    }
-    caps.update(overrides)
-    return caps
-
-
-def _fit_response(score: float) -> dict:
-    return {
-        "score": score,
-        "rationale": f"score={score}",
-        "diffuse": "" if score >= 0.70 else "too broad",
-        "confidence": {
-            "fit": 8.5, "basis": "test",
-            "falsifiers_tested": ["x"], "contradictions_reconciled": [],
-            "gap_to_close": {},
-        },
-    }
-
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_recursive_decompose_schedule.py
+++ b/tests/test_recursive_decompose_schedule.py
@@ -16,11 +16,12 @@ Tests verify:
 """
 from __future__ import annotations
 
-import asyncio
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
+
+from tests.conftest import _run
 
 
 # ---------------------------------------------------------------------------
@@ -89,9 +90,6 @@ def _fit_response(score: float) -> dict:
         },
     }
 
-
-def _run(coro):
-    return asyncio.run(coro)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_replan_sid_scoping.py
+++ b/tests/test_replan_sid_scoping.py
@@ -13,10 +13,11 @@ earlier invocation's in the same run.
 """
 from __future__ import annotations
 
-import asyncio
 import json
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
+
+from tests.conftest import _run
 
 _CATEGORY = "feature-implementation"  # a real entry in CATEGORY_ABBREV
 
@@ -67,9 +68,6 @@ _PLANNER_RESPONSE = {
     "subtasks": [_SUBTASK],
 }
 
-
-def _run(coro):
-    return asyncio.run(coro)
 
 
 def _run_phase_plan(leerie, task: str, replan_round: int = 0,

--- a/tests/test_rescue_integrator_work.py
+++ b/tests/test_rescue_integrator_work.py
@@ -17,14 +17,12 @@ which is what defeats both `git stash push` and `git stash create`
 
 from __future__ import annotations
 
-import asyncio
 import subprocess
 
 import pytest
 
+from tests.conftest import _run
 
-def _run(coro):
-    return asyncio.run(coro)
 
 
 def _git(*args, cwd, **kw):

--- a/tests/test_satisfied_probe_cache.py
+++ b/tests/test_satisfied_probe_cache.py
@@ -32,6 +32,8 @@ import json
 import subprocess
 from pathlib import Path
 
+from tests.conftest import _run
+
 _CAPS = {"max_parallel": 4, "max_total_workers": 999}
 _MODELS = {"satisfied_probe": "sonnet"}
 _EFFORTS = {"satisfied_probe": None}
@@ -79,9 +81,6 @@ def _init_git_repo(path: Path) -> str:
                           check=True, capture_output=True, text=True)
     return out.stdout.strip()
 
-
-def _run(coro):
-    return asyncio.run(coro)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_satisfied_probe_cache_invalidation.py
+++ b/tests/test_satisfied_probe_cache_invalidation.py
@@ -28,9 +28,10 @@ re-probed (fail-safe-to-reprobe), the same discipline as an unrelated sha.
 """
 from __future__ import annotations
 
-import asyncio
 import subprocess
 from pathlib import Path
+
+from tests.conftest import _run
 
 _CAPS = {"max_parallel": 4, "max_total_workers": 999}
 _MODELS = {"satisfied_probe": "sonnet"}
@@ -90,9 +91,6 @@ def _commit_more(path: Path, filename: str = "b.py") -> str:
     _git(["commit", "-q", "-m", f"add {filename}"], path)
     return _git(["rev-parse", "HEAD"], path)
 
-
-def _run(coro):
-    return asyncio.run(coro)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_settle_subtask_branch_coverage.py
+++ b/tests/test_settle_subtask_branch_coverage.py
@@ -11,14 +11,11 @@ mocking git.
 """
 from __future__ import annotations
 
-import asyncio
 import subprocess
 
+from tests.conftest import _run
 from tests.test_oom_naming import env  # noqa: F401  (pytest fixture)
 
-
-def _run(coro):
-    return asyncio.run(coro)
 
 
 def _git(*args, cwd):


### PR DESCRIPTION
## Summary

Consolidates three families of byte-identical or near-identical test scaffolding that had drifted into copies across `tests/*.py`: the EC2 SSM-exec-decode `aws`/`ssh` stub builders, the recursive-decompose fixture builders (`_fit_response`, `_split_response`, `_make_caps`), and the `_run(coro)` async-test helper.

## Which layer(s) does this PR touch?

(See [`CLAUDE.md`](../CLAUDE.md) for the three-layer rule.)

- [ ] `docs/DESIGN.md` (architecture)
- [ ] `docs/IMPLEMENTATION.md` (code surface)
- [ ] `orchestrator/leerie.py` (code)
- [ ] docs (`README.md`, `docs/USAGE.md`, `CONTRIBUTING.md`, etc.)
- [x] tests (`tests/`)
- [ ] CI / repo meta (`.github/`)

If multiple, has the change propagated **top-down** per the three-layer rule
(DESIGN → IMPLEMENTATION → code)?

- [ ] yes
- [x] not applicable (single layer)

## Task-completion checklist

(Mirrors `CLAUDE.md` and `CONTRIBUTING.md`.)

- [ ] `docs/IMPLEMENTATION.md` updated if code surface changed
- [ ] `docs/DESIGN.md` updated if architecture changed
- [ ] `pytest tests/` passes
- [ ] `python3 -c "import ast; ast.parse(open('orchestrator/leerie.py').read())"` passes
- [ ] `git diff --stat` reviewed for scope (no collateral edits)

## Testing notes

- `tests/ec2_stub.py` gained parameterized `make_ssm_stub_aws`/`make_ssm_stub_ssh` builders; `test_ec2_seed_repo.py`, `test_ec2_fetch_branch.py`, and `test_ec2_seed_auth.py` now delegate to them with their own path-rewrite mappings instead of each defining a near-identical stub generator.
- `tests/conftest.py` gained shared `_fit_response`, `_split_response`, and `_make_caps` fixture builders for the recursive-decompose test family (`test_recursive_decompose.py`, `test_recursive_decompose_schedule.py`, `test_decompose_budget_share.py`, and related callers), including a fix for a duplicate-kwarg crash in `test_recursive_decompose.py`'s `_make_caps` wrapper.
- `tests/conftest.py` gained a single `_run(coro)` helper (`asyncio.run(coro)`), replacing the byte-identical definition that had been independently redefined in fifteen test files.
- No production code (`orchestrator/leerie.py`) was touched — this is test-scaffolding deduplication only.

## Related issue

<!-- Closes #N -->

## Conformance notes

- tests-failed: `pytest` — 5 of 8,309+115 tests failed (`test_signal_cleanup.py`'s `test_the_refusal_names_the_duplicate`, `test_terminate_proc_tree_reaps_grandchildren`, `test_terminate_proc_tree_reaps_detached_session_grandchildren`, `test_descendant_tracker_reaps_orphaned_backgrounded_subprocess`, plus one more in the same run).
- rule-residual: "build/lint/tests must pass" not fixed — "Pre-existing on base tree per BASELINE block (tests axis was already RED before this run's diff); this run touches only tests/*.py test-helper deduplication and does not touch signal_cleanup or duplicate-provider code paths."
