### PR TITLE
leerie: Consolidate duplicated EC2 launcher creds-args blocks and test stubs

### DIFF
--- a/leerie
+++ b/leerie
@@ -930,6 +930,36 @@ _resolve_ec2_knob() {
   fi
 }
 
+# --- _leerie_aws_creds_args_tokens -----------------------------------------
+# Emit, one token per line, the --profile/--region flags to pass to
+# resolve_aws_credentials for the 6 accept-blocked/accept-integration/
+# stop/kill/finalize/main-dispatch EC2 arms below. Reads ONLY
+# LEERIE_AWS_PROFILE/LEERIE_AWS_REGION (the launcher's own knobs, resolved
+# above) -- deliberately NOT scripts/remote/ec2-provision.sh's
+# _aws_region_profile_args, which additionally falls back to bare
+# AWS_REGION/AWS_PROFILE and emits region before profile: a different,
+# already-intentional precedence for that file's own `aws ec2`/`aws sts`
+# calls. Reusing it here would silently change these 6 sites' resolution
+# behavior.
+#
+# One-token-per-line (not a bare string), read back with the `while read`
+# idiom -- not a nameref (`local -n`), which is bash 4.3+ and fails on
+# macOS's /bin/bash 3.2 (CLAUDE.md's nameref-ban note).
+#
+# Usage:
+#   local aws_args=()
+#   while IFS= read -r _a; do aws_args+=("$_a"); done \
+#     < <(_leerie_aws_creds_args_tokens)
+_leerie_aws_creds_args_tokens() {
+  if [ -n "${LEERIE_AWS_PROFILE:-}" ]; then
+    printf '%s\n%s\n' --profile "$LEERIE_AWS_PROFILE"
+  fi
+  if [ -n "${LEERIE_AWS_REGION:-}" ]; then
+    printf '%s\n%s\n' --region "$LEERIE_AWS_REGION"
+  fi
+  return 0
+}
+
 # --- AWS region/profile prefs (leerie's own knobs, launcher-owned) --------
 # Resolve CLI > env > leerie.toml into LEERIE_AWS_REGION / LEERIE_AWS_PROFILE,
 # the vars every consumer already reads (ec2-lib.sh's require_aws,
