### PR TITLE
fix: give `leerie finalize` a local arm instead of defaulting to Fly

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -1771,6 +1771,19 @@ Both paths share `scripts/host-finalize.sh`; the recovery command
 `leerie finalize <run-id>` also sources it — three call sites, one
 finalize implementation.
 
+That inline block is the *normal* local path, but it only runs when the
+launcher reaches the end of a run. A local run interrupted before then —
+Ctrl-C after the waves integrated but before `phase_finalize` — leaves a
+complete run branch on the host and no `finished_at` in `run.json`. So
+`leerie finalize <run-id>` is the recovery verb for local runs too, not
+only remote ones: it resolves the runtime to local (no Fly or EC2 sidecar
+present), skips the fetch — there is nothing to fetch, the state root is
+bind-mounted and the branch is already in the user's repo — and calls
+`host_finalize` directly. The completion gate there keys on
+`completed_waves`, deliberately not on `finished_at`, precisely so an
+interrupted-but-complete run is finalizable while a crashed-mid-wave one
+is not.
+
 **`no_push`: intent vs mechanism.** The orchestrator inside the Machine is
 *always* invoked with `--no-push` because the Fly Machine has no GitHub
 auth — a **mechanism flag**, not the user's preference. The user's actual

--- a/docs/IMPLEMENTATION.md
+++ b/docs/IMPLEMENTATION.md
@@ -7004,9 +7004,8 @@ auth fails. Any other `--runtime` value falls through unchanged.
 
 Verbs `kill`, `stop`, and `accept-blocked` accept an optional
 `--runtime <local|fly|ec2>` flag, validated against the same `RUNTIME_VALUES`
-enum that gates launching a new run. `finalize` remains narrower — it
-validates only `local`/`fly` (rejecting `ec2`) since `finalize --runtime ec2`
-has not shipped.
+enum that gates launching a new run. `finalize` accepts the same three
+values.
 
 The launcher's `RUNTIME=ec2` branch dispatches the full create → seed →
 launch → teardown cycle for launching a run; `stop --runtime ec2` routes to
