### PR TITLE
docs: stop DESIGN §12 contradicting itself about acting-worker layers

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -7495,8 +7495,8 @@ escape hatch.
 
 #### Acting-worker isolation — the same deny, scoped to a path
 
-L1–L4 above are scoped to `PLANNING_WORKER_TYPES`. Acting workers
-(implementer, conformer, integrator, rebaser) get **only L2**, and this
+L1–L4 above are scoped to `PLANNING_WORKER_TYPES`. Before this change acting
+workers (implementer, conformer, integrator, rebaser) had **only L2**, and this
 section already states what that is worth: *L2 is worth nothing without L1*.
 They cannot be given L1 — writing files unprompted is the job — so
 `claude_p` appends `--dangerously-skip-permissions` on `autonomous` alone,


### PR DESCRIPTION
## Summary

#234 fixed the parent section's claim that acting workers *"get only one of those four"* layers, but left the mirror image three lines into the subsection. After #234, `docs/DESIGN.md` §12 said both of these, four lines apart, both in the present tense:

| where | text |
|---|---|
| parent, `:7405` | "Acting workers cannot be given L1 at all: they get L2, **plus L4 per wave** and a path-scoped write denial" |
| subsection, `:7499` | "Acting workers (implementer, conformer, integrator, rebaser) get **only L2**" |

The subsection sentence is the *motivating* claim — it describes the pre-change state, and the same subsection later says "So **L4 now runs during execute too**". Nothing in its wording said so. It now reads "Before this change acting workers … **had** only L2", which is what it always meant.

DESIGN is the canonical layer under the three-layer rule, so an internal contradiction there is a defect rather than a wording preference.

## Which layer(s) does this PR touch?

- [x] `docs/DESIGN.md` (architecture)
- [ ] `docs/IMPLEMENTATION.md` (code surface)
- [ ] `orchestrator/leerie.py` (code)
- [ ] docs (`README.md`, `docs/USAGE.md`, `CONTRIBUTING.md`, etc.)
- [ ] tests (`tests/`)
- [ ] CI / repo meta (`.github/`)

Propagated top-down per the three-layer rule:

- [ ] yes
- [x] not applicable (single layer)

Docs-only, and specifically a *correction* to the canonical layer — nothing below it derives differently as a result. The code already behaved the way the parent sentence describes.

## Task-completion checklist

- [x] `docs/IMPLEMENTATION.md` updated if code surface changed — n/a, unchanged
- [x] `docs/DESIGN.md` updated if architecture changed — this is the change
- [ ] `pytest tests/` passes — **not run locally by request**; no code touched, CI covers the tree
- [x] `python3 -c "import ast; ast.parse(open('orchestrator/leerie.py').read())"` passes
- [x] `git diff --stat` reviewed for scope — 1 file, +2/-2

## Testing notes

No test change: there is no mechanical assertion that two English sentences agree, and inventing one for this would pin the phrasing rather than the meaning.

The check that actually applies is enumeration before editing. Both sites were listed first this time — `grep -n "Acting workers\|only L2\|four layers" docs/DESIGN.md` returns exactly the two, and no other layer (IMPLEMENTATION, CLAUDE.md, `orchestrator/leerie.py`, `tests/`) makes the claim at all.

Worth recording plainly: this is the **third** one-sided correction in this line of work — the extracted `_git` helper, then "only one of those four", now "only L2". Each time the sentence in front of me was edited without grepping for its counterpart.

## Related

Follows #232 and #234.

🤖 Generated with [Claude Code](https://claude.com/claude-code)