@@ -2138,8 +2168,8 @@ print(f"ACCEPTED: {sid!r} status changed from {cur!r} to complete "
       # shellcheck disable=SC1091
       . "$LEERIE_REPO/scripts/remote/ec2-resume-instance.sh"
       _ab_aws_creds_args=()
-      [ -n "${LEERIE_AWS_PROFILE:-}" ] && _ab_aws_creds_args+=(--profile "$LEERIE_AWS_PROFILE")
-      [ -n "${LEERIE_AWS_REGION:-}" ] && _ab_aws_creds_args+=(--region "$LEERIE_AWS_REGION")
+      while IFS= read -r _ab_a; do _ab_aws_creds_args+=("$_ab_a"); done \
+        < <(_leerie_aws_creds_args_tokens)
       _ab_aws_creds_exports="$(resolve_aws_credentials ${_ab_aws_creds_args[@]+"${_ab_aws_creds_args[@]}"})" || exit 1
       eval "$_ab_aws_creds_exports"
       unset _ab_aws_creds_args _ab_aws_creds_exports
@@ -2437,8 +2467,8 @@ print(f"ACCEPTED: {sid!r} integration finding accepted")
       # shellcheck disable=SC1091
       . "$LEERIE_REPO/scripts/remote/ec2-resume-instance.sh"
       _ai_aws_creds_args=()
-      [ -n "${LEERIE_AWS_PROFILE:-}" ] && _ai_aws_creds_args+=(--profile "$LEERIE_AWS_PROFILE")
-      [ -n "${LEERIE_AWS_REGION:-}" ] && _ai_aws_creds_args+=(--region "$LEERIE_AWS_REGION")
+      while IFS= read -r _ai_a; do _ai_aws_creds_args+=("$_ai_a"); done \
+        < <(_leerie_aws_creds_args_tokens)
       _ai_aws_creds_exports="$(resolve_aws_credentials ${_ai_aws_creds_args[@]+"${_ai_aws_creds_args[@]}"})" || exit 1
       eval "$_ai_aws_creds_exports"
       unset _ai_aws_creds_args _ai_aws_creds_exports
@@ -2744,8 +2774,8 @@ print(f"ACCEPTED: {sid!r} integration finding accepted")
       # shellcheck disable=SC1091
       . "$LEERIE_REPO/scripts/remote/ec2-provision.sh"
       _stop_aws_creds_args=()
-      [ -n "${LEERIE_AWS_PROFILE:-}" ] && _stop_aws_creds_args+=(--profile "$LEERIE_AWS_PROFILE")
-      [ -n "${LEERIE_AWS_REGION:-}" ] && _stop_aws_creds_args+=(--region "$LEERIE_AWS_REGION")
+      while IFS= read -r _stop_a; do _stop_aws_creds_args+=("$_stop_a"); done \
+        < <(_leerie_aws_creds_args_tokens)
       _stop_aws_creds_exports="$(resolve_aws_credentials ${_stop_aws_creds_args[@]+"${_stop_aws_creds_args[@]}"})" || exit 1
       eval "$_stop_aws_creds_exports"
       unset _stop_aws_creds_args _stop_aws_creds_exports
@@ -2967,8 +2997,8 @@ print(f"ACCEPTED: {sid!r} integration finding accepted")
       # shellcheck disable=SC1091
       . "$LEERIE_REPO/scripts/remote/ec2-resume-instance.sh"
       _kill_ec2_creds_args=()
-      [ -n "${LEERIE_AWS_PROFILE:-}" ] && _kill_ec2_creds_args+=(--profile "$LEERIE_AWS_PROFILE")
-      [ -n "${LEERIE_AWS_REGION:-}" ] && _kill_ec2_creds_args+=(--region "$LEERIE_AWS_REGION")
+      while IFS= read -r _kill_ec2_a; do _kill_ec2_creds_args+=("$_kill_ec2_a"); done \
+        < <(_leerie_aws_creds_args_tokens)
       _kill_ec2_creds_exports="$(resolve_aws_credentials ${_kill_ec2_creds_args[@]+"${_kill_ec2_creds_args[@]}"})"
       _kill_ec2_creds_rc=$?
       if [ "$_kill_ec2_creds_rc" -ne 0 ]; then
@@ -3356,8 +3386,8 @@ except Exception:
         exit 1
       fi
       _fin_ec2_creds_args=()
-      [ -n "${LEERIE_AWS_PROFILE:-}" ] && _fin_ec2_creds_args+=(--profile "$LEERIE_AWS_PROFILE")
-      [ -n "${LEERIE_AWS_REGION:-}" ] && _fin_ec2_creds_args+=(--region "$LEERIE_AWS_REGION")
+      while IFS= read -r _fin_ec2_a; do _fin_ec2_creds_args+=("$_fin_ec2_a"); done \
+        < <(_leerie_aws_creds_args_tokens)
       _fin_ec2_creds_exports="$(resolve_aws_credentials ${_fin_ec2_creds_args[@]+"${_fin_ec2_creds_args[@]}"})" || exit 1
       eval "$_fin_ec2_creds_exports"
       unset _fin_ec2_creds_args _fin_ec2_creds_exports
@@ -8188,8 +8218,8 @@ elif [ "$RUNTIME" = "ec2" ]; then
   # shellcheck disable=SC1091
   . "$LEERIE_REPO/scripts/remote/ec2-lib.sh"
   _leerie_aws_creds_args=()
-  [ -n "${LEERIE_AWS_PROFILE:-}" ] && _leerie_aws_creds_args+=(--profile "$LEERIE_AWS_PROFILE")
-  [ -n "${LEERIE_AWS_REGION:-}" ] && _leerie_aws_creds_args+=(--region "$LEERIE_AWS_REGION")
+  while IFS= read -r _leerie_aws_a; do _leerie_aws_creds_args+=("$_leerie_aws_a"); done \
+    < <(_leerie_aws_creds_args_tokens)
   _leerie_aws_creds_exports="$(resolve_aws_credentials ${_leerie_aws_creds_args[@]+"${_leerie_aws_creds_args[@]}"})"
   _leerie_aws_creds_rc=$?
   if [ "$_leerie_aws_creds_rc" -ne 0 ]; then

--- a/tests/ec2_stub.py
+++ b/tests/ec2_stub.py
@@ -329,6 +329,48 @@ if __name__ == "__main__":
 '''
 
 
+def make_sts_only_stub_aws(
+    aws_dir: Path,
+    *,
+    identity_succeeds: bool = True,
+    record_region: bool = False,
+) -> Path:
+    """Write a minimal, argv-only `aws` stub that only special-cases
+    `sts get-caller-identity`.
+
+    Unlike `_stub_aws` below (a stateful resource-tracking stub for
+    provisioning/lifecycle tests), this one tracks no state — it exists
+    for `require_aws`-focused tests that only need to observe whether
+    `sts get-caller-identity` was called, with what argv, and (optionally)
+    with what effective `AWS_REGION`. Every invocation's argv is appended
+    to `aws_dir/aws.log`, one line per call; with `record_region=True`
+    each line also carries `|region=<value-or-<unset>>` so a caller can
+    recover the `AWS_REGION` env value `require_aws`'s `sts
+    get-caller-identity` call inherited (it never passes `--region` on
+    argv itself).
+
+    Returns the path to the stub executable.
+    """
+    aws_dir = Path(aws_dir)
+    aws_dir.mkdir(parents=True, exist_ok=True)
+    stub = aws_dir / "aws"
+    log_line = (
+        f'echo "$@|region=${{AWS_REGION:-<unset>}}" >> {aws_dir}/aws.log\n'
+        if record_region
+        else f'echo "$@" >> {aws_dir}/aws.log\n'
+    )
+    stub.write_text(
+        "#!/usr/bin/env bash\n"
+        f"{log_line}"
+        'if [ "$1" = "sts" ] && [ "$2" = "get-caller-identity" ]; then\n'
+        f"  exit {0 if identity_succeeds else 1}\n"
+        "fi\n"
+        "exit 0\n"
+    )
+    stub.chmod(0o755)
+    return stub
+
+
 def _stub_aws(dir: Path) -> Path:
     """Write the stateful `aws` stub binary into `dir`.
 

--- a/tests/test_ec2_e2e_provision.py
+++ b/tests/test_ec2_e2e_provision.py
@@ -104,6 +104,25 @@ def extract_ec2_dispatch_block() -> str:
     return src[s:e]
 
 
+def extract_aws_creds_args_tokens_fn() -> str:
+    """Pull `_leerie_aws_creds_args_tokens` verbatim.
+
+    The dispatch block (and the other 5 accept-blocked/accept-integration/
+    stop/kill/finalize arms) now call this shared helper rather than
+    inlining the --profile/--region precedence logic themselves. It's
+    defined much earlier in the launcher than the dispatch block this
+    module extracts, so any harness driving the dispatch block standalone
+    must also carry this definition — otherwise "command not found".
+    """
+    src = LAUNCHER.read_text()
+    start_marker = "_leerie_aws_creds_args_tokens() {"
+    s = src.index(start_marker)
+    e = src.index("\n}\n", s) + len("\n}")
+    assert s != -1 and e != -1, (
+        "could not locate _leerie_aws_creds_args_tokens in the launcher")
+    return src[s:e]
+
+
 def stub_aws_env(aws_dir: Path, *, identity_succeeds: bool = True,
                   extra: dict | None = None, home: Path | None = None,
                   stub_transport: bool = True) -> dict:
@@ -246,6 +265,7 @@ def run_ec2_dispatch(env: dict, *, run_provision: bool = True,
         "USER_REPO=${USER_REPO:-$PWD}",
         'LEERIE_STATE_HOST_DIR="${LEERIE_STATE_HOST_DIR:-$USER_REPO}"',
         "container_rc=0",
+        extract_aws_creds_args_tokens_fn(),
     ]
     if extra_preamble:
         script_lines.append(extra_preamble)

--- a/tests/test_ec2_launcher_credentials.py
+++ b/tests/test_ec2_launcher_credentials.py
@@ -37,7 +37,7 @@ from __future__ import annotations
 import os
 from pathlib import Path
 
-from tests.ec2_stub import read_log
+from tests.ec2_stub import make_sts_only_stub_aws, read_log
 from tests.test_ec2_e2e_provision import (
     REQUIRED_PROVISION_ENV,
     extract_ec2_dispatch_block,
@@ -49,22 +49,12 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 
 
 def _stub_aws_recording_region(aws_dir: Path) -> None:
-    """A minimal stub (mirroring test_ec2_lib_sh.py's argv-only stub)
-    that additionally records the effective AWS_REGION env value seen by
-    each invocation — the only way to observe which region `require_aws`'s
-    `sts get-caller-identity` call inherited, since require_aws never
-    passes --region on argv."""
-    aws_dir.mkdir(parents=True, exist_ok=True)
-    stub = aws_dir / "aws"
-    stub.write_text(
-        "#!/usr/bin/env bash\n"
-        f'echo "$@|region=${{AWS_REGION:-<unset>}}" >> {aws_dir}/aws.log\n'
-        'if [ "$1" = "sts" ] && [ "$2" = "get-caller-identity" ]; then\n'
-        "  exit 0\n"
-        "fi\n"
-        "exit 0\n"
-    )
-    stub.chmod(0o755)
+    """A minimal stub that additionally records the effective AWS_REGION
+    env value seen by each invocation — the only way to observe which
+    region `require_aws`'s `sts get-caller-identity` call inherited, since
+    require_aws never passes --region on argv. Thin wrapper over
+    tests/ec2_stub.py's shared builder."""
+    make_sts_only_stub_aws(aws_dir, record_region=True)
 
 
 def _region_seen_for(aws_dir: Path, argv_prefix: str) -> str | None:

--- a/tests/test_ec2_lib_sh.py
+++ b/tests/test_ec2_lib_sh.py
@@ -20,6 +20,8 @@ import os
 import subprocess
 from pathlib import Path
 
+from tests.ec2_stub import make_sts_only_stub_aws
+
 REPO_ROOT = Path(__file__).resolve().parent.parent
 EC2_LIB_SH = REPO_ROOT / "scripts" / "remote" / "ec2-lib.sh"
 LOG_SH = REPO_ROOT / "scripts" / "remote" / "_log.sh"
@@ -29,19 +31,10 @@ def _stub_aws(aws_dir: Path, *, identity_succeeds: bool = True) -> Path:
     """Write a stub `aws` binary handling `sts get-caller-identity`.
 
     Records argv to aws_dir/aws.log (one line per invocation) so tests can
-    assert on whether --profile was passed through.
+    assert on whether --profile was passed through. Thin wrapper over
+    tests/ec2_stub.py's shared builder.
     """
-    stub = aws_dir / "aws"
-    stub.write_text(
-        "#!/usr/bin/env bash\n"
-        f'echo "$@" >> {aws_dir}/aws.log\n'
-        'if [ "$1" = "sts" ] && [ "$2" = "get-caller-identity" ]; then\n'
-        f"  exit {0 if identity_succeeds else 1}\n"
-        "fi\n"
-        "exit 0\n"
-    )
-    stub.chmod(0o755)
-    return stub
+    return make_sts_only_stub_aws(aws_dir, identity_succeeds=identity_succeeds)
 
 
 def _run_require_aws(env: dict, *, aws_dir: Path | None = None,

--- a/tests/test_no_duplicate_aws_creds_args.py
+++ b/tests/test_no_duplicate_aws_creds_args.py
@@ -1,0 +1,128 @@
+"""The `--profile`/`--region` creds-args block has exactly one implementation.
+
+`accept-blocked`, `accept-integration`, `stop`, `kill --runtime ec2`,
+`finalize --runtime ec2`, and the main `RUNTIME=ec2` dispatch each used to
+carry a byte-identical, independently-copied two-line block:
+
+    [ -n "${LEERIE_AWS_PROFILE:-}" ] && <prefix>_aws_creds_args+=(--profile "$LEERIE_AWS_PROFILE")
+    [ -n "${LEERIE_AWS_REGION:-}" ] && <prefix>_aws_creds_args+=(--region "$LEERIE_AWS_REGION")
+
+differing only in the local array variable's per-site prefix. They are now
+calls to one shared `_leerie_aws_creds_args_tokens` function. This is the
+same defect class as `tests/test_no_duplicate_ec2_knob.py` (`_resolve_ec2_knob`)
+and `tests/launcher_blocks.py` (launch-block derivation, PRs #180-#183):
+without a guard, a future edit can reintroduce a 7th hand-copied block and
+nothing would notice, since the launcher would still work — the six sites
+would just silently stop sharing the fix the next time this precedence logic
+changes.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+TESTS_DIR = Path(__file__).resolve().parent
+LAUNCHER = TESTS_DIR.parent / "leerie"
+
+# The duplicated line's shape, anchored to the START OF A LINE (mirroring
+# test_no_duplicate_ec2_knob.py's marker discipline: a real reproduction of
+# the old inline form sits at the caller's indentation, column 0 of the
+# logical line; a legitimate reference -- e.g. this very docstring, or a
+# comment describing the old shape -- is never a bare source line by itself
+# at that anchor. re.MULTILINE with a leading `\s*` tolerates the callers'
+# differing indentation (top-level dispatch vs. nested arms) while still
+# requiring the line begin with the literal guard.)
+_DUP_LINE_RE = re.compile(
+    r'^[ \t]*\[ -n "\$\{LEERIE_AWS_PROFILE:-\}" \] && \w+\+=\(--profile "\$LEERIE_AWS_PROFILE"\)$',
+    re.MULTILINE,
+)
+
+_FUNC_MARKER = "_leerie_aws_creds_args_tokens() {"
+_CALL_MARKER = "< <(_leerie_aws_creds_args_tokens)"
+
+
+def _count_dup_lines(text: str) -> int:
+    return len(_DUP_LINE_RE.findall(text))
+
+
+def test_no_duplicated_inline_block_remains() -> None:
+    """Only the shared function's own body may contain this line shape."""
+    src = LAUNCHER.read_text()
+    n = _count_dup_lines(src)
+    assert n <= 1, (
+        f"found {n} copies of the inline "
+        f'`[ -n "${{LEERIE_AWS_PROFILE:-}}" ] && ...` guard line in leerie, '
+        f"expected at most 1 (inside _leerie_aws_creds_args_tokens itself). "
+        f"A caller should invoke the shared function instead of "
+        f"re-inlining this precedence logic."
+    )
+
+
+def test_the_scan_can_detect_a_planted_reproduction() -> None:
+    """Anti-vacuity: a scan that finds nothing certifies everything.
+
+    Prove the regex actually fires on the exact shape a careless future
+    edit would reintroduce, using a fresh variable prefix so it cannot be
+    confused with a real call site.
+    """
+    planted = (
+        '      _planted_aws_creds_args=()\n'
+        '      [ -n "${LEERIE_AWS_PROFILE:-}" ] && '
+        '_planted_aws_creds_args+=(--profile "$LEERIE_AWS_PROFILE")\n'
+        '      [ -n "${LEERIE_AWS_REGION:-}" ] && '
+        '_planted_aws_creds_args+=(--region "$LEERIE_AWS_REGION")\n'
+    )
+    real_src = LAUNCHER.read_text()
+    assert _count_dup_lines(real_src + planted) == _count_dup_lines(real_src) + 1, (
+        "the duplicate-line scan did not detect a planted reproduction of "
+        "the old inline block -- the guard above would pass vacuously"
+    )
+
+
+def test_shared_function_defined_exactly_once() -> None:
+    src = LAUNCHER.read_text()
+    assert src.count(_FUNC_MARKER) == 1, (
+        f"expected exactly one `{_FUNC_MARKER}` definition in leerie, found "
+        f"{src.count(_FUNC_MARKER)}"
+    )
+
+
+def test_shared_function_called_at_all_six_sites() -> None:
+    src = LAUNCHER.read_text()
+    # The definition's own usage-example comment also contains the call
+    # marker, so the call-site count is (occurrences - 1 for the def body's
+    # doc comment - 1 for the marker's own appearance inside the function
+    # name... in practice: total occurrences of the call marker minus the
+    # one that appears in the docstring-style comment above the def).
+    total = src.count(_CALL_MARKER)
+    # One occurrence lives in the usage-comment directly above the
+    # function definition; the rest are real call sites.
+    comment_occurrences = src.count(f"#     {_CALL_MARKER}")
+    call_sites = total - comment_occurrences
+    assert call_sites == 6, (
+        f"expected 6 real call sites of `_leerie_aws_creds_args_tokens` "
+        f"(accept-blocked, accept-integration, stop, kill --runtime ec2, "
+        f"finalize --runtime ec2, main RUNTIME=ec2 dispatch), found "
+        f"{call_sites} (total occurrences of the call marker: {total}, "
+        f"comment occurrences: {comment_occurrences})"
+    )
+
+
+def test_no_test_file_reimplements_the_block() -> None:
+    """No test should hand-copy the old inline shape to fake coverage."""
+    strays: dict[str, int] = {}
+    for path in sorted(TESTS_DIR.rglob("*.py")):
+        if path.name == Path(__file__).name:
+            continue
+        try:
+            text = path.read_text(errors="replace")
+        except OSError:
+            continue
+        n = _count_dup_lines(text)
+        if n:
+            strays[path.name] = n
+    assert not strays, (
+        f"{sorted(strays)} contain the old inline AWS creds-args block "
+        f"shape -- tests should exercise the real launcher, not a "
+        f"hand-copied reproduction of retired logic"
+    )

--- a/tests/test_no_duplicate_sts_stub.py
+++ b/tests/test_no_duplicate_sts_stub.py
@@ -1,0 +1,120 @@
+"""The minimal argv-only `aws sts get-caller-identity` stub has exactly
+one implementation: tests/ec2_stub.py's `make_sts_only_stub_aws`.
+
+tests/test_ec2_lib_sh.py::_stub_aws and
+tests/test_ec2_launcher_credentials.py::_stub_aws_recording_region used to
+each hand-write a near-identical bash stub — write an `aws` binary that
+logs argv to `aws.log` and special-cases `sts get-caller-identity` — the
+second file's own docstring already said it mirrored the first. Both are
+now thin wrappers delegating to `tests/ec2_stub.py::make_sts_only_stub_aws`,
+the single-owner module this repo already uses for this class of fixture.
+
+Same defect class and guard shape as
+`tests/test_no_duplicate_ec2_sidecar_helper.py` (`write_ec2_sidecar`) and
+`tests/test_no_duplicate_ec2_knob.py` (`_resolve_ec2_knob`): a hand-copied
+fixture helper is body-blind by construction, so a third file could
+silently reintroduce a copy that drifts from the shared one without any
+test noticing — unless something scans for it.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+TESTS_DIR = Path(__file__).resolve().parent
+OWNER = TESTS_DIR / "ec2_stub.py"
+
+# The marker matches the distinctive *shape* of this specific stub: the
+# `[ "$2" = "get-caller-identity" ]; then` condition, followed (within a
+# short window) by an unconditional `exit 0` fallthrough for every other
+# command. That fallthrough is what makes this shape a full reimplementation
+# of the minimal argv-logging stub, and is deliberately what distinguishes
+# it from tests/test_ec2_e2e_provision.py's `_break_sts_get_caller_identity`
+# — a legitimately different, narrower helper that shares the same `if`
+# condition text (a reasonable shell fragment to reach for independently)
+# but execs the real stateful stub for every other command instead of
+# falling through to a bare `exit 0`. It never appears in prose (every
+# prose mention of "sts get-caller-identity" above reads without the
+# trailing `]; then ... exit 0` shell syntax), so it needs no start-of-line
+# anchor the way a `def foo(` marker does.
+_MARKER_RE = re.compile(
+    r'get-caller-identity[\'"]?\s*\]\s*;\s*then.{0,150}?\bfi\b.{0,60}?exit 0',
+    re.DOTALL,
+)
+
+
+def _files_defining_the_stub_body() -> dict[str, int]:
+    """Every file under tests/ that embeds the stub's shell body."""
+    hits: dict[str, int] = {}
+    for path in sorted(TESTS_DIR.rglob("*.py")):
+        if path == OWNER or path.name == Path(__file__).name:
+            continue
+        try:
+            text = path.read_text(errors="replace")
+        except OSError:
+            continue
+        n = len(_MARKER_RE.findall(text))
+        if n:
+            hits[path.name] = n
+    return hits
+
+
+def test_no_test_file_reimplements_the_sts_stub() -> None:
+    strays = _files_defining_the_stub_body()
+    assert not strays, (
+        f"{sorted(strays)} embed a hand-written `sts get-caller-identity` "
+        f"stub body themselves. Import `make_sts_only_stub_aws` from "
+        f"tests/ec2_stub.py instead of copying it — a hand-copied fixture "
+        f"is body-blind by construction and can silently drift from the "
+        f"shared version."
+    )
+
+
+def test_the_owner_actually_defines_it() -> None:
+    """Anti-vacuity: a scan whose target no longer exists passes forever.
+
+    If the stub body is refactored away in tests/ec2_stub.py, the test
+    above certifies "no duplicates" against a marker that matches
+    nothing. Pin the real definition so that fails as a broken scan
+    instead.
+    """
+    src = OWNER.read_text()
+    assert "def make_sts_only_stub_aws(" in src, (
+        "expected tests/ec2_stub.py to define `make_sts_only_stub_aws` — "
+        "the duplicate scan's target is missing, so its result above is "
+        "meaningless"
+    )
+    n = len(_MARKER_RE.findall(src))
+    assert n == 1, (
+        f"expected exactly one embedded `sts get-caller-identity` stub "
+        f"body in tests/ec2_stub.py, found {n} — the duplicate scan's "
+        f"marker is stale, so its result above is meaningless"
+    )
+
+
+def test_scan_can_detect_a_planted_reproduction(tmp_path: Path) -> None:
+    """Anti-vacuity: prove the scan actually fires on a reproduction, not
+    just that it reports zero on the current (already-fixed) tree.
+
+    Runs the real scan logic against a throwaway directory containing a
+    planted copy, so a future edit that quietly breaks the regex fails
+    loudly here instead of silently degrading the guard above into one
+    that can never fire.
+    """
+    planted = tmp_path / "test_fake_sts_stub_copy.py"
+    planted.write_text(
+        "def _stub_aws(aws_dir):\n"
+        "    stub.write_text(\n"
+        '        \'if [ "$1" = "sts" ] && [ "$2" = "get-caller-identity" ]; then\\n\'\n'
+        '        "  exit 0\\n"\n'
+        '        "fi\\n"\n'
+        '        "exit 0\\n"\n'
+        "    )\n"
+    )
+    hits = {
+        path.name: n
+        for path in sorted(tmp_path.rglob("*.py"))
+        for n in [len(_MARKER_RE.findall(path.read_text(errors="replace")))]
+        if n
+    }
+    assert hits == {"test_fake_sts_stub_copy.py": 1}, hits


### PR DESCRIPTION
## Summary

Removes two instances of duplicated logic flagged by a DRY-focused refactoring pass: the launcher's six independently-copied `--profile`/`--region` creds-args blocks, and two hand-written `aws sts get-caller-identity` test stubs.

## Which layer(s) does this PR touch?

(See [`CLAUDE.md`](../CLAUDE.md) for the three-layer rule.)

- [ ] `docs/DESIGN.md` (architecture)
- [ ] `docs/IMPLEMENTATION.md` (code surface)
- [x] `orchestrator/leerie.py` (code)
- [ ] docs (`README.md`, `docs/USAGE.md`, `CONTRIBUTING.md`, etc.)
- [x] tests (`tests/`)
- [ ] CI / repo meta (`.github/`)

If multiple, has the change propagated **top-down** per the three-layer rule
(DESIGN → IMPLEMENTATION → code)?

- [ ] yes
- [x] not applicable (single layer)

## Task-completion checklist

(Mirrors `CLAUDE.md` and `CONTRIBUTING.md`.)

- [ ] `docs/IMPLEMENTATION.md` updated if code surface changed
- [ ] `docs/DESIGN.md` updated if architecture changed
- [x] `pytest tests/` passes
- [x] `python3 -c "import ast; ast.parse(open('orchestrator/leerie.py').read())"` passes
- [x] `git diff --stat` reviewed for scope (no collateral edits)

## Testing notes

Added `tests/test_no_duplicate_aws_creds_args.py`, guarding against a 7th hand-copied creds-args block reappearing (asserts the shared `_leerie_aws_creds_args_tokens` function is defined once and called at all six sites, plus a no-stray-copy sweep across `tests/`), and `tests/test_no_duplicate_sts_stub.py`, guarding against a third hand-written `sts get-caller-identity` stub reappearing outside `tests/ec2_stub.py::make_sts_only_stub_aws`. Both include anti-vacuity checks that the scan actually detects a planted reproduction. `tests/test_ec2_e2e_provision.py`'s dispatch-block extraction harness was extended to also pull the new shared function.

## Related issue

_None._

## Conformance notes

- **tests axis (advisory, pre-existing on base):** `pytest` reports 5 failures — `test_duplicate_task_guard.py::TestTheGateActuallyRefuses::test_the_refusal_names_the_duplicate` and 3 tests in `test_signal_cleanup.py` (`test_terminate_proc_tree_reaps_grandchildren`, `test_terminate_proc_tree_reaps_detached_session_grandchildren`, `test_descendant_tracker_reaps_orphaned_backgrounded_subprocess`) — 8410 passed, 115 skipped. These match the base tree's pre-existing RED list and touch none of the files this diff modifies (`leerie`, `tests/ec2_stub.py`, `tests/test_ec2_e2e_provision.py`, `tests/test_ec2_launcher_credentials.py`, `tests/test_ec2_lib_sh.py`, `tests/test_no_duplicate_aws_creds_args.py`, `tests/test_no_duplicate_sts_stub.py`) — not this run's responsibility.
