### PR TITLE
leerie: Consolidate duplicated EC2-launcher and accept-verb test harness helpers

### DIFF
--- a/tests/ec2_stub.py
+++ b/tests/ec2_stub.py
@@ -57,12 +57,46 @@ Usage:
 from __future__ import annotations
 
 import json
+import subprocess
 from pathlib import Path
 
 STATE_FILENAME = "state.json"
 LOG_FILENAME = "aws.log"
 
 _EMPTY_STATE = {"instances": {}, "volumes": {}}
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_LAUNCHER = REPO_ROOT / "leerie"
+
+
+def run_launcher(
+    args: list[str],
+    env: dict,
+    *,
+    launcher: Path = DEFAULT_LAUNCHER,
+    timeout: int = 30,
+    use_bash: bool = False,
+) -> subprocess.CompletedProcess:
+    """Invoke the `leerie` launcher as a subprocess and return the result.
+
+    Single-owner replacement for the near-identical `_run_launcher` helper
+    previously redefined in tests/test_auto_detect_run_runtime.py,
+    tests/test_ec2_launcher_kill.py, and tests/test_ec2_launcher_resume.py
+    (all `subprocess.run([LAUNCHER] + args, env=env, capture_output=True,
+    text=True, timeout=N)`, differing only in the timeout value and
+    whether the launcher is invoked via an explicit `bash` prefix). Not to
+    be confused with tests/test_group_state_dir_guard.py's own
+    `_run_launcher`, which has a materially different signature and
+    purpose (stub-binary injection) and is left untouched.
+    """
+    argv = (["bash", str(launcher)] if use_bash else [str(launcher)]) + args
+    return subprocess.run(
+        argv,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
 
 # The stub script itself. Kept as a single string (rather than importing
 # a shared module at runtime) so the stub has zero dependency on this

--- a/tests/test_accept_blocked.py
+++ b/tests/test_accept_blocked.py
@@ -23,12 +23,19 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 
 
 def _run_accept(state_path: Path, sid: str,
-                force: bool = False) -> subprocess.CompletedProcess:
-    """Run the accept-blocked mutation via the launcher."""
+                force: bool = False,
+                verb: str = "accept-blocked") -> subprocess.CompletedProcess:
+    """Run the accept-blocked/accept-integration mutation via the launcher.
+
+    Shared by the whole accept-verb test family (see
+    tests/test_accept_integration.py's ``verb="accept-integration"``
+    callers) -- this is the sole owner of the local-path launcher
+    invocation shape.
+    """
     env = {k: v for k, v in os.environ.items()}
     env["LEERIE_STATE_DIR"] = str(state_path.parent.parent.parent)
     run_id = state_path.parent.name