@@ -7016,9 +7015,23 @@ stop`/`destroy`; EC2 to `aws ec2 stop-instances`/`terminate-instances`; local
 to `nerdctl stop`/`kill` via `_is_local_container` (`nerdctl inspect
 <run-id>`). `stop` uses SIGTERM-equivalents (graceful state save); `kill`
 uses immediate destroy (EC2 after the fetch-before-terminate sync).
-`finalize --runtime local` still errors — local finalization is inline.
-Without the flag, verbs infer runtime from the sidecar (Fly, then EC2, then
-`nerdctl inspect`, via `_auto_detect_run_runtime`). `resume` accepts
+A local run finalizes inline at the end of a normal run; `finalize
+--runtime local` is the *recovery* path for one interrupted before that
+block could run (Ctrl-C after the waves integrated, say), where `run.json`
+carries no `finished_at` and the already-synced probe cannot fire. It skips
+the fetch entirely — the branch and state are already on the host — and goes
+straight to `host_finalize`, whose completion gate keys on
+`completed_waves`, not `finished_at`. `finalize --force` is refused for a
+local run: it exists to SIGTERM a detached remote orchestrator, and a local
+run's orchestrator exits with its container.
+
+Without the flag, verbs infer runtime from the sidecar via
+`_auto_detect_run_runtime`: `fly-machine.json` → fly, else
+`ec2-instance.json` → ec2, else **local by absence**. `finalize` resolves the
+absent case to local rather than falling through to the Fly arm. It cannot
+use `_is_local_container` (`nerdctl inspect <run-id>`) the way `stop`/`kill`
+do — that probe only succeeds while the container is alive, and a finalize
+runs after it has exited. `resume` accepts
 `--runtime` directly (fly takes the smart-attach path, local the inline
 re-exec path).
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -2131,7 +2131,34 @@ detects as `ec2`; a fly-machine.json-only run dir still detects as `fly`
 echoed; an explicit runtime short-circuits detection even when a sidecar
 for a different runtime is present; Fly wins when (never expected in
 practice) both sidecars co-exist; and the Fly-only wrapper returns
-nonzero for an EC2 run. The second half invokes the real launcher end to
+nonzero for an EC2 run.
+
+`finalize`'s **local** arm is covered by six further end-to-end cases in the
+same file. The discriminating one is
+`test_finalize_local_run_without_finished_at_reaches_host_finalize`: a run
+dir with no Fly/EC2 sidecar and deliberately **no `finished_at`** — the shape
+left by a Ctrl-C after the waves integrated but before `phase_finalize`.
+Before the local arm existed, `_auto_detect_run_runtime` left `_fin_runtime`
+empty, the `_already_synced` probe missed for want of `finished_at`, and the
+dispatch chain's bare `else` sent the run into the Fly path, where
+`require_flyctl` offered to *install flyctl* for a run that never touched
+Fly. The fixture sets `no_push` so `host_finalize` short-circuits at its own
+early gate (`scripts/host-finalize.sh:294`) — a return from *inside*
+`host_finalize`, which is what proves the launcher handed off, without the
+test needing a git remote or a rebaser worker. The remaining cases pin
+`--runtime local` as accepted (it used to `exit 1`), `--force` refused with
+the local message rather than the EC2 one, a missing run branch failing
+closed on the branch rather than deeper in `host_finalize`, a Fly sidecar
+still promoting to `fly` (the local default must not swallow a real Fly
+run), and the advertised usage enum reading `local|fly|ec2` — asserted
+through a real rejection, so it checks what a user is shown rather than a
+source substring. These fixtures point `USER_REPO` at a scratch git repo,
+which the finalize arm honors via `USER_REPO="${USER_REPO:-$PWD}"`. Note the
+local-shaped fixtures in `tests/test_launcher_finalize_no_work.py` cannot
+catch this regression: all of them exit early through `_already_synced` /
+`pushed_at` / argv validation and never reach the runtime dispatch.
+
+The second half invokes the real launcher end to
 end (mirroring
 `tests/test_accept_blocked.py`'s local-path pattern) across `stop`,
 `kill`, `accept-blocked`, and `finalize`: each accepts `ec2`

--- a/leerie
+++ b/leerie
@@ -3194,7 +3194,7 @@ print(f"ACCEPTED: {sid!r} integration finding accepted")
         # silently dropped and the user thought they had passed --force.
         --*)
           remote_log "finalize: unknown flag: $_a"
-          echo "  Usage: leerie finalize <run-id> [--force] [--no-verify] [--no-push] [--runtime fly|ec2]" >&2
+          echo "  Usage: leerie finalize <run-id> [--force] [--no-verify] [--no-push] [--runtime local|fly|ec2]" >&2
           exit 1
           ;;
         *)
@@ -3203,7 +3203,7 @@ print(f"ACCEPTED: {sid!r} integration finding accepted")
           # — refuse to silently accept it.
           if [ "$_fin_seen_positional" = "true" ]; then
             remote_log "finalize: unexpected extra positional: $_a"
-            echo "  Usage: leerie finalize <run-id> [--force] [--no-verify] [--no-push] [--runtime fly|ec2]" >&2
+            echo "  Usage: leerie finalize <run-id> [--force] [--no-verify] [--no-push] [--runtime local|fly|ec2]" >&2
             exit 1
           fi
           _fin_seen_positional=true
@@ -3218,15 +3218,11 @@ print(f"ACCEPTED: {sid!r} integration finding accepted")
     # path — a surprise the operator would not have asked for.
     if [ -n "$_fin_prev" ]; then
       remote_log "finalize: $_fin_prev requires a value"
-      echo "  Usage: leerie finalize <run-id> [--force] [--no-verify] [--no-push] [--runtime fly|ec2]" >&2
+      echo "  Usage: leerie finalize <run-id> [--force] [--no-verify] [--no-push] [--runtime local|fly|ec2]" >&2
       exit 1
     fi
     if [ -n "$_fin_runtime" ] && [ "$_fin_runtime" != "fly" ] && [ "$_fin_runtime" != "local" ] && [ "$_fin_runtime" != "ec2" ]; then
       remote_log "finalize: --runtime must be 'local', 'fly', or 'ec2' (got '$_fin_runtime')"
-      exit 1
-    fi
-    if [ "$_fin_runtime" = "local" ]; then
-      remote_log "finalize --runtime local: no local-runtime equivalent yet (local runs finalize inline)."
       exit 1
     fi
     _fin_detected="$(_auto_detect_run_runtime "$_fin_run_id" "$_fin_runtime")" || _fin_detected=""
@@ -3237,9 +3233,24 @@ print(f"ACCEPTED: {sid!r} integration finding accepted")
       remote_log "finalize: auto-detected EC2 run; promoting --runtime to ec2"
       _fin_runtime="ec2"
     fi
+    # Neither remote sidecar and no explicit --runtime: a local run.
+    # `_auto_detect_run_runtime` returning non-zero means exactly that (it
+    # probes only fly-machine.json then ec2-instance.json), and it is the
+    # only usable signal here. `_is_local_container` — which stop/kill use —
+    # cannot serve: it shells `nerdctl inspect <run-id>`, and a finalize by
+    # definition runs after the container has exited, so it reports "not
+    # local" for every run this arm exists to serve.
+    #
+    # Defaulting to local mirrors `resume`, which starts at RUNTIME=local and
+    # only *promotes* on sidecar detection. Before this, an empty runtime fell
+    # through to the Fly arm below and asked the operator to install flyctl
+    # for a run that never touched Fly.
+    if [ -z "$_fin_runtime" ]; then
+      _fin_runtime="local"
+    fi
     if [ -z "$_fin_run_id" ]; then
       remote_log "finalize requires a <run-id>"
-      echo "  Usage: leerie finalize <run-id> [--force] [--no-verify] [--no-push] [--runtime fly|ec2]" >&2
+      echo "  Usage: leerie finalize <run-id> [--force] [--no-verify] [--no-push] [--runtime local|fly|ec2]" >&2
       exit 1
     fi
     _fin_run_dir="$LEERIE_STATE_HOST_DIR/runs/$_fin_run_id"
@@ -3355,6 +3366,50 @@ except Exception:
       remote_log "finalize: run already synced to host; skipping fetch_branch"
       _fetched_run_id="$_fin_run_id"
       _fetched_run_dir="$_fin_run_dir"
+    elif [ "$_fin_runtime" = "local" ]; then
+      # Local run: branch and state are already on this host (the
+      # orchestrator writes straight to the bind-mounted state root), so
+      # there is nothing to fetch — fall through to host_finalize.
+      #
+      # This is the recovery path for a local run interrupted before its
+      # inline post-run finalize block could run. `finished_at` is unwritten
+      # in that case, so the `_already_synced` probe above cannot fire.
+      #
+      # `--force` is meaningless here: it exists to SIGTERM a *detached*
+      # remote orchestrator, and a local run's orchestrator dies with its
+      # container. Refuse it rather than silently ignoring it (mirrors the
+      # EC2 arm's refusal below).
+      if [ "$_FINALIZE_FORCE" = "true" ]; then
+        remote_log "finalize --force is not supported for local runs: there is no detached orchestrator to stop (a local run's orchestrator exits with its container)"
+        remote_log "  Retry without --force, or run \`leerie kill $_fin_run_id\` if a container is still up."
+        exit 1
+      fi
+      # Fail closed when there is no branch to push. host_finalize's own
+      # no_push gate covers the deliberate no-work case (DESIGN §8); this
+      # catches the other shape — a run whose branch was never created, or
+      # was deleted — where host_finalize would otherwise fail further in
+      # with a message about run.json rather than about the missing branch.
+      _fin_local_branch="$(_json_get "$_fin_run_dir/run.json" "branch")"
+      _fin_local_no_push="$(python3 -c '
+import json, sys
+try:
+    d = json.load(open(sys.argv[1]))
+    print("true" if d.get("no_push") is True else "")
+except Exception:
+    pass
+' "$_fin_run_dir/run.json")"
+      if [ "$_fin_local_no_push" != "true" ] && { [ -z "$_fin_local_branch" ] || \
+           ! git -C "$USER_REPO" rev-parse --verify \
+               "refs/heads/$_fin_local_branch" >/dev/null 2>&1; }; then
+        remote_log "finalize: local run $_fin_run_id has no run branch in $USER_REPO"
+        remote_log "  Expected branch: ${_fin_local_branch:-<none recorded in run.json>}"
+        remote_log "  Nothing to push. The per-subtask work (if any) is on the"
+        remote_log "  leerie/subtasks/$_fin_run_id/* branches."
+        exit 1
+      fi
+      remote_log "finalize: local run $_fin_run_id; state and branch already on this host, skipping fetch"
+      _fetched_run_id="$_fin_run_id"
+      _fetched_run_dir="$_fin_run_dir"
     elif [ "$_fin_runtime" = "ec2" ]; then
       # EC2 fetch: stream the completed run's branch + state back to the host,
       # then fall through to host_finalize exactly as the Fly path does.
@@ -3460,7 +3515,7 @@ except Exception:
       fi
       _fetched_run_id="$_fin_run_id"
       _fetched_run_dir="$_fin_run_dir"
-    else
+    elif [ "$_fin_runtime" = "fly" ]; then
       # shellcheck disable=SC1091
       . "$LEERIE_REPO/scripts/remote/provision.sh"
       # shellcheck disable=SC1091
@@ -3524,6 +3579,13 @@ except Exception:
         remote_log "error: fetch_branch succeeded but $_fetched_run_dir missing"
         exit 1
       fi
+    else
+      # Unreachable: the enum validator above accepts only local/fly/ec2 and
+      # the empty case is resolved to local. Kept so a future runtime added
+      # to the validator without an arm here fails loudly instead of
+      # silently taking whichever branch happens to be last.
+      remote_log "finalize: internal error - unhandled runtime: $_fin_runtime"
+      exit 1
     fi
     # Detect --no-verify and --no-push from $@ for consistency with the
     # normal post-run path. Seed from any inherited environment value first

--- a/tests/test_auto_detect_run_runtime.py
+++ b/tests/test_auto_detect_run_runtime.py
@@ -33,6 +33,9 @@ import os
 import subprocess
 from pathlib import Path
 
+import pytest
+
+from tests.conftest import HAS_JQ
 from tests.ec2_stub import run_launcher as _run_launcher_shared
 
 REPO_ROOT_LAUNCHER = Path(__file__).resolve().parent.parent / "leerie"
@@ -426,3 +429,168 @@ def test_resume_fly_sidecar_still_promotes_to_fly_no_regression(tmp_path):
     assert r.returncode != 0
     assert "auto-detected Fly run" in r.stderr
     assert "LEERIE_FLY_APP is required" in r.stderr
+
+
+# --- finalize: the local arm ----------------------------------------------
+#
+# Before this arm existed, `_auto_detect_run_runtime` had no local case, so a
+# local run left `_fin_runtime` empty and fell through the dispatch chain's
+# bare `else` into the Fly path — which calls `require_flyctl` and offers to
+# INSTALL flyctl for a run that never touched Fly. The only thing that kept
+# an ordinary local run out of that branch was the `_already_synced` probe,
+# which requires `finished_at`; a run interrupted before `phase_finalize`
+# (Ctrl-C after the waves integrated) has none, so it hit flyctl.
+#
+# These drive the real launcher end to end. `USER_REPO` is honored by the
+# finalize arm (`USER_REPO="${USER_REPO:-$PWD}"`), which is what lets the
+# fixtures point it at a scratch repo instead of this one.
+
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=True, capture_output=True, text=True,
+    )
+
+
+def _make_local_run(state_dir: Path, tmp_path: Path, run_id: str, *,
+                    create_branch: bool = True,
+                    finished: bool = False,
+                    no_push: bool = False) -> tuple[Path, Path]:
+    """A local run dir (no Fly/EC2 sidecar) plus a scratch USER_REPO.
+
+    Deliberately writes NO `finished_at` unless asked: that is the exact
+    shape of the incident this arm exists for, and it is what makes the
+    `_already_synced` probe miss so the dispatch has to classify the runtime.
+    """
+    repo = tmp_path / "user_repo"
+    repo.mkdir(parents=True, exist_ok=True)
+    _git(repo, "init", "-q", "-b", "main")
+    _git(repo, "config", "user.email", "t@example.com")
+    _git(repo, "config", "user.name", "t")
+    (repo / "f.txt").write_text("base\n")
+    _git(repo, "add", "f.txt")
+    _git(repo, "commit", "-q", "-m", "base")
+
+    branch = f"leerie/runs/{run_id}"
+    if create_branch:
+        _git(repo, "checkout", "-q", "-b", branch)
+        (repo / "f.txt").write_text("work\n")
+        _git(repo, "commit", "-q", "-am", "work")
+        _git(repo, "checkout", "-q", "main")
+
+    run_dir = state_dir / "runs" / run_id
+    run_dir.mkdir(parents=True, exist_ok=True)
+    run_json = {
+        "run_id": run_id,
+        "branch": branch,
+        "working_branch": "main",
+        "pr_base_branch": "main",
+    }
+    if finished:
+        run_json["finished_at"] = "2026-08-24T22:00:00+00:00"
+    if no_push:
+        run_json["no_push"] = True
+    (run_dir / "run.json").write_text(json.dumps(run_json))
+    (run_dir / "state.json").write_text(
+        json.dumps({"completed_waves": 1, "waves": [["s1"]]})
+    )
+    return run_dir, repo
+
+
+def _finalize(args, state_dir: Path, repo: Path):
+    env = _launcher_env(state_dir)
+    env["USER_REPO"] = str(repo)
+    return _run_launcher_shared(
+        args, env, launcher=REPO_ROOT_LAUNCHER, timeout=60
+    )
+
+
+@pytest.mark.skipif(not HAS_JQ, reason="host_finalize parses run.json with jq")
+def test_finalize_local_run_without_finished_at_reaches_host_finalize(tmp_path):
+    """THE reported bug: a local run interrupted before `finished_at` was
+    written must finalize locally, never ask for flyctl.
+
+    `no_push` is set so `host_finalize` short-circuits at its own early gate
+    (host-finalize.sh:294) — that return is *inside* host_finalize, so
+    observing it proves the launcher handed off, without this test needing a
+    git remote or a rebaser worker.
+
+    Note the existing local-shaped fixtures in
+    tests/test_launcher_finalize_no_work.py cannot catch this regression:
+    every one of them exits early via `_already_synced` / `pushed_at` / argv
+    validation and never reaches the runtime dispatch at all.
+    """
+    state_dir = tmp_path / "state"
+    run_dir, repo = _make_local_run(state_dir, tmp_path, "r1", no_push=True)
+    assert "finished_at" not in json.loads((run_dir / "run.json").read_text())
+
+    r = _finalize(["finalize", "r1"], state_dir, repo)
+
+    combined = r.stdout + r.stderr
+    assert "flyctl" not in combined.lower(), combined
+    assert "state and branch already on this host" in r.stderr, r.stderr
+    assert "no_push=true; skipping push + PR" in r.stderr, r.stderr
+    assert r.returncode == 0, combined
+
+
+@pytest.mark.skipif(not HAS_JQ, reason="host_finalize parses run.json with jq")
+def test_finalize_local_accepts_explicit_runtime_local(tmp_path):
+    """`--runtime local` used to be refused outright ("no local-runtime
+    equivalent yet"). It is now a supported selector for the same arm."""
+    state_dir = tmp_path / "state"
+    _, repo = _make_local_run(state_dir, tmp_path, "r1", no_push=True)
+    r = _finalize(["finalize", "r1", "--runtime", "local"], state_dir, repo)
+    assert "no local-runtime equivalent" not in r.stderr, r.stderr
+    assert "flyctl" not in (r.stdout + r.stderr).lower()
+    assert r.returncode == 0, r.stdout + r.stderr
+
+
+def test_finalize_local_refuses_force(tmp_path):
+    """--force exists to SIGTERM a detached remote orchestrator; a local
+    run's orchestrator exits with its container. Refused, not ignored — and
+    with the local message, not the EC2 one."""
+    state_dir = tmp_path / "state"
+    _, repo = _make_local_run(state_dir, tmp_path, "r1")
+    r = _finalize(["finalize", "r1", "--force"], state_dir, repo)
+    assert r.returncode != 0
+    assert "not supported for local runs" in r.stderr, r.stderr
+    assert "flyctl-transport only" not in r.stderr, r.stderr
+    assert "flyctl" not in (r.stdout + r.stderr).lower()
+
+
+def test_finalize_local_fails_closed_when_run_branch_absent(tmp_path):
+    """No branch and no `no_push` intent: fail with a message about the
+    missing branch, not a flyctl prompt and not a confusing run.json error
+    from deeper inside host_finalize."""
+    state_dir = tmp_path / "state"
+    _, repo = _make_local_run(state_dir, tmp_path, "r1", create_branch=False)
+    r = _finalize(["finalize", "r1"], state_dir, repo)
+    assert r.returncode != 0
+    assert "has no run branch" in r.stderr, r.stderr
+    assert "flyctl" not in (r.stdout + r.stderr).lower()
+
+
+def test_finalize_fly_sidecar_still_promotes_to_fly_no_regression(tmp_path):
+    """The local default must not swallow a genuine Fly run."""
+    state_dir = tmp_path / "state"
+    _, repo = _make_local_run(state_dir, tmp_path, "r1")
+    (state_dir / "runs" / "r1" / "fly-machine.json").write_text(
+        json.dumps({"fly_machine_id": "m1"})
+    )
+    r = _finalize(["finalize", "r1"], state_dir, repo)
+    assert "auto-detected Fly run; promoting --runtime to fly" in r.stderr
+    assert "state and branch already on this host" not in r.stderr
+    assert r.returncode != 0
+    assert "LEERIE_FLY_APP is required" in r.stderr, r.stderr
+
+
+def test_finalize_usage_strings_offer_local(tmp_path):
+    """Paired with the behavioural tests above: the advertised enum must
+    match what the arm now accepts. Driven through a real rejection so this
+    asserts what a user is actually shown, not a source substring."""
+    state_dir = tmp_path / "state"
+    _, repo = _make_local_run(state_dir, tmp_path, "r1")
+    r = _finalize(["finalize", "r1", "--foorce"], state_dir, repo)
+    assert r.returncode != 0
+    assert "--runtime local|fly|ec2" in r.stderr, r.stderr


### PR DESCRIPTION
## The bug

`leerie finalize <run-id>` on a local run offered to **install flyctl** for a run that never touched Fly.

`_auto_detect_run_runtime` (`leerie:689`) probes only for `fly-machine.json` then `ec2-instance.json` — there is no local case, so a local run left `_fin_runtime` empty. The dispatch chain was `if _already_synced / elif ec2 / else`, and that bare `else` **is** the Fly path: it calls `require_flyctl`, which offers an interactive install. Empty runtime therefore meant Fly.

The only thing keeping an ordinary local run out of that branch was the `_already_synced` probe, which requires `finished_at`. A run interrupted before `phase_finalize` — Ctrl-C after the waves integrated — has none. `--runtime local` was hard-rejected, so there was no escape hatch either.

`finalize` was the only run-id verb missing the local fallback that `stop`, `kill`, `accept-blocked`, `accept-integration`, and `resume` all have.

## Why the code is the defect, not the spec

`IMPLEMENTATION.md` already documented the local arm — *"Fly, then EC2, then `nerdctl inspect`, via `_auto_detect_run_runtime`"* — for a function containing no `nerdctl` call.

But `_is_local_container` cannot be that probe: it shells `nerdctl inspect <run-id>`, which only succeeds while the container exists. That is right for `stop`/`kill` and wrong for `finalize`, which by definition runs *after* it has exited — implementing the documented sentence literally would have left the bug in place. Local is resolved by **absence of both sidecars**, which is exactly what `_auto_detect_run_runtime` returning non-zero means.

## Changes

`leerie` (+71/−9) — drop the `--runtime local` reject; resolve an empty runtime to `local`; new local dispatch arm (nothing to fetch → straight to `host_finalize`, `--force` refused, fail closed on a missing run branch); trailing `else` becomes an explicit `elif fly` plus an impossible-runtime guard; all 4 `Usage:` strings now read `[--runtime local|fly|ec2]`.

That last change also closes a latent `set -u` bug: `FLY_APP` is exported only under `_fin_runtime = fly`, so the old empty-runtime fallthrough would have hit unbound `$FLY_APP` — masked only because `require_flyctl` exited first.

Docs are updated top-down per the three-layer rule. `IMPLEMENTATION.md` also drops a separately stale claim that finalize validates only local/fly and rejects `ec2` (untrue — `leerie:3224` accepts it and `:3358` wires a real arm).

## Testing

`tests/test_auto_detect_run_runtime.py`: 6 new end-to-end cases, file now **29 tests, all passing**.

The discriminating case builds a run dir with no sidecar and deliberately **no `finished_at`**. The existing local-shaped fixtures in `test_launcher_finalize_no_work.py` cannot catch this regression — every one exits early via `_already_synced` / `pushed_at` / argv validation and never reaches the runtime dispatch. It sets `no_push` so `host_finalize` short-circuits at its own early gate (`host-finalize.sh:294`) — a return from *inside* `host_finalize`, which is what proves the hand-off, without needing a git remote or a rebaser worker.

Verified end to end against a real stuck local run (Ctrl-C'd, 4/4 waves integrated, no `finished_at`): resolved to local, skipped the fetch, rebased onto a moved base, pushed, and opened its PR — never naming flyctl.

⚠️ `shellcheck` was not available on the authoring host, so CI is the first real lint of these bash changes. `bash -n` passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)