### PR TITLE
leerie: Consolidate duplicated flyctl/EC2 test-stub helpers across the test suite

### DIFF
--- a/tests/fly_stub.py
+++ b/tests/fly_stub.py
@@ -23,7 +23,10 @@ def make_fake_flyctl(
     `$CMD`, `auth ...` into `$SUB=auth` (exiting 0 immediately — every
     call site's only use of `auth` is the `auth status` preflight probe,
     so any auth subcommand succeeding is equivalent), `machine <subsub>`
-    into `$SUB=machine` / `$MSUB`, and `ssh` into `$SUB=ssh`.
+    into `$SUB=machine` / `$MSUB`, `ssh` into `$SUB=ssh`, and
+    `apps <subsub> [arg]` (`apps list --json` / `apps create <name>`)
+    into `$SUB=apps` / `$MSUB` / `$AARG` — `$AARG` carries the app name
+    for `create` (unused, but harmlessly consumed, for `list --json`).
 
     `extra_preamble` is emitted verbatim before flag parsing (for
     caller-specific path/state variables the case body needs).
@@ -41,12 +44,15 @@ def make_fake_flyctl(
         + 'CMD=""\n'
         'SUB=""\n'
         'MSUB=""\n'
+        'AARG=""\n'
         'while [ $# -gt 0 ]; do\n'
         '  case "$1" in\n'
         '    -C) CMD="$2"; shift 2 ;;\n'
         '    auth) SUB="auth"; shift ;;\n'
         '    machine) SUB="machine"; shift; MSUB="${1:-}"; shift || true ;;\n'
         '    ssh) SUB="ssh"; shift ;;\n'
+        '    apps) SUB="apps"; shift; MSUB="${1:-}"; shift || true; '
+        'AARG="${1:-}"; shift || true ;;\n'
         '    *) shift ;;\n'
         '  esac\n'
         'done\n'

--- a/tests/stub_helpers.py
+++ b/tests/stub_helpers.py
@@ -27,7 +27,7 @@ def _make_stub_timeout(stub_dir: Path) -> None:
 
     Adequate for tests that merely need the binary to exist on the
     stubbed PATH. A test that asserts the cap actually *fires* must
-    use `_stub_timeout` (imported from tests.test_ec2_transport) instead.
+    use `_stub_timeout` (below) instead.
 
     Six test files each defined a byte-identical `_make_stub_timeout(stub_dir)`,
     differing only in docstring wording: it writes a `timeout` shim that skips
@@ -39,8 +39,8 @@ def _make_stub_timeout(stub_dir: Path) -> None:
     `tests/ec2_stub.py` and `tests/launcher_blocks.py`.
 
     This is deliberately NOT the stub for tests that assert the cap actually
-    *fires*: `_stub_timeout` in `tests/test_ec2_transport.py` is a distinct,
-    intentionally different killing variant for that case, and stays there.
+    *fires*: `_stub_timeout` (below) is a distinct, intentionally different
+    killing variant for that case.
     """
     stub = stub_dir / "timeout"
     stub.write_text(
@@ -48,6 +48,69 @@ def _make_stub_timeout(stub_dir: Path) -> None:
 while [[ "$1" == --* ]]; do shift; done
 shift
 exec "$@"
+"""
+    )
+    stub.chmod(0o755)
+
+
+def _stub_timeout(bin_dir: Path) -> None:
+    """Real, group-killing `timeout` stub.
+
+    These tests pin PATH to `{bin_dir}:/usr/bin:/bin` so a fake binary is
+    found and the host's Homebrew layout can't leak in. But macOS ships no
+    `timeout` in /usr/bin (it's coreutils, via Homebrew), so
+    `_seed_timeout_prefix` correctly no-ops — and a stall test's `sleep 600`
+    then runs unbounded, hanging the suite for 10 minutes rather than
+    failing.
+
+    Unlike `_make_stub_timeout` above, this one must honour the cap: the
+    tests it serves assert the timeout actually *fires* (rc 124), so an
+    `exec "$@"` stub that ignores the duration would hang exactly like no
+    stub at all.
+
+    Runs the child in its own process GROUP and signals the whole group on
+    expiry — killing only the direct child is not enough: its grandchildren
+    (a stalled stub's own `sleep`) inherit the captured stdout, and a
+    `$(...)` capture blocks until every writer closes the pipe, so the
+    caller would hang even though the child is dead. Real GNU timeout kills
+    the group for exactly this reason.
+    """
+    stub = bin_dir / "timeout"
+    stub.write_text(
+        """#!/usr/bin/env bash
+kill_after=""
+while [[ "$1" == --* ]]; do
+  case "$1" in
+    --kill-after=*) kill_after="${1#--kill-after=}" ;;
+    --kill-after)   kill_after="$2"; shift ;;
+    --foreground)   ;;
+  esac
+  shift
+done
+secs="$1"; shift
+
+# `set -m` puts the child in its own process group (pgid == its pid), so
+# `kill -- -$pgid` reaches the whole subtree.
+set -m
+"$@" &
+child=$!
+set +m
+
+(
+  sleep "$secs"
+  kill -TERM -- "-$child" 2>/dev/null || kill -TERM "$child" 2>/dev/null
+  if [ -n "$kill_after" ]; then
+    sleep "$kill_after"
+    kill -KILL -- "-$child" 2>/dev/null || kill -KILL "$child" 2>/dev/null
+  fi
+) &
+waiter=$!
+
+wait "$child" 2>/dev/null; rc=$?
+kill -TERM "$waiter" 2>/dev/null
+# GNU timeout reports 124 when it had to kill the child.
+[ "$rc" -eq 143 ] && rc=124
+exit "$rc"
 """
     )
     stub.chmod(0o755)

--- a/tests/test_ec2_launcher_readonly_verbs.py
+++ b/tests/test_ec2_launcher_readonly_verbs.py
@@ -49,6 +49,7 @@ from tests.ec2_stub import (
     build_ec2_launcher_env,
     read_log,
     read_state,
+    run_launcher as _run_launcher_shared,
     seed_running_instance,
     write_ec2_sidecar,
 )
@@ -181,10 +182,7 @@ def _seed_remote_state(work_dest: Path, run_id: str, state: dict) -> Path:
 
 
 def _run(args: list[str], env: dict) -> subprocess.CompletedProcess:
-    return subprocess.run(
-        ["bash", str(LAUNCHER)] + args,
-        env=env, capture_output=True, text=True, timeout=30,
-    )
+    return _run_launcher_shared(args, env, launcher=LAUNCHER, use_bash=True, timeout=30)
 
 
 # --- accept-blocked: EC2 runtime resolution ------------------------------

--- a/tests/test_ec2_seed_auth.py
+++ b/tests/test_ec2_seed_auth.py
@@ -26,7 +26,7 @@ from pathlib import Path
 from tests import ec2_stub
 from tests.conftest import run_bash
 from tests.stub_helpers import _make_stub_timeout
-from tests.test_ec2_transport import _stub_timeout as _make_killing_stub_timeout
+from tests.stub_helpers import _stub_timeout as _make_killing_stub_timeout
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 EC2_SEED_AUTH_SH = REPO_ROOT / "scripts" / "remote" / "ec2-seed-auth.sh"

--- a/tests/test_ec2_seed_repo.py
+++ b/tests/test_ec2_seed_repo.py
@@ -29,7 +29,7 @@ from pathlib import Path
 from tests import ec2_stub
 from tests.conftest import init_git_repo, run_bash
 from tests.stub_helpers import _make_stub_timeout
-from tests.test_ec2_transport import _stub_timeout as _make_killing_stub_timeout
+from tests.stub_helpers import _stub_timeout as _make_killing_stub_timeout
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 EC2_SEED_SH = REPO_ROOT / "scripts" / "remote" / "ec2-seed-repo.sh"

--- a/tests/test_ec2_ssm.py
+++ b/tests/test_ec2_ssm.py
@@ -33,53 +33,12 @@ import os
 from pathlib import Path
 
 from tests.conftest import run_bash
+from tests.stub_helpers import _stub_timeout
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 EC2_LIB_SH = REPO_ROOT / "scripts" / "remote" / "ec2-lib.sh"
 EC2_SSM_SH = REPO_ROOT / "scripts" / "remote" / "ec2-ssm.sh"
 LOG_SH = REPO_ROOT / "scripts" / "remote" / "_log.sh"
-
-
-def _stub_timeout(bin_dir: Path) -> None:
-    """Real, group-killing `timeout` stub — see test_ec2_transport.py's
-    identical helper for the full rationale (macOS ships no
-    /usr/bin/timeout, so an unbounded stall test would hang the suite)."""
-    stub = bin_dir / "timeout"
-    stub.write_text(
-        """#!/usr/bin/env bash
-kill_after=""
-while [[ "$1" == --* ]]; do
-  case "$1" in
-    --kill-after=*) kill_after="${1#--kill-after=}" ;;
-    --kill-after)   kill_after="$2"; shift ;;
-    --foreground)   ;;
-  esac
-  shift
-done
-secs="$1"; shift
-
-set -m
-"$@" &
-child=$!
-set +m
-
-(
-  sleep "$secs"
-  kill -TERM -- "-$child" 2>/dev/null || kill -TERM "$child" 2>/dev/null
-  if [ -n "$kill_after" ]; then
-    sleep "$kill_after"
-    kill -KILL -- "-$child" 2>/dev/null || kill -KILL "$child" 2>/dev/null
-  fi
-) &
-waiter=$!
-
-wait "$child" 2>/dev/null; rc=$?
-kill -TERM "$waiter" 2>/dev/null
-[ "$rc" -eq 143 ] && rc=124
-exit "$rc"
-"""
-    )
-    stub.chmod(0o755)
 
 
 def _stub_aws_interactive_session(bin_dir: Path, *, stall: bool = False) -> Path:

--- a/tests/test_ec2_transport.py
+++ b/tests/test_ec2_transport.py
@@ -22,72 +22,11 @@ from __future__ import annotations
 from pathlib import Path
 
 from tests.conftest import run_bash
+from tests.stub_helpers import _stub_timeout
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 EC2_LIB_SH = REPO_ROOT / "scripts" / "remote" / "ec2-lib.sh"
 LOG_SH = REPO_ROOT / "scripts" / "remote" / "_log.sh"
-
-
-def _stub_timeout(bin_dir: Path) -> None:
-    """Provide a real, killing `timeout` on the test's stubbed PATH.
-
-    These tests pin PATH to `{bin_dir}:/usr/bin:/bin` so the fake `aws`
-    is found and the host's Homebrew layout can't leak in. But macOS
-    ships no `timeout` in /usr/bin (it's coreutils, via Homebrew), so
-    `_seed_timeout_prefix` correctly no-ops — and the stall test's
-    `sleep 600` then runs unbounded, hanging the suite for 10 minutes
-    rather than failing.
-
-    Unlike `_make_stub_timeout` in tests/test_seed_repo_sh.py, this one
-    must honour the cap: the test it serves asserts the timeout *fires*
-    (rc 124), so an `exec "$@"` stub that ignores the duration would
-    hang exactly like no stub at all.
-    """
-    stub = bin_dir / "timeout"
-    stub.write_text(
-        """#!/usr/bin/env bash
-# Stub GNU timeout. Runs the child in its own process GROUP and signals
-# the whole group on expiry — killing only the direct child is not
-# enough: its grandchildren (the stalled stub's own `sleep`) inherit the
-# captured stdout, and a $(...) capture blocks until every writer closes
-# the pipe, so the caller would hang even though the child is dead.
-# Real GNU timeout kills the group for exactly this reason.
-kill_after=""
-while [[ "$1" == --* ]]; do
-  case "$1" in
-    --kill-after=*) kill_after="${1#--kill-after=}" ;;
-    --kill-after)   kill_after="$2"; shift ;;
-    --foreground)   ;;
-  esac
-  shift
-done
-secs="$1"; shift
-
-# `set -m` puts the child in its own process group (pgid == its pid), so
-# `kill -- -$pgid` reaches the whole subtree.
-set -m
-"$@" &
-child=$!
-set +m
-
-(
-  sleep "$secs"
-  kill -TERM -- "-$child" 2>/dev/null || kill -TERM "$child" 2>/dev/null
-  if [ -n "$kill_after" ]; then
-    sleep "$kill_after"
-    kill -KILL -- "-$child" 2>/dev/null || kill -KILL "$child" 2>/dev/null
-  fi
-) &
-waiter=$!
-
-wait "$child" 2>/dev/null; rc=$?
-kill -TERM "$waiter" 2>/dev/null
-# GNU timeout reports 124 when it had to kill the child.
-[ "$rc" -eq 143 ] && rc=124
-exit "$rc"
-"""
-    )
-    stub.chmod(0o755)
 
 
 def _stub_aws_ssm(bin_dir: Path, *, remote_rc: int = 0,

--- a/tests/test_ensure_image.py
+++ b/tests/test_ensure_image.py
@@ -34,6 +34,8 @@ import os
 import subprocess
 from pathlib import Path
 
+from tests.fly_stub import make_fake_flyctl
+
 REPO_ROOT = Path(__file__).resolve().parent.parent
 LAUNCHER = REPO_ROOT / "leerie"
 
@@ -81,23 +83,20 @@ def _stub_flyctl(tmp_path: Path, existing_apps: list[str] | None = None,
     create_succeeds: whether `apps create <name>` exits 0.
     """
     apps = existing_apps or []
-    stub = tmp_path / "flyctl"
-    stub.write_text(
-        "#!/usr/bin/env bash\n"
-        f"echo \"$@\" >> {tmp_path}/flyctl.log\n"
-        'if [ "$1" = "apps" ] && [ "$2" = "list" ]; then\n'
+    extra_preamble = f'echo "$@" >> {tmp_path}/flyctl.log\n'
+    case_body = (
+        'if [ "$SUB" = "apps" ] && [ "$MSUB" = "list" ]; then\n'
         '  cat <<JSON\n'
         + "[" + ", ".join(f'{{"Name": "{n}"}}' for n in apps) + "]\n"
         + "JSON\n"
         '  exit 0\n'
         'fi\n'
-        'if [ "$1" = "apps" ] && [ "$2" = "create" ]; then\n'
+        'if [ "$SUB" = "apps" ] && [ "$MSUB" = "create" ]; then\n'
         f"  exit {0 if create_succeeds else 1}\n"
         'fi\n'
         'exit 0\n'
     )
-    stub.chmod(0o755)
-    return stub
+    return make_fake_flyctl(tmp_path, case_body, extra_preamble=extra_preamble)
 
 
 def _run(tag: str, *, env: dict, cwd: Path,

--- a/tests/test_fly_per_repo_image.py
+++ b/tests/test_fly_per_repo_image.py
@@ -15,6 +15,7 @@ import hashlib
 import subprocess
 from pathlib import Path
 
+from tests.fly_stub import make_fake_flyctl
 from tests.repo_image_block_extract import extract_block as _extract_block
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -240,15 +241,14 @@ def _make_build_push_stub(tmp_path: Path, rc: int = 0) -> Path:
 
 def _make_flyctl_stub(tmp_path: Path, app: str = "testapp") -> Path:
     """Create a flyctl stub that returns app-list JSON and exits 0."""
-    stub = tmp_path / "flyctl"
-    stub.write_text(
-        "#!/usr/bin/env bash\n"
-        f'if [ "${{1:-}}" = "apps" ]; then\n'
+    case_body = (
+        f'if [ "$SUB" = "apps" ]; then\n'
         f'  printf \'[{{"Name":"{app}"}}]\\n\'\n'
-        f'  exit 0\nfi\nexit 0\n'
+        '  exit 0\n'
+        'fi\n'
+        'exit 0\n'
     )
-    stub.chmod(0o755)
-    return stub
+    return make_fake_flyctl(tmp_path, case_body)
 
 
 def _run_ensure_image(

--- a/tests/test_fly_state_dir_sidecar.py
+++ b/tests/test_fly_state_dir_sidecar.py
@@ -24,6 +24,8 @@ from __future__ import annotations
 import subprocess
 from pathlib import Path
 
+from tests.fly_stub import make_fake_flyctl
+
 REPO_ROOT = Path(__file__).resolve().parent.parent
 LEERIE = REPO_ROOT / "leerie"
 FETCH_SH = REPO_ROOT / "scripts" / "remote" / "fetch-branch.sh"
@@ -143,16 +145,7 @@ def _make_user_repo(tmp_path: Path) -> Path:
 
 def _make_flyctl_stub_auth_only(tmp_path: Path) -> Path:
     """Minimal flyctl stub: auth status passes, all else fails."""
-    stub = tmp_path / "flyctl"
-    stub.write_text(
-        "#!/usr/bin/env bash\n"
-        'case "$1 ${2:-}" in\n'
-        "  'auth status') exit 0 ;;\n"
-        "  *) exit 1 ;;\n"
-        "esac\n"
-    )
-    stub.chmod(0o755)
-    return stub
+    return make_fake_flyctl(tmp_path, "exit 1\n")
 
 
 def test_stop_resolves_run_dir_from_state_host_dir(tmp_path: Path):

--- a/tests/test_no_duplicate_ec2_run_launcher_helper.py
+++ b/tests/test_no_duplicate_ec2_run_launcher_helper.py
@@ -11,33 +11,96 @@ different name, as those three files now do).
 tests/test_group_state_dir_guard.py's own `_run_launcher(tmp_path, args,
 env_extra=None, stub=None, stub_log=None)` is a genuinely distinct helper
 (different purpose: injects a stub binary and returns a `.stub_log`-
-augmented result) and is excluded by construction -- the regex below
-matches only the specific two-positional-arg `(args, env)` call shape,
-not that five-parameter one.
+augmented result) and is excluded by construction -- the scan below
+matches only the specific two-positional-arg `(args, env)` shape, not
+that five-parameter one.
+
+The scan is NAME-INDEPENDENT (an AST walk over `def`s whose two
+positional parameters are named `args`/`env`, not merely a literal
+`_run_launcher(` match). test-002 widened it after
+tests/test_ec2_launcher_readonly_verbs.py's own `_run(args, env)` -- a
+byte-for-byte duplicate of the run_launcher shape under a different name
+-- evaded the original literal-name regex entirely. A thin function whose
+body is a single `return <call naming run_launcher>(...)` is exempted:
+that is the "wraps it in a thin local function" delegation the module
+docstring already sanctions (test_ec2_launcher_kill.py,
+test_ec2_launcher_resume.py), not a reimplementation.
 """
 from __future__ import annotations
 
-import re
+import ast
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 TESTS_DIR = REPO_ROOT / "tests"
 
-# Matches `def _run_launcher(args..., env...)` -- i.e. a two-positional-arg
-# def whose second parameter is named `env`, which is the shape the three
-# migrated duplicates shared. tests/test_group_state_dir_guard.py's
-# `_run_launcher(tmp_path, args, env_extra=None, ...)` does not match: its
-# second positional parameter is named `args`, not `env`.
-_DEF_RE = re.compile(
-    r"^\s*def _run_launcher\(\s*args\s*:[^,]*,\s*env\s*:", re.MULTILINE
-)
+_DUPLICATE_SHAPE_PARAM_NAMES = ("args", "env")
+
+
+def _delegates_to_shared_run_launcher(body: list[ast.stmt]) -> bool:
+    """True when a function body is a single `return <call>(...)` whose
+    call target names `run_launcher` -- the sanctioned thin-alias shape,
+    which must not be flagged as a duplicate."""
+    if len(body) != 1:
+        return False
+    stmt = body[0]
+    if not isinstance(stmt, ast.Return) or stmt.value is None:
+        return False
+    call = stmt.value
+    if not isinstance(call, ast.Call):
+        return False
+    func = call.func
+    if isinstance(func, ast.Name):
+        name = func.id
+    elif isinstance(func, ast.Attribute):
+        name = func.attr
+    else:
+        return False
+    return "run_launcher" in name
+
+
+def _is_duplicate_shaped(node: ast.FunctionDef) -> bool:
+    params = list(node.args.posonlyargs) + list(node.args.args)
+    if len(params) != len(_DUPLICATE_SHAPE_PARAM_NAMES):
+        return False
+    if tuple(p.arg for p in params) != _DUPLICATE_SHAPE_PARAM_NAMES:
+        return False
+    return not _delegates_to_shared_run_launcher(node.body)
+
+
+def _duplicate_shaped_files() -> set[str]:
+    offenders: set[str] = set()
+    for path in sorted(TESTS_DIR.rglob("test_*.py")):
+        rel = str(path.relative_to(REPO_ROOT))
+        tree = ast.parse(path.read_text())
+        for node in ast.walk(tree):
+            if isinstance(node, ast.FunctionDef) and _is_duplicate_shaped(node):
+                offenders.add(rel)
+    return offenders
+
 
 # Legacy call sites not yet migrated to the shared `run_launcher` helper.
 # This is a shrink-only allowlist: a migration subtask removes a file's
-# local two-positional-arg `_run_launcher` def, drops the file's name from
-# this set in the same commit, and CI catches any new local redefinition
-# of that shape outside this set.
-_KNOWN_UNMIGRATED: frozenset[str] = frozenset()
+# local two-positional-arg duplicate-shaped helper, drops the file's name
+# from this set in the same commit, and CI catches any new local
+# redefinition of that shape outside this set.
+#
+# test-002 widened the scan above from a literal `_run_launcher` name
+# match to the structural shape regardless of function name, and migrated
+# tests/test_ec2_launcher_readonly_verbs.py's own differently-named
+# `_run` duplicate onto the shared helper in the same change. The
+# widening also surfaced two pre-existing, differently-named duplicates
+# the old name-keyed regex could never see (`_run` in
+# test_ec2_launcher_finalize.py, `_run_launcher_under_bash32` in
+# test_ec2_bash32_portability.py) -- both are genuinely unmigrated and
+# out of this subtask's scope, so they are recorded here rather than
+# silently passing the widened guard.
+_KNOWN_UNMIGRATED: frozenset[str] = frozenset(
+    {
+        "tests/test_ec2_launcher_finalize.py",
+        "tests/test_ec2_bash32_portability.py",
+    }
+)
 
 
 def test_run_launcher_is_defined_in_ec2_stub():
@@ -63,19 +126,15 @@ def test_run_launcher_matches_the_common_call_shape():
 
 def test_no_local_run_launcher_reimplementations_outside_the_allowlist():
     """No file under tests/ defines its own two-positional-arg
-    `def _run_launcher(args, env)` unless it is a still-unmigrated legacy
-    site named in `_KNOWN_UNMIGRATED`. A new local def of that shape
-    outside that set is a fresh duplication and must import the shared
-    `run_launcher` helper from tests/ec2_stub.py instead."""
-    offenders = []
-    for path in sorted(TESTS_DIR.rglob("test_*.py")):
-        text = path.read_text()
-        if _DEF_RE.search(text):
-            offenders.append(str(path.relative_to(REPO_ROOT)))
-    unexpected = sorted(set(offenders) - _KNOWN_UNMIGRATED)
+    `(args, env)` invoke helper, under any name, unless it is a still-
+    unmigrated legacy site named in `_KNOWN_UNMIGRATED`. A new local def
+    of that shape outside that set is a fresh duplication and must import
+    the shared `run_launcher` helper from tests/ec2_stub.py instead."""
+    offenders = _duplicate_shaped_files()
+    unexpected = sorted(offenders - _KNOWN_UNMIGRATED)
     assert unexpected == [], (
         "The following files define a NEW local two-positional-arg "
-        "`_run_launcher(args, env)` helper not in the legacy allowlist; "
+        "`(args, env)` invoke helper not in the legacy allowlist; "
         "import `run_launcher` from tests/ec2_stub.py instead:\n"
         + "\n".join(unexpected)
     )
@@ -83,29 +142,57 @@ def test_no_local_run_launcher_reimplementations_outside_the_allowlist():
 
 def test_allowlist_has_no_stale_entries():
     """Every entry in `_KNOWN_UNMIGRATED` must still define a local
-    two-positional-arg `_run_launcher`. When a migration subtask removes
-    a file's local def, it must also drop that file's name from this
-    allowlist in the same commit -- otherwise this shrink-only list
-    silently stops shrinking."""
-    offenders = set()
-    for path in sorted(TESTS_DIR.rglob("test_*.py")):
-        text = path.read_text()
-        if _DEF_RE.search(text):
-            offenders.add(str(path.relative_to(REPO_ROOT)))
+    two-positional-arg duplicate-shaped invoke helper. When a migration
+    subtask removes a file's local def, it must also drop that file's
+    name from this allowlist in the same commit -- otherwise this
+    shrink-only list silently stops shrinking."""
+    offenders = _duplicate_shaped_files()
     stale = sorted(_KNOWN_UNMIGRATED - offenders)
     assert stale == [], (
         "The following files no longer define a local two-positional-arg "
-        "`_run_launcher` but are still in the allowlist; remove them from "
-        "_KNOWN_UNMIGRATED:\n" + "\n".join(stale)
+        "duplicate-shaped invoke helper but are still in the allowlist; "
+        "remove them from _KNOWN_UNMIGRATED:\n" + "\n".join(stale)
     )
 
 
 def test_group_state_dir_guard_helper_is_not_flagged():
-    """Anti-vacuity control: the regex must not match
+    """Anti-vacuity control: the scan must not match
     tests/test_group_state_dir_guard.py's genuinely distinct
     `_run_launcher(tmp_path, args, env_extra=None, stub=None,
     stub_log=None)` helper, which this guard is not meant to migrate."""
     path = TESTS_DIR / "test_group_state_dir_guard.py"
     text = path.read_text()
     assert "def _run_launcher(" in text
-    assert not _DEF_RE.search(text)
+    tree = ast.parse(text)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == "_run_launcher":
+            assert not _is_duplicate_shaped(node)
+
+
+def test_scan_flags_a_differently_named_duplicate():
+    """Regression for the evasion class this subtask fixes: the pre-fix
+    literal-name regex (`^\\s*def _run_launcher\\(...`) could never see
+    tests/test_ec2_launcher_readonly_verbs.py's own `_run(args, env)`, a
+    byte-for-byte duplicate of the run_launcher shape under a different
+    name. Plants a `_run`-named duplicate-shaped def and asserts the
+    widened, name-independent scan still flags it."""
+    import tempfile
+
+    src = (
+        "import subprocess\n\n"
+        "def _run(args, env):\n"
+        "    return subprocess.run(['leerie'] + args, env=env)\n"
+    )
+    with tempfile.TemporaryDirectory() as tmp:
+        planted = Path(tmp) / "test_planted_differently_named.py"
+        planted.write_text(src)
+        tree = ast.parse(planted.read_text())
+        found = any(
+            isinstance(node, ast.FunctionDef) and _is_duplicate_shaped(node)
+            for node in ast.walk(tree)
+        )
+    assert found, (
+        "the scan failed to detect a differently-named "
+        "(non-'_run_launcher') duplicate-shaped def -- the name-"
+        "independent widening has regressed"
+    )

--- a/tests/test_no_duplicate_launcher_invoke_helper.py
+++ b/tests/test_no_duplicate_launcher_invoke_helper.py
@@ -9,12 +9,20 @@ tests/test_auto_detect_run_runtime.py, tests/test_ec2_launcher_kill.py, and
 tests/test_ec2_launcher_resume.py.
 
 Mirrors tests/test_no_duplicate_run_bash_helper.py's shrink-only-allowlist
-pattern: no file under tests/ should define its own `def _run_launcher(`
-(or same-shaped invoke helper) unless it is either a still-unmigrated
-legacy site named in `_KNOWN_UNMIGRATED`, or the permanently-excluded
-tests/test_group_state_dir_guard.py, whose own `_run_launcher` is a
-materially different, 5-parameter stub-binary-injection helper that
-happens to share a name and is not a duplicate of this one.
+pattern: no file under tests/ should define its own `(args, env) ->
+CompletedProcess` invoke helper, under ANY name, unless it is either a
+still-unmigrated legacy site named in `_KNOWN_UNMIGRATED`, or the
+permanently-excluded tests/test_group_state_dir_guard.py, whose own
+`_run_launcher` is a materially different, 5-parameter stub-binary-
+injection helper that happens to share a name and is not a duplicate of
+this one.
+
+The scan is deliberately NAME-INDEPENDENT (matches any `def` whose two
+positional parameters are `args`/`env`-shaped, not just one literally
+named `_run_launcher`) -- test-002 widened it after
+tests/test_ec2_launcher_readonly_verbs.py's own `_run(args, env)` (a
+byte-for-byte duplicate of this shape under a different name) evaded the
+original name-keyed scan entirely.
 """
 from __future__ import annotations
 
@@ -24,14 +32,57 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parent.parent
 TESTS_DIR = REPO_ROOT / "tests"
 
-_HELPER_NAME = "_run_launcher"
-
 # The (args, env) two-positional-parameter shape that
 # tests/ec2_stub.py::run_launcher replaces. This is what distinguishes a
 # reintroduced duplicate from tests/test_group_state_dir_guard.py's
 # unrelated 5-parameter `_run_launcher(tmp_path, args, env_extra, stub,
-# stub_log)`, which shares only the name.
+# stub_log)`, which shares only a name (and would in any case be excluded
+# by param count alone even under the name-independent scan below).
 _DUPLICATE_SHAPE_PARAM_COUNT = 2
+
+# The two positional parameter names the duplicate shape shares across
+# every migrated site (`_run_launcher`, `_run`, ...): first parameter
+# `args`, second parameter `env`. Requiring the names (not just the count)
+# keeps the scan from flagging an unrelated two-positional-arg helper that
+# happens to share nothing but arity.
+_DUPLICATE_SHAPE_PARAM_NAMES = ("args", "env")
+
+
+def _delegates_to_shared_run_launcher(body: list[ast.stmt]) -> bool:
+    """True when a function body is a single `return <call>(...)` whose
+    call target names `run_launcher` (directly, aliased, or as an
+    attribute e.g. `ec2_stub.run_launcher` / `_run_launcher_shared`).
+    This is the "thin same-behavior local alias" shape the success
+    criteria explicitly sanctions (test_ec2_launcher_kill.py,
+    test_ec2_launcher_resume.py) -- it must NOT be flagged as a
+    duplicate, since it delegates to the single owner rather than
+    reimplementing it."""
+    if len(body) != 1:
+        return False
+    stmt = body[0]
+    if not isinstance(stmt, ast.Return) or stmt.value is None:
+        return False
+    call = stmt.value
+    if not isinstance(call, ast.Call):
+        return False
+    func = call.func
+    if isinstance(func, ast.Name):
+        name = func.id
+    elif isinstance(func, ast.Attribute):
+        name = func.attr
+    else:
+        return False
+    return "run_launcher" in name
+
+
+def _is_duplicate_shaped(node: ast.FunctionDef) -> bool:
+    args = node.args
+    params = list(args.posonlyargs) + list(args.args)
+    if len(params) != _DUPLICATE_SHAPE_PARAM_COUNT:
+        return False
+    if tuple(p.arg for p in params) != _DUPLICATE_SHAPE_PARAM_NAMES:
+        return False
+    return not _delegates_to_shared_run_launcher(node.body)
 
 # Permanently excluded: not a legacy unmigrated site, and never intended to
 # migrate onto tests.ec2_stub.run_launcher -- see the module docstring and
@@ -43,18 +94,35 @@ _PERMANENT_EXCEPTIONS: frozenset[str] = frozenset(
 # Shrink-only allowlist for genuinely unmigrated legacy sites. refactor-002
 # already consolidated the three known duplicates
 # (test_ec2_launcher_kill.py, test_ec2_launcher_resume.py,
-# test_auto_detect_run_runtime.py) into tests.ec2_stub.run_launcher, so
-# this starts empty. A future migration subtask removes a file's local
-# duplicate-shaped `_run_launcher` def and, if it cannot land the same
-# commit as the def's removal, adds the file's name here temporarily --
-# then drops it again once the def is gone.
-_KNOWN_UNMIGRATED: frozenset[str] = frozenset()
+# test_auto_detect_run_runtime.py) into tests.ec2_stub.run_launcher. A
+# future migration subtask removes a file's local duplicate-shaped
+# invoke-helper def and, if it cannot land the same commit as the def's
+# removal, adds the file's name here temporarily -- then drops it again
+# once the def is gone.
+#
+# test-002 widened this scan from a literal `_run_launcher` name match to
+# the structural (args, env) -> CompletedProcess shape regardless of
+# function name, and migrated tests/test_ec2_launcher_readonly_verbs.py's
+# own differently-named `_run` duplicate onto the shared helper in the
+# same change. The widening also surfaced two pre-existing, differently-
+# named duplicates the old name-keyed scan could never see
+# (`_run` in test_ec2_launcher_finalize.py,
+# `_run_launcher_under_bash32` in test_ec2_bash32_portability.py) -- both
+# are genuinely unmigrated and out of this subtask's scope, so they are
+# recorded here rather than silently passing the widened guard.
+_KNOWN_UNMIGRATED: frozenset[str] = frozenset(
+    {
+        "tests/test_ec2_launcher_finalize.py",
+        "tests/test_ec2_bash32_portability.py",
+    }
+)
 
 
 def _duplicate_shaped_run_launcher_files() -> set[str]:
-    """Files under tests/ defining a `_run_launcher` with the duplicate
-    (args, env) two-positional-parameter shape, excluding
-    _PERMANENT_EXCEPTIONS."""
+    """Files under tests/ defining ANY `def` (regardless of name) with the
+    duplicate (args, env) two-positional-parameter shape, excluding
+    _PERMANENT_EXCEPTIONS. Name-independent by design -- see the module
+    docstring for why a name-keyed scan is insufficient."""
     offenders: set[str] = set()
     for path in sorted(TESTS_DIR.rglob("test_*.py")):
         rel = str(path.relative_to(REPO_ROOT))
@@ -62,11 +130,8 @@ def _duplicate_shaped_run_launcher_files() -> set[str]:
             continue
         tree = ast.parse(path.read_text())
         for node in ast.walk(tree):
-            if isinstance(node, ast.FunctionDef) and node.name == _HELPER_NAME:
-                args = node.args
-                param_count = len(args.posonlyargs) + len(args.args)
-                if param_count == _DUPLICATE_SHAPE_PARAM_COUNT:
-                    offenders.add(rel)
+            if isinstance(node, ast.FunctionDef) and _is_duplicate_shaped(node):
+                offenders.add(rel)
     return offenders
 
 
@@ -142,21 +207,20 @@ def test_migrated_files_import_the_shared_helper():
 
 def test_permanent_exception_still_has_a_different_shape():
     """tests/test_group_state_dir_guard.py's `_run_launcher` must keep a
-    param count different from the duplicate shape this guard scans for,
-    or the permanent-exception carve-out is silently hiding a real
-    duplicate. If this ever fails because that helper's signature
-    changed to match ec2_stub.run_launcher's shape, it should be migrated
-    and dropped from _PERMANENT_EXCEPTIONS instead of exempted."""
+    shape different from the duplicate shape this guard scans for, or the
+    permanent-exception carve-out is silently hiding a real duplicate. If
+    this ever fails because that helper's signature changed to match
+    ec2_stub.run_launcher's shape, it should be migrated and dropped from
+    _PERMANENT_EXCEPTIONS instead of exempted."""
+    helper_name = "_run_launcher"
     rel = "tests/test_group_state_dir_guard.py"
     assert rel in _PERMANENT_EXCEPTIONS
     tree = ast.parse((REPO_ROOT / rel).read_text())
     found = False
     for node in ast.walk(tree):
-        if isinstance(node, ast.FunctionDef) and node.name == _HELPER_NAME:
+        if isinstance(node, ast.FunctionDef) and node.name == helper_name:
             found = True
-            args = node.args
-            param_count = len(args.posonlyargs) + len(args.args)
-            assert param_count != _DUPLICATE_SHAPE_PARAM_COUNT, (
+            assert not _is_duplicate_shaped(node), (
                 f"{rel}'s `_run_launcher` now matches the duplicate "
                 "(args, env) shape -- it should migrate onto "
                 "tests.ec2_stub.run_launcher and be removed from "
@@ -167,8 +231,9 @@ def test_permanent_exception_still_has_a_different_shape():
 
 def test_scan_finds_a_planted_reproduction():
     """Anti-vacuity: the AST scan must actually detect a duplicate-shaped
-    `_run_launcher` when one exists, proving a return of `[]` elsewhere
-    reflects a clean tree rather than a scan that matches nothing."""
+    invoke helper when one exists, proving a return of `[]` elsewhere
+    reflects a clean tree rather than a scan that matches nothing. Named
+    `_run_launcher`, matching the historically observed name."""
     import tempfile
 
     src = (
@@ -181,10 +246,36 @@ def test_scan_finds_a_planted_reproduction():
         planted.write_text(src)
         tree = ast.parse(planted.read_text())
         found = any(
-            isinstance(node, ast.FunctionDef)
-            and node.name == _HELPER_NAME
-            and (len(node.args.posonlyargs) + len(node.args.args))
-            == _DUPLICATE_SHAPE_PARAM_COUNT
+            isinstance(node, ast.FunctionDef) and _is_duplicate_shaped(node)
             for node in ast.walk(tree)
         )
     assert found, "the scan failed to detect a planted duplicate-shaped def"
+
+
+def test_scan_finds_a_differently_named_planted_reproduction():
+    """Regression for the evasion class this subtask fixes:
+    tests/test_ec2_launcher_readonly_verbs.py's own `_run(args, env)` was
+    a byte-for-byte duplicate of the `run_launcher` shape under a
+    different name, and the pre-fix name-keyed scan (`node.name ==
+    '_run_launcher'`) could not see it. Plants a `_run`-named duplicate
+    and asserts the widened, name-independent scan still flags it."""
+    import tempfile
+
+    src = (
+        "import subprocess\n\n"
+        "def _run(args, env):\n"
+        "    return subprocess.run(['leerie'] + args, env=env)\n"
+    )
+    with tempfile.TemporaryDirectory() as tmp:
+        planted = Path(tmp) / "test_planted_differently_named.py"
+        planted.write_text(src)
+        tree = ast.parse(planted.read_text())
+        found = any(
+            isinstance(node, ast.FunctionDef) and _is_duplicate_shaped(node)
+            for node in ast.walk(tree)
+        )
+    assert found, (
+        "the scan failed to detect a differently-named "
+        "(non-'_run_launcher') duplicate-shaped def -- the name-"
+        "independent widening has regressed"
+    )

--- a/tests/test_no_duplicate_stub_timeout.py
+++ b/tests/test_no_duplicate_stub_timeout.py
@@ -1,15 +1,19 @@
-"""`_make_stub_timeout` has exactly one definition, in tests/stub_helpers.py.
+"""`_make_stub_timeout` and `_stub_timeout` each have exactly one
+definition, in tests/stub_helpers.py.
 
 Six test files previously each defined a byte-identical no-op `timeout`
-bash-stub builder. Nothing stops a future edit from reintroducing a copy in
-one of the consumer files — this is a structural regression guard against
-exactly that, mirroring the single-owner discipline in
-`tests/test_no_duplicate_seed_shell_helpers.py` and
+bash-stub builder (`_make_stub_timeout`). Nothing stops a future edit from
+reintroducing a copy in one of the consumer files — this is a structural
+regression guard against exactly that, mirroring the single-owner
+discipline in `tests/test_no_duplicate_seed_shell_helpers.py` and
 `tests/test_no_duplicate_launcher_blocks.py`.
 
-The distinct killing variant `_stub_timeout` in tests/test_ec2_transport.py
-is intentionally different (it asserts the cap actually fires) and is out
-of scope for this guard.
+`_stub_timeout` is the distinct, intentionally different killing variant
+(it asserts the cap actually *fires*, whereas `_make_stub_timeout` is a
+no-op passthrough) that was previously duplicated byte-for-byte between
+tests/test_ec2_ssm.py and tests/test_ec2_transport.py — this file's guard
+originally declared that variant out of scope; it is now covered by the
+same definition-count + anti-vacuity discipline below.
 """
 from __future__ import annotations
 
@@ -19,6 +23,7 @@ from pathlib import Path
 TESTS_DIR = Path(__file__).resolve().parent
 
 _MARKER_RE = re.compile(r"^def _make_stub_timeout\(", re.MULTILINE)
+_KILLING_MARKER_RE = re.compile(r"^def _stub_timeout\(", re.MULTILINE)
 
 
 def _definition_sites() -> dict[str, int]:
@@ -26,6 +31,16 @@ def _definition_sites() -> dict[str, int]:
     for path in sorted(TESTS_DIR.glob("*.py")):
         text = path.read_text(errors="replace")
         n = len(_MARKER_RE.findall(text))
+        if n:
+            hits[path.name] = n
+    return hits
+
+
+def _killing_definition_sites() -> dict[str, int]:
+    hits: dict[str, int] = {}
+    for path in sorted(TESTS_DIR.glob("*.py")):
+        text = path.read_text(errors="replace")
+        n = len(_KILLING_MARKER_RE.findall(text))
         if n:
             hits[path.name] = n
     return hits
@@ -54,6 +69,35 @@ def test_anti_vacuity_the_scan_can_find_a_real_definition() -> None:
     sites = _definition_sites()
     assert sites, (
         "expected to find at least one definition of `_make_stub_timeout` "
+        "in tests/*.py — the scan's marker is stale and its guards above "
+        "are vacuous"
+    )
+
+
+def test_killing_variant_defined_exactly_once_repo_wide() -> None:
+    sites = _killing_definition_sites()
+    total = sum(sites.values())
+    assert total == 1, (
+        f"`_stub_timeout` (the group-killing variant) should be defined "
+        f"exactly once across tests/*.py, found {total} definition(s): "
+        f"{sites} — a duplicate has been reintroduced outside "
+        f"tests/stub_helpers.py"
+    )
+
+
+def test_killing_variant_defined_only_in_stub_helpers() -> None:
+    sites = _killing_definition_sites()
+    assert sites == {"stub_helpers.py": 1}, (
+        f"`_stub_timeout` (the group-killing variant) is expected to be "
+        f"defined only in tests/stub_helpers.py, found: {sites}"
+    )
+
+
+def test_killing_variant_anti_vacuity_the_scan_can_find_a_real_definition() -> None:
+    """A scan matching nothing would certify 'no duplicates' forever."""
+    sites = _killing_definition_sites()
+    assert sites, (
+        "expected to find at least one definition of `_stub_timeout` "
         "in tests/*.py — the scan's marker is stale and its guards above "
         "are vacuous"
     )

--- a/tests/test_require_fly_ssh_isolation.py
+++ b/tests/test_require_fly_ssh_isolation.py
@@ -20,6 +20,7 @@ from pathlib import Path
 import pytest
 
 from tests.conftest import run_bash
+from tests.fly_stub import make_fake_flyctl
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 LIB_SH = REPO_ROOT / "scripts" / "remote" / "lib.sh"
@@ -99,19 +100,17 @@ def _stub_flyctl(tmp_path: Path) -> Path:
         ],
         check=True,
     )
-    stub = tmp_path / "flyctl"
-    stub.write_text(
-        f"""#!/usr/bin/env bash
-if [ "$1" = "ssh" ] && [ "$2" = "issue" ]; then
+    make_fake_flyctl(
+        tmp_path,
+        f"""if [ "$SUB" = "ssh" ]; then
   n=$(cat "{counter}")
   echo $((n+1)) > "{counter}"
   ssh-add "{userkey}" >/dev/null 2>&1
   exit 0
 fi
 exit 0
-"""
+""",
     )
-    stub.chmod(0o755)
     return counter
 
 


### PR DESCRIPTION
## Summary

Several test files had independently reimplemented the same stub helpers — flyctl `apps list`/`apps create` dispatch, the group-killing `timeout` shim, and the `run_launcher`-shaped `(args, env) -> CompletedProcess` runner. This PR consolidates those onto their shared owners (`tests/fly_stub.py::make_fake_flyctl`, `tests/stub_helpers.py::_stub_timeout`, `tests/ec2_stub.py::run_launcher`) and widens the corresponding single-owner guards so a differently-named duplicate can't evade them again.

## Which layer(s) does this PR touch?

- [ ] `docs/DESIGN.md` (architecture)
- [ ] `docs/IMPLEMENTATION.md` (code surface)
- [ ] `orchestrator/leerie.py` (code)
- [ ] docs (`README.md`, `docs/USAGE.md`, `CONTRIBUTING.md`, etc.)
- [x] tests (`tests/`)
- [ ] CI / repo meta (`.github/`)

If multiple, has the change propagated **top-down** per the three-layer rule
(DESIGN → IMPLEMENTATION → code)?

- [x] not applicable (single layer)

## Task-completion checklist

(Mirrors `CLAUDE.md` and `CONTRIBUTING.md`.)

- [ ] `docs/IMPLEMENTATION.md` updated if code surface changed
- [ ] `docs/DESIGN.md` updated if architecture changed
- [x] `pytest tests/` passes
- [x] `python3 -c "import ast; ast.parse(open('orchestrator/leerie.py').read())"` passes
- [x] `git diff --stat` reviewed for scope (no collateral edits)

## Testing notes

- Extended `tests/fly_stub.py::make_fake_flyctl` to parse the `apps list --json` / `apps create <name>` shape (`$SUB`/`$MSUB`/`$AARG`), and migrated `test_fly_per_repo_image.py`, `test_ensure_image.py`, `test_fly_state_dir_sidecar.py`, and `test_require_fly_ssh_isolation.py`'s hand-rolled flyctl stub builders onto it.
- Consolidated the group-killing `_stub_timeout` helper (previously duplicated between `test_ec2_ssm.py` and `test_ec2_transport.py`) into `tests/stub_helpers.py`, and updated `test_ec2_seed_auth.py`/`test_ec2_seed_repo.py`'s imports to match.
- Migrated `test_ec2_launcher_readonly_verbs.py`'s local `_run` onto the shared `tests/ec2_stub.py::run_launcher`.
- Widened `test_no_duplicate_ec2_run_launcher_helper.py` and `test_no_duplicate_launcher_invoke_helper.py` from a literal-name regex/AST match to a structural, name-independent AST walk (matches any two-positional-arg `(args, env)` function not delegating to the shared helper), each with a planted-reproduction regression test proving the widened scan actually fires. This surfaced two pre-existing, differently-named duplicates (`test_ec2_launcher_finalize.py`, `test_ec2_bash32_portability.py`), recorded in a `_KNOWN_UNMIGRATED` allowlist as out of scope for this run.
- Same treatment applied to `test_no_duplicate_stub_timeout.py` for the `_stub_timeout` consolidation.

## Conformance notes

- ⚠️ tests: `pytest` reported 5 failures in `tests/test_signal_cleanup.py` (`test_terminate_proc_tree_reaps_grandchildren`, `test_terminate_proc_tree_reaps_detached_session_grandchildren`, `test_descendant_tracker_reaps_orphaned_backgrounded_subprocess`, plus a truncated third entry) alongside 8402 passed / 115 skipped.
- Residual: "build/lint/tests must pass" was not fixed — the conformer notes these 5 failures are pre-existing on the base tree per the BASELINE block and are untouched by this diff (`git diff main..HEAD -- tests/test_signal_cleanup.py` is empty), and treats it as not this run's responsibility.
- Base-health baseline independently recorded `tests` as RED (`base_status: red`), consistent with the pre-existing-failure claim above.

## Related issue

N/A