-    argv = [str(REPO_ROOT / "leerie"), "accept-blocked", run_id, sid,
+    argv = [str(REPO_ROOT / "leerie"), verb, run_id, sid,
             "--runtime", "local"]
     if force:
         argv.append("--force")
@@ -41,16 +48,20 @@ def _run_accept(state_path: Path, sid: str,
     )
 
 
-def _make_state(tmp_path: Path, subtask_status: dict,
-                blocked: dict | None = None,
-                waves: list | None = None) -> Path:
+def _make_state(tmp_path: Path, primary: dict, *,
+                key: str = "subtask_status",
+                **extra) -> Path:
+    """Write a state.json under a fresh run dir.
+
+    ``key`` names the top-level field ``primary`` is stored under
+    (``subtask_status`` for accept-blocked, ``integration_gate`` for
+    accept-integration -- see tests/test_accept_integration.py).
+    ``**extra`` (e.g. ``blocked=``, ``waves=``, ``integration_defects=``)
+    are merged in as further top-level fields when given.
+    """
     run_dir = tmp_path / "runs" / "test-run-001"
     run_dir.mkdir(parents=True)
-    state = {"subtask_status": subtask_status}
-    if blocked is not None:
-        state["blocked"] = blocked
-    if waves is not None:
-        state["waves"] = waves
+    state = {key: primary, **extra}
     state_file = run_dir / "state.json"
     state_file.write_text(json.dumps(state, indent=2))
     return state_file

--- a/tests/test_accept_integration.py
+++ b/tests/test_accept_integration.py
@@ -33,38 +33,26 @@ import subprocess
 from pathlib import Path
 from unittest.mock import AsyncMock
 
+from functools import partial
+
 from tests.test_accept_blocked import (
     _expected_remote_state,
     _flyctl_stub,
+    _make_state as _make_state_base,
+    _run_accept,
 )
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 
+# accept-integration's local-path invocation shares _run_accept's argv
+# shape with accept-blocked (tests/test_accept_blocked.py), differing
+# only in which launcher verb is dispatched.
+_run_accept = partial(_run_accept, verb="accept-integration")
 
-def _run_accept(state_path: Path, sid: str) -> subprocess.CompletedProcess:
-    env = {k: v for k, v in os.environ.items()}
-    env["LEERIE_STATE_DIR"] = str(state_path.parent.parent.parent)
-    run_id = state_path.parent.name
-    return subprocess.run(
-        [str(REPO_ROOT / "leerie"), "accept-integration", run_id, sid,
-         "--runtime", "local"],
-        env=env,
-        capture_output=True,
-        text=True,
-        timeout=30,
-    )
-
-
-def _make_state(tmp_path: Path, integration_gate: dict,
-                integration_defects: dict | None = None) -> Path:
-    run_dir = tmp_path / "runs" / "test-run-001"
-    run_dir.mkdir(parents=True)
-    state = {"integration_gate": integration_gate}
-    if integration_defects is not None:
-        state["integration_defects"] = integration_defects
-    state_file = run_dir / "state.json"
-    state_file.write_text(json.dumps(state, indent=2))
-    return state_file
+# accept-integration writes state.json's "integration_gate" field where
+# accept-blocked writes "subtask_status" -- everything else about state
+# construction is shared.
+_make_state = partial(_make_state_base, key="integration_gate")
 
 
 def test_accepts_a_rejected_finding(tmp_path):

--- a/tests/test_auto_detect_run_runtime.py
+++ b/tests/test_auto_detect_run_runtime.py
@@ -33,6 +33,8 @@ import os
 import subprocess
 from pathlib import Path
 
+from tests.ec2_stub import run_launcher as _run_launcher_shared
+
 REPO_ROOT_LAUNCHER = Path(__file__).resolve().parent.parent / "leerie"
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -225,20 +227,16 @@ def _make_e2e_run(state_dir: Path, run_id: str, *, ec2: bool = False,
     return run_dir
 
 
-def _run_launcher(args: list[str], state_dir: Path) -> subprocess.CompletedProcess:
-    return subprocess.run(
-        [str(REPO_ROOT_LAUNCHER)] + args,
-        env=_launcher_env(state_dir),
-        capture_output=True,
-        text=True,
-        timeout=30,
+def _launcher(args: list[str], state_dir: Path) -> subprocess.CompletedProcess:
+    return _run_launcher_shared(
+        args, _launcher_env(state_dir), launcher=REPO_ROOT_LAUNCHER, timeout=30
     )
 
 
 def test_stop_rejects_bogus_runtime_value(tmp_path):
     state_dir = tmp_path / "state"
     _make_e2e_run(state_dir, "r1")
-    r = _run_launcher(["stop", "r1", "--runtime", "bogus"], state_dir)
+    r = _launcher(["stop", "r1", "--runtime", "bogus"], state_dir)
     assert r.returncode != 0
     assert "must be 'local', 'fly', or 'ec2'" in r.stderr
 
@@ -252,7 +250,7 @@ def test_stop_accepts_explicit_ec2_enum_but_needs_a_sidecar(tmp_path):
     an unknown-runtime rejection."""
     state_dir = tmp_path / "state"
     _make_e2e_run(state_dir, "r1")
-    r = _run_launcher(["stop", "r1", "--runtime", "ec2"], state_dir)
+    r = _launcher(["stop", "r1", "--runtime", "ec2"], state_dir)
     assert r.returncode != 0
     assert "must be" not in r.stderr
     assert "does not support EC2 runs yet" not in r.stderr
@@ -267,7 +265,7 @@ def test_stop_autodetects_ec2_sidecar_and_proceeds_past_detection(tmp_path):
     tests/test_ec2_launcher_stop.py against a stubbed `aws`."""
     state_dir = tmp_path / "state"
     _make_e2e_run(state_dir, "r1", ec2=True)
-    r = _run_launcher(["stop", "r1"], state_dir)
+    r = _launcher(["stop", "r1"], state_dir)
     assert r.returncode != 0
     assert "auto-detected ec2 run" in r.stderr
     assert "does not support EC2 runs yet" not in r.stderr
@@ -276,7 +274,7 @@ def test_stop_autodetects_ec2_sidecar_and_proceeds_past_detection(tmp_path):
 def test_stop_fly_sidecar_still_promotes_to_fly_no_regression(tmp_path):
     state_dir = tmp_path / "state"
     _make_e2e_run(state_dir, "r1", fly=True)
-    r = _run_launcher(["stop", "r1"], state_dir)
+    r = _launcher(["stop", "r1"], state_dir)
     # No LEERIE_FLY_APP set, so it still fails — but via the pre-existing
     # Fly-specific error, proving detection promoted to "fly" and reached
     # the Fly branch rather than the (now EC2-aware) fallthrough.
@@ -294,7 +292,7 @@ def test_kill_accepts_explicit_ec2_enum_but_needs_a_sidecar(tmp_path):
     have."""
     state_dir = tmp_path / "state"
     _make_e2e_run(state_dir, "r1")
-    r = _run_launcher(["kill", "r1", "--runtime", "ec2", "--force"], state_dir)
+    r = _launcher(["kill", "r1", "--runtime", "ec2", "--force"], state_dir)
     assert r.returncode != 0
     assert "does not support EC2 runs yet" not in r.stderr
     assert "no ec2_instance_id found" in r.stderr
@@ -309,7 +307,7 @@ def test_kill_autodetects_ec2_sidecar_and_proceeds_past_detection(tmp_path):
     tests/test_ec2_launcher_kill.py against a stubbed `aws`."""
     state_dir = tmp_path / "state"
     _make_e2e_run(state_dir, "r1", ec2=True)
-    r = _run_launcher(["kill", "r1", "--force"], state_dir)
+    r = _launcher(["kill", "r1", "--force"], state_dir)
     assert r.returncode != 0
     assert "auto-detected ec2 run" in r.stderr
     assert "does not support EC2 runs yet" not in r.stderr
@@ -321,7 +319,7 @@ def test_accept_blocked_rejects_bogus_runtime_value(tmp_path):
     (run_dir / "state.json").write_text(
         json.dumps({"subtask_status": {"s1": "blocked"}})
     )
-    r = _run_launcher(
+    r = _launcher(
         ["accept-blocked", "r1", "s1", "--runtime", "bogus"], state_dir
     )
     assert r.returncode != 0
@@ -341,7 +339,7 @@ def test_accept_blocked_autodetects_ec2_sidecar(tmp_path):
     (run_dir / "state.json").write_text(
         json.dumps({"subtask_status": {"s1": "blocked"}})
     )
-    r = _run_launcher(["accept-blocked", "r1", "s1"], state_dir)
+    r = _launcher(["accept-blocked", "r1", "s1"], state_dir)
     assert r.returncode != 0
     assert "does not support EC2 runs yet" not in r.stderr
     assert "aws" in r.stderr.lower()
@@ -354,7 +352,7 @@ def test_accept_blocked_autodetects_ec2_sidecar(tmp_path):
 def test_finalize_rejects_bogus_runtime_value(tmp_path):
     state_dir = tmp_path / "state"
     _make_e2e_run(state_dir, "r1")
-    r = _run_launcher(["finalize", "r1", "--runtime", "bogus"], state_dir)
+    r = _launcher(["finalize", "r1", "--runtime", "bogus"], state_dir)
     assert r.returncode != 0
     assert "must be 'local', 'fly', or 'ec2'" in r.stderr
 
@@ -373,7 +371,7 @@ def test_finalize_rejects_bogus_runtime_value(tmp_path):
 def test_finalize_accepts_explicit_ec2_enum_and_enters_the_ec2_arm(tmp_path):
     state_dir = tmp_path / "state"
     _make_e2e_run(state_dir, "r1")
-    r = _run_launcher(["finalize", "r1", "--runtime", "ec2"], state_dir)
+    r = _launcher(["finalize", "r1", "--runtime", "ec2"], state_dir)
     assert r.returncode != 0
     assert "does not support EC2 runs yet" not in r.stderr
     # This fixture writes no ec2_instance_id, so the arm's own fail-closed
@@ -384,7 +382,7 @@ def test_finalize_accepts_explicit_ec2_enum_and_enters_the_ec2_arm(tmp_path):
 def test_finalize_autodetects_ec2_sidecar_and_promotes(tmp_path):
     state_dir = tmp_path / "state"
     _make_e2e_run(state_dir, "r1", ec2=True)
-    r = _run_launcher(["finalize", "r1"], state_dir)
+    r = _launcher(["finalize", "r1"], state_dir)
     assert "auto-detected EC2 run; promoting --runtime to ec2" in r.stderr
     assert "does not support EC2 runs yet" not in r.stderr
 
@@ -424,7 +422,7 @@ def test_resume_autodetects_ec2_sidecar_and_promotes(tmp_path):
 def test_resume_fly_sidecar_still_promotes_to_fly_no_regression(tmp_path):
     state_dir = tmp_path / "state"
     _make_e2e_run(state_dir, "r1", fly=True, with_state=True)
-    r = _run_launcher(["resume", "r1"], state_dir)
+    r = _launcher(["resume", "r1"], state_dir)
     assert r.returncode != 0
     assert "auto-detected Fly run" in r.stderr
     assert "LEERIE_FLY_APP is required" in r.stderr

--- a/tests/test_ec2_launcher_kill.py
+++ b/tests/test_ec2_launcher_kill.py
@@ -40,7 +40,13 @@ import os
 import subprocess
 from pathlib import Path
 
-from tests.ec2_stub import leaked_resources, read_log, read_state, seed_running_instance
+from tests.ec2_stub import (
+    leaked_resources,
+    read_log,
+    read_state,
+    run_launcher as _run_launcher_shared,
+    seed_running_instance,
+)
 from tests.stub_helpers import _make_stub_timeout
 from tests.test_ec2_fetch_branch import (
     _init_instance_repo_with_run,
@@ -189,14 +195,8 @@ def _setup_fixture(tmp_path: Path, *, with_completed_run: bool = True):
     return env, bin_dir, state_dir, run_dir, instance_id
 
 
-def _run_launcher(args: list[str], env: dict) -> subprocess.CompletedProcess:
-    return subprocess.run(
-        [str(LAUNCHER)] + args,
-        env=env,
-        capture_output=True,
-        text=True,
-        timeout=60,
-    )
+def _launcher(args: list[str], env: dict) -> subprocess.CompletedProcess:
+    return _run_launcher_shared(args, env, launcher=LAUNCHER, timeout=60)
 
 
 # ---------------------------------------------------------------------------
@@ -207,7 +207,7 @@ def _run_launcher(args: list[str], env: dict) -> subprocess.CompletedProcess:
 def test_fetch_precedes_terminate_by_call_index(tmp_path):
     env, aws_dir, state_dir, run_dir, iid = _setup_fixture(tmp_path)
 
-    result = _run_launcher(["kill", "r1", "--force"], env)
+    result = _launcher(["kill", "r1", "--force"], env)
 
     assert result.returncode == 0, f"stdout={result.stdout} stderr={result.stderr}"
 
@@ -228,7 +228,7 @@ def test_fetch_precedes_terminate_by_call_index(tmp_path):
 def test_successful_kill_leaves_zero_non_terminated_instances_and_no_leaked_volumes(tmp_path):
     env, aws_dir, state_dir, run_dir, iid = _setup_fixture(tmp_path)
 
-    result = _run_launcher(["kill", "r1", "--force"], env)
+    result = _launcher(["kill", "r1", "--force"], env)
     assert result.returncode == 0, f"stdout={result.stdout} stderr={result.stderr}"
 
     state = read_state(aws_dir)
@@ -245,7 +245,7 @@ def test_fetch_failure_leaves_instance_running_not_terminated(tmp_path):
         tmp_path, with_completed_run=False
     )
 
-    result = _run_launcher(["kill", "r1", "--force"], env)
+    result = _launcher(["kill", "r1", "--force"], env)
 
     assert result.returncode != 0
     combined = result.stdout + result.stderr
@@ -272,7 +272,7 @@ def test_kill_never_hands_the_run_id_to_flyctl(tmp_path):
     run, on both the success and failure paths."""
     env, aws_dir, state_dir, run_dir, iid = _setup_fixture(tmp_path)
 
-    result = _run_launcher(["kill", "r1", "--force"], env)
+    result = _launcher(["kill", "r1", "--force"], env)
     assert result.returncode == 0, f"stdout={result.stdout} stderr={result.stderr}"
     assert _read_flyctl_log(aws_dir) == [], "flyctl must never be invoked for an EC2 run"
 
@@ -282,7 +282,7 @@ def test_kill_never_hands_the_run_id_to_flyctl_on_fetch_failure(tmp_path):
         tmp_path, with_completed_run=False
     )
 
-    result = _run_launcher(["kill", "r1", "--force"], env)
+    result = _launcher(["kill", "r1", "--force"], env)
     assert result.returncode != 0
     assert _read_flyctl_log(aws_dir) == [], "flyctl must never be invoked for an EC2 run"
 
@@ -295,7 +295,7 @@ def test_kill_never_hands_the_run_id_to_flyctl_on_fetch_failure(tmp_path):
 def test_successful_kill_marks_run_json_killed(tmp_path):
     env, aws_dir, state_dir, run_dir, iid = _setup_fixture(tmp_path)
 
-    result = _run_launcher(["kill", "r1", "--force"], env)
+    result = _launcher(["kill", "r1", "--force"], env)
     assert result.returncode == 0, f"stdout={result.stdout} stderr={result.stderr}"
 
     run_json = json.loads((run_dir / "run.json").read_text())
@@ -310,7 +310,7 @@ def test_kill_bootstraps_run_json_from_ec2_instance_sidecar_when_absent(tmp_path
     env, aws_dir, state_dir, run_dir, iid = _setup_fixture(tmp_path)
     (run_dir / "run.json").unlink()
 
-    result = _run_launcher(["kill", "r1", "--force"], env)
+    result = _launcher(["kill", "r1", "--force"], env)
     assert result.returncode == 0, f"stdout={result.stdout} stderr={result.stderr}"
 
     run_json = json.loads((run_dir / "run.json").read_text())
@@ -328,7 +328,7 @@ def test_kill_fails_closed_when_no_instance_id_in_sidecar(tmp_path):
     (run_dir / "ec2-instance.json").unlink()
     (run_dir / "run.json").write_text(json.dumps({}))
 
-    result = _run_launcher(["kill", "r1", "--runtime", "ec2", "--force"], env)
+    result = _launcher(["kill", "r1", "--runtime", "ec2", "--force"], env)
 
     assert result.returncode != 0
     assert "no ec2_instance_id found" in result.stderr
@@ -386,7 +386,7 @@ def test_kill_with_correct_confirmation_proceeds(tmp_path):
 
 def test_kill_runtime_flag_rejects_unknown_value(tmp_path):
     env, aws_dir, state_dir, run_dir, iid = _setup_fixture(tmp_path)
-    result = _run_launcher(["kill", "r1", "--runtime", "bogus", "--force"], env)
+    result = _launcher(["kill", "r1", "--runtime", "bogus", "--force"], env)
     assert result.returncode == 1
     assert "must be 'local', 'fly', or 'ec2'" in result.stderr
     log = read_log(aws_dir)
@@ -395,7 +395,7 @@ def test_kill_runtime_flag_rejects_unknown_value(tmp_path):
 
 def test_kill_unknown_flag_errors(tmp_path):
     env, aws_dir, state_dir, run_dir, iid = _setup_fixture(tmp_path)
-    result = _run_launcher(["kill", "r1", "--bogus-flag", "--force"], env)
+    result = _launcher(["kill", "r1", "--bogus-flag", "--force"], env)
     assert result.returncode == 1
     assert "unknown kill flag" in result.stderr
     log = read_log(aws_dir)
@@ -404,7 +404,7 @@ def test_kill_unknown_flag_errors(tmp_path):
 
 def test_kill_unexpected_second_positional_errors(tmp_path):
     env, aws_dir, state_dir, run_dir, iid = _setup_fixture(tmp_path)
-    result = _run_launcher(["kill", "r1", "r2", "--force"], env)
+    result = _launcher(["kill", "r1", "r2", "--force"], env)
     assert result.returncode == 1
     assert "unexpected kill arg" in result.stderr
     log = read_log(aws_dir)

--- a/tests/test_ec2_launcher_resume.py
+++ b/tests/test_ec2_launcher_resume.py
@@ -27,7 +27,13 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-from tests.ec2_stub import _stub_aws, read_log, read_state, seed_running_instance
+from tests.ec2_stub import (
+    _stub_aws,
+    read_log,
+    read_state,
+    run_launcher as _run_launcher_shared,
+    seed_running_instance,
+)
 from tests.test_ec2_e2e_provision import (
     REQUIRED_PROVISION_ENV,
     extract_ec2_dispatch_block,
@@ -355,10 +361,8 @@ def _paused_ec2_run(state_dir: Path, run_id: str, iid: str) -> None:
         "pause_reason": "user-requested"}))
 
 
-def _run_launcher(args: list[str], env: dict):
-    import subprocess
-    return subprocess.run(["bash", str(LAUNCHER)] + args,
-                          env=env, capture_output=True, text=True, timeout=120)
+def _launcher(args: list[str], env: dict):
+    return _run_launcher_shared(args, env, launcher=LAUNCHER, timeout=120, use_bash=True)
 
 
 def test_real_launcher_promotes_runtime_for_a_paused_ec2_run(tmp_path: Path):
@@ -370,7 +374,7 @@ def test_real_launcher_promotes_runtime_for_a_paused_ec2_run(tmp_path: Path):
     env, state_dir = _seam_env(tmp_path, aws_dir)
     _paused_ec2_run(state_dir, RUN_ID, "i-00000000000000042")
 
-    err = (_run_launcher(["resume", RUN_ID], env).stderr or "")
+    err = (_launcher(["resume", RUN_ID], env).stderr or "")
     assert "promoting --runtime to ec2" in err, (
         "the resume verb must promote RUNTIME=ec2 for a run whose sidecar "
         f"names an instance, so the dispatch block is reachable. stderr:\n{err}")
@@ -383,7 +387,7 @@ def test_real_launcher_no_longer_fails_closed_on_ec2_resume(tmp_path: Path):
     env, state_dir = _seam_env(tmp_path, aws_dir)
     _paused_ec2_run(state_dir, RUN_ID, "i-00000000000000043")
 
-    err = (_run_launcher(["resume", RUN_ID], env).stderr or "")
+    err = (_launcher(["resume", RUN_ID], env).stderr or "")
     assert "does not support EC2 runs yet" not in err, err
 
 
@@ -400,7 +404,7 @@ def test_fly_resume_promotion_is_unchanged(tmp_path: Path):
     (run_dir / "fly-machine.json").write_text(json.dumps(
         {"fly_machine_id": "5683dcd0", "run_id": "fly-run-0001"}))
 
-    err = (_run_launcher(["resume", "fly-run-0001"], env).stderr or "")
+    err = (_launcher(["resume", "fly-run-0001"], env).stderr or "")
     assert "promoting --runtime to fly" in err, err
     assert "promoting --runtime to ec2" not in err, err
 

--- a/tests/test_no_duplicate_accept_verb_helper.py
+++ b/tests/test_no_duplicate_accept_verb_helper.py
@@ -1,0 +1,99 @@
+"""Guards the single-owner `_run_accept`/`_make_state` test harness helpers
+for the accept-verb family (accept-blocked, accept-integration).
+
+tests/test_accept_blocked.py is the sole owner. tests/test_accept_integration.py
+already imports both names from it (`from tests.test_accept_blocked import
+_run_accept, _make_state`) rather than redefining them -- this is the
+location refactor-001 establishes and the codebase already implements, not
+tests/conftest.py. See tests/test_no_duplicate_run_bash_helper.py for the
+shrink-only-allowlist pattern this mirrors.
+
+Scoped to the accept-verb family only: `_make_state` is a generic name
+reused by ~25 unrelated test files for unrelated State-object builders, so
+this file's scan is restricted to files that also reference `_run_accept(`
+(the accept-verb call shape) -- never a blanket `^def _make_state(` sweep
+across tests/.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+TESTS_DIR = REPO_ROOT / "tests"
+
+_OWNER = "tests/test_accept_blocked.py"
+
+_DEF_RUN_ACCEPT_RE = re.compile(r"^\s*def _run_accept\(", re.MULTILINE)
+_CALLS_RUN_ACCEPT_RE = re.compile(r"_run_accept\(")
+
+# Legacy call sites not yet migrated onto the shared helpers. Shrink-only:
+# a migration subtask removes a file's local def, drops the file's name
+# from this set in the same commit, and CI catches any new local def
+# outside this set.
+_KNOWN_UNMIGRATED: frozenset[str] = frozenset()
+
+
+def _accept_verb_family_files() -> list[Path]:
+    """Files under tests/ that reference the `_run_accept(` call shape --
+    the scope signal that distinguishes the accept-verb family from the
+    ~25 unrelated files that define their own generically-named
+    `_make_state` for unrelated purposes."""
+    return [
+        path
+        for path in sorted(TESTS_DIR.rglob("test_*.py"))
+        if _CALLS_RUN_ACCEPT_RE.search(path.read_text())
+    ]
+
+
+def test_run_accept_and_make_state_importable_from_test_accept_blocked():
+    import tests.test_accept_blocked as owner
+
+    assert callable(owner._run_accept)
+    assert callable(owner._make_state)
+
+
+def test_test_accept_integration_imports_rather_than_redefines():
+    text = (TESTS_DIR / "test_accept_integration.py").read_text()
+    assert "from tests.test_accept_blocked import" in text
+    assert "_run_accept" in text
+    assert "_make_state" in text
+    assert not _DEF_RUN_ACCEPT_RE.search(text), (
+        "test_accept_integration.py defines a local `_run_accept` instead "
+        "of importing the shared one from tests.test_accept_blocked"
+    )
+
+
+def test_no_local_run_accept_reimplementations_outside_the_owner():
+    """No file that calls `_run_accept(...)` may define its own local
+    `_run_accept` unless it is the owner (tests/test_accept_blocked.py) or
+    a still-unmigrated legacy site named in `_KNOWN_UNMIGRATED`."""
+    offenders = []
+    for path in _accept_verb_family_files():
+        rel = str(path.relative_to(REPO_ROOT))
+        if rel == _OWNER:
+            continue
+        if _DEF_RUN_ACCEPT_RE.search(path.read_text()):
+            offenders.append(rel)
+    unexpected = sorted(set(offenders) - _KNOWN_UNMIGRATED)
+    assert unexpected == [], (
+        "The following files define a NEW local `_run_accept` helper "
+        "instead of importing it from tests.test_accept_blocked:\n"
+        + "\n".join(unexpected)
+    )
+
+
+def test_allowlist_has_no_stale_entries():
+    offenders = set()
+    for path in _accept_verb_family_files():
+        rel = str(path.relative_to(REPO_ROOT))
+        if rel == _OWNER:
+            continue
+        if _DEF_RUN_ACCEPT_RE.search(path.read_text()):
+            offenders.add(rel)
+    stale = sorted(_KNOWN_UNMIGRATED - offenders)
+    assert stale == [], (
+        "The following files no longer define a local `_run_accept` but "
+        "are still in the allowlist; remove them from _KNOWN_UNMIGRATED:\n"
+        + "\n".join(stale)
+    )

--- a/tests/test_no_duplicate_ec2_run_launcher_helper.py
+++ b/tests/test_no_duplicate_ec2_run_launcher_helper.py
@@ -1,0 +1,111 @@
+"""Guards the single-owner `run_launcher` helper in tests/ec2_stub.py.
+
+Once refactor-001 landed, no file under tests/ should redefine the
+`(args, env) -> subprocess.CompletedProcess` shape of `_run_launcher`
+that used to be duplicated across tests/test_auto_detect_run_runtime.py,
+tests/test_ec2_launcher_kill.py, and tests/test_ec2_launcher_resume.py --
+every call site should import `run_launcher` from tests/ec2_stub.py
+instead (optionally wrapping it in a thin local function under a
+different name, as those three files now do).
+
+tests/test_group_state_dir_guard.py's own `_run_launcher(tmp_path, args,
+env_extra=None, stub=None, stub_log=None)` is a genuinely distinct helper
+(different purpose: injects a stub binary and returns a `.stub_log`-
+augmented result) and is excluded by construction -- the regex below
+matches only the specific two-positional-arg `(args, env)` call shape,
+not that five-parameter one.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+TESTS_DIR = REPO_ROOT / "tests"
+
+# Matches `def _run_launcher(args..., env...)` -- i.e. a two-positional-arg
+# def whose second parameter is named `env`, which is the shape the three
+# migrated duplicates shared. tests/test_group_state_dir_guard.py's
+# `_run_launcher(tmp_path, args, env_extra=None, ...)` does not match: its
+# second positional parameter is named `args`, not `env`.
+_DEF_RE = re.compile(
+    r"^\s*def _run_launcher\(\s*args\s*:[^,]*,\s*env\s*:", re.MULTILINE
+)
+
+# Legacy call sites not yet migrated to the shared `run_launcher` helper.
+# This is a shrink-only allowlist: a migration subtask removes a file's
+# local two-positional-arg `_run_launcher` def, drops the file's name from
+# this set in the same commit, and CI catches any new local redefinition
+# of that shape outside this set.
+_KNOWN_UNMIGRATED: frozenset[str] = frozenset()
+
+
+def test_run_launcher_is_defined_in_ec2_stub():
+    import tests.ec2_stub as ec2_stub
+
+    assert callable(ec2_stub.run_launcher)
+
+
+def test_run_launcher_matches_the_common_call_shape():
+    import inspect
+
+    import tests.ec2_stub as ec2_stub
+
+    sig = inspect.signature(ec2_stub.run_launcher)
+    params = sig.parameters
+    assert list(params) == ["args", "env", "launcher", "timeout", "use_bash"]
+    assert params["launcher"].kind == inspect.Parameter.KEYWORD_ONLY
+    assert params["timeout"].kind == inspect.Parameter.KEYWORD_ONLY
+    assert params["use_bash"].kind == inspect.Parameter.KEYWORD_ONLY
+    assert params["timeout"].default == 30
+    assert params["use_bash"].default is False
+
+
+def test_no_local_run_launcher_reimplementations_outside_the_allowlist():
+    """No file under tests/ defines its own two-positional-arg
+    `def _run_launcher(args, env)` unless it is a still-unmigrated legacy
+    site named in `_KNOWN_UNMIGRATED`. A new local def of that shape
+    outside that set is a fresh duplication and must import the shared
+    `run_launcher` helper from tests/ec2_stub.py instead."""
+    offenders = []
+    for path in sorted(TESTS_DIR.rglob("test_*.py")):
+        text = path.read_text()
+        if _DEF_RE.search(text):
+            offenders.append(str(path.relative_to(REPO_ROOT)))
+    unexpected = sorted(set(offenders) - _KNOWN_UNMIGRATED)
+    assert unexpected == [], (
+        "The following files define a NEW local two-positional-arg "
+        "`_run_launcher(args, env)` helper not in the legacy allowlist; "
+        "import `run_launcher` from tests/ec2_stub.py instead:\n"
+        + "\n".join(unexpected)
+    )
+
+
+def test_allowlist_has_no_stale_entries():
+    """Every entry in `_KNOWN_UNMIGRATED` must still define a local
+    two-positional-arg `_run_launcher`. When a migration subtask removes
+    a file's local def, it must also drop that file's name from this
+    allowlist in the same commit -- otherwise this shrink-only list
+    silently stops shrinking."""
+    offenders = set()
+    for path in sorted(TESTS_DIR.rglob("test_*.py")):
+        text = path.read_text()
+        if _DEF_RE.search(text):
+            offenders.add(str(path.relative_to(REPO_ROOT)))
+    stale = sorted(_KNOWN_UNMIGRATED - offenders)
+    assert stale == [], (
+        "The following files no longer define a local two-positional-arg "
+        "`_run_launcher` but are still in the allowlist; remove them from "
+        "_KNOWN_UNMIGRATED:\n" + "\n".join(stale)
+    )
+
+
+def test_group_state_dir_guard_helper_is_not_flagged():
+    """Anti-vacuity control: the regex must not match
+    tests/test_group_state_dir_guard.py's genuinely distinct
+    `_run_launcher(tmp_path, args, env_extra=None, stub=None,
+    stub_log=None)` helper, which this guard is not meant to migrate."""
+    path = TESTS_DIR / "test_group_state_dir_guard.py"
+    text = path.read_text()
+    assert "def _run_launcher(" in text
+    assert not _DEF_RE.search(text)

--- a/tests/test_no_duplicate_launcher_invoke_helper.py
+++ b/tests/test_no_duplicate_launcher_invoke_helper.py
@@ -1,0 +1,190 @@
+"""Guards the single-owner `run_launcher` invoke helper in tests/ec2_stub.py.
+
+tests/ec2_stub.py, not tests/conftest.py, is the established convention for
+EC2-launcher-test scaffolding (see its own docstring on `make_ssm_stub_aws`
+et al.: "Single-owner discipline (same precedent as the state-machine stub
+above and tests/launcher_blocks.py)"). `run_launcher` there already
+replaced the near-identical `_run_launcher` previously redefined in
+tests/test_auto_detect_run_runtime.py, tests/test_ec2_launcher_kill.py, and
+tests/test_ec2_launcher_resume.py.
+
+Mirrors tests/test_no_duplicate_run_bash_helper.py's shrink-only-allowlist
+pattern: no file under tests/ should define its own `def _run_launcher(`
+(or same-shaped invoke helper) unless it is either a still-unmigrated
+legacy site named in `_KNOWN_UNMIGRATED`, or the permanently-excluded
+tests/test_group_state_dir_guard.py, whose own `_run_launcher` is a
+materially different, 5-parameter stub-binary-injection helper that
+happens to share a name and is not a duplicate of this one.
+"""
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+TESTS_DIR = REPO_ROOT / "tests"
+
+_HELPER_NAME = "_run_launcher"
+
+# The (args, env) two-positional-parameter shape that
+# tests/ec2_stub.py::run_launcher replaces. This is what distinguishes a
+# reintroduced duplicate from tests/test_group_state_dir_guard.py's
+# unrelated 5-parameter `_run_launcher(tmp_path, args, env_extra, stub,
+# stub_log)`, which shares only the name.
+_DUPLICATE_SHAPE_PARAM_COUNT = 2
+
+# Permanently excluded: not a legacy unmigrated site, and never intended to
+# migrate onto tests.ec2_stub.run_launcher -- see the module docstring and
+# tests/ec2_stub.py::run_launcher's own docstring.
+_PERMANENT_EXCEPTIONS: frozenset[str] = frozenset(
+    {"tests/test_group_state_dir_guard.py"}
+)
+
+# Shrink-only allowlist for genuinely unmigrated legacy sites. refactor-002
+# already consolidated the three known duplicates
+# (test_ec2_launcher_kill.py, test_ec2_launcher_resume.py,
+# test_auto_detect_run_runtime.py) into tests.ec2_stub.run_launcher, so
+# this starts empty. A future migration subtask removes a file's local
+# duplicate-shaped `_run_launcher` def and, if it cannot land the same
+# commit as the def's removal, adds the file's name here temporarily --
+# then drops it again once the def is gone.
+_KNOWN_UNMIGRATED: frozenset[str] = frozenset()
+
+
+def _duplicate_shaped_run_launcher_files() -> set[str]:
+    """Files under tests/ defining a `_run_launcher` with the duplicate
+    (args, env) two-positional-parameter shape, excluding
+    _PERMANENT_EXCEPTIONS."""
+    offenders: set[str] = set()
+    for path in sorted(TESTS_DIR.rglob("test_*.py")):
+        rel = str(path.relative_to(REPO_ROOT))
+        if rel in _PERMANENT_EXCEPTIONS:
+            continue
+        tree = ast.parse(path.read_text())
+        for node in ast.walk(tree):
+            if isinstance(node, ast.FunctionDef) and node.name == _HELPER_NAME:
+                args = node.args
+                param_count = len(args.posonlyargs) + len(args.args)
+                if param_count == _DUPLICATE_SHAPE_PARAM_COUNT:
+                    offenders.add(rel)
+    return offenders
+
+
+def test_run_launcher_is_importable_from_ec2_stub():
+    import tests.ec2_stub as ec2_stub
+
+    assert callable(ec2_stub.run_launcher)
+
+
+def test_run_launcher_matches_the_common_call_shape():
+    import inspect
+
+    import tests.ec2_stub as ec2_stub
+
+    sig = inspect.signature(ec2_stub.run_launcher)
+    params = sig.parameters
+    assert list(params) == ["args", "env", "launcher", "timeout", "use_bash"]
+    assert params["launcher"].kind == inspect.Parameter.KEYWORD_ONLY
+    assert params["timeout"].kind == inspect.Parameter.KEYWORD_ONLY
+    assert params["use_bash"].kind == inspect.Parameter.KEYWORD_ONLY
+    assert params["timeout"].default == 30
+    assert params["use_bash"].default is False
+
+
+def test_no_local_invoke_helper_reimplementations_outside_the_allowlist():
+    """No file under tests/ defines its own duplicate-shaped `_run_launcher`
+    unless it is a still-unmigrated legacy site named in
+    `_KNOWN_UNMIGRATED`. A new local duplicate-shaped `_run_launcher` def
+    outside that set is a fresh duplication and must import the shared
+    `run_launcher` helper from tests/ec2_stub.py instead."""
+    offenders = _duplicate_shaped_run_launcher_files()
+    unexpected = sorted(offenders - _KNOWN_UNMIGRATED)
+    assert unexpected == [], (
+        "The following files define a NEW local duplicate-shaped "
+        "`_run_launcher` helper not in the legacy allowlist; import "
+        "`run_launcher` from tests/ec2_stub.py instead:\n"
+        + "\n".join(unexpected)
+    )
+
+
+def test_allowlist_has_no_stale_entries():
+    """Every entry in `_KNOWN_UNMIGRATED` must still define a duplicate-
+    shaped local `_run_launcher`. When a migration subtask removes a
+    file's local def, it must also drop that file's name from this
+    allowlist in the same commit -- otherwise this shrink-only list
+    silently stops shrinking."""
+    offenders = _duplicate_shaped_run_launcher_files()
+    stale = sorted(_KNOWN_UNMIGRATED - offenders)
+    assert stale == [], (
+        "The following files no longer define a duplicate-shaped local "
+        "`_run_launcher` but are still in the allowlist; remove them from "
+        "_KNOWN_UNMIGRATED:\n" + "\n".join(stale)
+    )
+
+
+def test_migrated_files_import_the_shared_helper():
+    """The three files refactor-002 consolidated must import
+    tests.ec2_stub.run_launcher rather than defining their own -- this is
+    the positive control proving _KNOWN_UNMIGRATED is empty because they
+    migrated, not because the scan is blind to them."""
+    migrated = [
+        "tests/test_ec2_launcher_kill.py",
+        "tests/test_ec2_launcher_resume.py",
+        "tests/test_auto_detect_run_runtime.py",
+    ]
+    for rel in migrated:
+        text = (REPO_ROOT / rel).read_text()
+        assert "from tests.ec2_stub import" in text or "tests.ec2_stub" in text, (
+            f"{rel} no longer appears to import tests.ec2_stub -- did it "
+            "regain a local duplicate-shaped `_run_launcher`?"
+        )
+
+
+def test_permanent_exception_still_has_a_different_shape():
+    """tests/test_group_state_dir_guard.py's `_run_launcher` must keep a
+    param count different from the duplicate shape this guard scans for,
+    or the permanent-exception carve-out is silently hiding a real
+    duplicate. If this ever fails because that helper's signature
+    changed to match ec2_stub.run_launcher's shape, it should be migrated
+    and dropped from _PERMANENT_EXCEPTIONS instead of exempted."""
+    rel = "tests/test_group_state_dir_guard.py"
+    assert rel in _PERMANENT_EXCEPTIONS
+    tree = ast.parse((REPO_ROOT / rel).read_text())
+    found = False
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == _HELPER_NAME:
+            found = True
+            args = node.args
+            param_count = len(args.posonlyargs) + len(args.args)
+            assert param_count != _DUPLICATE_SHAPE_PARAM_COUNT, (
+                f"{rel}'s `_run_launcher` now matches the duplicate "
+                "(args, env) shape -- it should migrate onto "
+                "tests.ec2_stub.run_launcher and be removed from "
+                "_PERMANENT_EXCEPTIONS rather than staying exempted."
+            )
+    assert found, f"{rel} no longer defines `_run_launcher` at all"
+
+
+def test_scan_finds_a_planted_reproduction():
+    """Anti-vacuity: the AST scan must actually detect a duplicate-shaped
+    `_run_launcher` when one exists, proving a return of `[]` elsewhere
+    reflects a clean tree rather than a scan that matches nothing."""
+    import tempfile
+
+    src = (
+        "import subprocess\n\n"
+        "def _run_launcher(args, env):\n"
+        "    return subprocess.run(['leerie'] + args, env=env)\n"
+    )
+    with tempfile.TemporaryDirectory() as tmp:
+        planted = Path(tmp) / "test_planted_reproduction.py"
+        planted.write_text(src)
+        tree = ast.parse(planted.read_text())
+        found = any(
+            isinstance(node, ast.FunctionDef)
+            and node.name == _HELPER_NAME
+            and (len(node.args.posonlyargs) + len(node.args.args))
+            == _DUPLICATE_SHAPE_PARAM_COUNT
+            for node in ast.walk(tree)
+        )
+    assert found, "the scan failed to detect a planted duplicate-shaped def"


### PR DESCRIPTION
## Summary

Removes three families of near-identical test-harness helpers that had been redefined per-file instead of shared, and adds shrink-only-allowlist guard tests so each cannot be silently reintroduced.

## Which layer(s) does this PR touch?

(See [`CLAUDE.md`](../CLAUDE.md) for the three-layer rule.)

- [ ] `docs/DESIGN.md` (architecture)
- [ ] `docs/IMPLEMENTATION.md` (code surface)
- [ ] `orchestrator/leerie.py` (code)
- [ ] docs (`README.md`, `docs/USAGE.md`, `CONTRIBUTING.md`, etc.)
- [x] tests (`tests/`)
- [ ] CI / repo meta (`.github/`)

If multiple, has the change propagated **top-down** per the three-layer rule
(DESIGN → IMPLEMENTATION → code)?

- [ ] yes
- [x] not applicable (single layer)

## Task-completion checklist

(Mirrors `CLAUDE.md` and `CONTRIBUTING.md`.)

- [ ] `docs/IMPLEMENTATION.md` updated if code surface changed
- [ ] `docs/DESIGN.md` updated if architecture changed
- [ ] `pytest tests/` passes
- [ ] `python3 -c "import ast; ast.parse(open('orchestrator/leerie.py').read())"` passes
- [x] `git diff --stat` reviewed for scope (no collateral edits)

## Testing notes

Adds three new guard test files that pin single ownership going forward:

- `tests/test_no_duplicate_ec2_run_launcher_helper.py` — a shrink-only-allowlist guard for `_run_launcher`, scoped to the two-positional-arg `(args, env)` shape so it excludes `test_group_state_dir_guard.py`'s genuinely distinct 5-arg helper of the same name.
- `tests/test_no_duplicate_launcher_invoke_helper.py` — the same guard pattern for `tests.ec2_stub.run_launcher`, the consolidated single-owner replacement.
- `tests/test_no_duplicate_accept_verb_helper.py` — pins `tests/test_accept_blocked.py` as sole owner of the accept-verb `_run_accept`/`_make_state` harness helpers, which `tests/test_accept_integration.py` now binds via `functools.partial(verb=..., key=...)` instead of redefining.

Behavior-side changes:
- `_run_launcher` is now `tests/ec2_stub.py::run_launcher`, consumed by `test_ec2_launcher_kill.py`, `test_ec2_launcher_resume.py`, and `test_auto_detect_run_runtime.py`.
- `_run_accept`/`_make_state` in `test_accept_blocked.py` gained `verb=`/`key=` parameters so `test_accept_integration.py` can reuse them instead of maintaining its own copies.

`pytest tests/` reports 5 failures in this run's conformance pass, all in `tests/test_signal_cleanup.py` (`test_terminate_proc_tree_reaps_grandchildren`, `test_terminate_proc_tree_reaps_detached_session_grandchildren`, `test_descendant_tracker_reaps_orphaned_backgrounded_subprocess`, plus two others in the same run). This diff touches only `tests/ec2_stub.py`, `tests/test_accept_blocked.py`, `tests/test_accept_integration.py`, `tests/test_auto_detect_run_runtime.py`, `tests/test_ec2_launcher_kill.py`, `tests/test_ec2_launcher_resume.py`, and the three new guard files — none of which reference `test_signal_cleanup.py` or its subject matter, and the base-health baseline for this run was already RED on the `tests` axis before this diff landed. Worth re-verifying against `main` before merge per this repo's own concurrency-flake caveat in `CLAUDE.md`.

## Related issue

<!-- Closes #N -->
