### PR TITLE
fix: unbreak the git-helper guard, and correct two claims PR #245 got wrong

### DIFF
--- a/docs/IMPLEMENTATION.md
+++ b/docs/IMPLEMENTATION.md
@@ -2669,7 +2669,7 @@ a container.
 |------|-------------|
 | `stop <run-id> [--runtime local\|fly\|ec2]` | Pause a run — a remote Fly machine, an EC2 instance (`stop-instances`, preserving the root EBS volume), or a local container. Resumable via `resume` (EC2 `resume` calls `resume_instance()` and re-resolves the reassigned public IP). |
 | `kill <run-id> [--force]` | Destroy a remote machine permanently. `--force` skips confirmation. Also accepts `--machine-id <id> [--app <app>]` for orphan cleanup. |
-| `finalize <run-id> [--force] [--no-verify] [--no-push] [--runtime fly]` | Post-detach finalization: collect un-integrated subtask branches on the machine, fetch the run branch, then push + open PR on the host. Without `--force`, requires the orchestrator to be dead. `--force` SIGTERMs a live orchestrator first, then collects and fetches. |
+| `finalize <run-id> [--force] [--no-verify] [--no-push] [--runtime local\|fly\|ec2]` | Finalization fast-path: get the run branch onto the host, then push + open PR. What "get it onto the host" means is runtime-dependent. **Fly/EC2:** collect un-integrated subtask branches on the machine and fetch the run branch; without `--force`, requires the orchestrator to be dead, and `--force` SIGTERMs a live one first (Fly only — the EC2 arm refuses it, since the force path is flyctl-transport). **Local:** there is nothing to fetch (the state root is bind-mounted and the branch is already in the user's repo), so it skips straight to `host_finalize`; `--force` is refused, because it exists to stop a *detached* orchestrator and a local run's exits with its container. Runtime is auto-detected from the run dir: `fly-machine.json` → fly, `ec2-instance.json` → ec2, **neither → local**. That last case is why a Fly/EC2 run whose sidecar has been deleted now reports "has no run branch in `$USER_REPO`" instead of reaching flyctl — pass `--runtime fly` explicitly to override. |
 | `re-seed <run-id> [--force]` | Mid-run host→machine re-rsync of dirty delta. `--force` bypasses the safety check that refuses to clobber machine-side uncommitted edits. |
 | `status <run-id\|chain-id\|group-id>` | Render run/chain/group state from `run.json`. |
 | `attach <run-id\|chain-id>` | Poll `run.json` files every 5s. |
@@ -7060,6 +7060,17 @@ address this together:
    `fetch_branch`, then the host-side finalize block (push + `gh pr
    create`). Idempotent — an already-pushed run short-circuits with
    "already finalized."
+
+   The `fetch_branch` half is **remote-only**. This section describes the
+   detached-orchestrator problem the verb was built for, but the verb also
+   serves local runs, where there is no machine to fetch from: the state root
+   is bind-mounted and the run branch is already in the user's repo, so the
+   local arm sets the fetched-run-dir to the run dir it already has and goes
+   straight to the host-side finalize block. A local run normally finalizes
+   inline at the end of `leerie "task"`; the verb matters when that inline
+   block never ran — a Ctrl-C after the waves integrated leaves no
+   `finished_at`, which is exactly the case the already-synced short-circuit
+   cannot detect.
 
 `leerie finalize` resolves `<run-id>` directly against
 `$LEERIE_STATE_HOST_DIR/runs/<run-id>/` (the run-id IS the machine id, DESIGN

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -2152,8 +2152,18 @@ closed on the branch rather than deeper in `host_finalize`, a Fly sidecar
 still promoting to `fly` (the local default must not swallow a real Fly
 run), and the advertised usage enum reading `local|fly|ec2` — asserted
 through a real rejection, so it checks what a user is shown rather than a
-source substring. These fixtures point `USER_REPO` at a scratch git repo,
-which the finalize arm honors via `USER_REPO="${USER_REPO:-$PWD}"`. Note the
+source substring. These fixtures point the launcher at a scratch git repo via
+its **working directory**, which is the only lever that works: `leerie:39`
+assigns `USER_REPO="$(pwd -P)"` unconditionally, so the
+`USER_REPO="${USER_REPO:-$PWD}"` at the top of the finalize arm can never fire
+and exporting `USER_REPO` has no effect. `tests/ec2_stub.py`'s shared
+`run_launcher` grew a `cwd` parameter for this (the idiom
+`test_launcher_finalize_no_work.py` already used). Getting it wrong fails
+silently rather than loudly — every `git -C "$USER_REPO"` would run against
+the leerie checkout pytest was started from, where the fixture's run branch
+does not exist, so the branch-dependent assertions would pass for the wrong
+reason. `test_finalize_local_branch_gate_is_scoped_to_the_launcher_cwd` pins
+the plumbing with two sources that disagree. Note the
 local-shaped fixtures in `tests/test_launcher_finalize_no_work.py` cannot
 catch this regression: all of them exit early through `_already_synced` /
 `pushed_at` / argv validation and never reach the runtime dispatch.

--- a/tests/ec2_stub.py
+++ b/tests/ec2_stub.py
@@ -76,6 +76,7 @@ def run_launcher(
     launcher: Path = DEFAULT_LAUNCHER,
     timeout: int = 30,
     use_bash: bool = False,
+    cwd: Path | None = None,
 ) -> subprocess.CompletedProcess:
     """Invoke the `leerie` launcher as a subprocess and return the result.
 
@@ -88,11 +89,18 @@ def run_launcher(
     be confused with tests/test_group_state_dir_guard.py's own
     `_run_launcher`, which has a materially different signature and
     purpose (stub-binary injection) and is left untouched.
+
+    `cwd` is load-bearing for any test that needs the launcher to act on a
+    scratch repo: `leerie:39` assigns `USER_REPO="$(pwd -P)"` unconditionally,
+    so setting `USER_REPO` in `env` has NO effect — the launcher overwrites it
+    before any verb runs. The working directory is the only lever. This is the
+    same idiom `tests/test_launcher_finalize_no_work.py` already uses.
     """
     argv = (["bash", str(launcher)] if use_bash else [str(launcher)]) + args
     return subprocess.run(
         argv,
         env=env,
+        cwd=None if cwd is None else str(cwd),
         capture_output=True,
         text=True,
         timeout=timeout,

--- a/tests/test_auto_detect_run_runtime.py
+++ b/tests/test_auto_detect_run_runtime.py
@@ -35,7 +35,7 @@ from pathlib import Path
 
 import pytest
 
-from tests.conftest import HAS_JQ
+from tests.conftest import HAS_JQ, run_git_repo_first as _git
 from tests.ec2_stub import run_launcher as _run_launcher_shared
 
 REPO_ROOT_LAUNCHER = Path(__file__).resolve().parent.parent / "leerie"
@@ -441,22 +441,22 @@ def test_resume_fly_sidecar_still_promotes_to_fly_no_regression(tmp_path):
 # which requires `finished_at`; a run interrupted before `phase_finalize`
 # (Ctrl-C after the waves integrated) has none, so it hit flyctl.
 #
-# These drive the real launcher end to end. `USER_REPO` is honored by the
-# finalize arm (`USER_REPO="${USER_REPO:-$PWD}"`), which is what lets the
-# fixtures point it at a scratch repo instead of this one.
-
-
-def _git(repo: Path, *args: str) -> None:
-    subprocess.run(
-        ["git", "-C", str(repo), *args],
-        check=True, capture_output=True, text=True,
-    )
+# These drive the real launcher end to end against a scratch repo, and the
+# ONLY way to point it there is the child's working directory: `leerie:39`
+# assigns `USER_REPO="$(pwd -P)"` unconditionally, so the
+# `USER_REPO="${USER_REPO:-$PWD}"` at the top of the finalize arm can never
+# fire and exporting `USER_REPO` in the environment does nothing. Getting this
+# wrong is silent rather than loud — the launcher happily runs every
+# `git -C "$USER_REPO"` against the leerie checkout pytest was started from,
+# where the fixture's run branch does not exist, so the branch-dependent
+# assertions pass for the wrong reason.
 
 
 def _make_local_run(state_dir: Path, tmp_path: Path, run_id: str, *,
                     create_branch: bool = True,
                     finished: bool = False,
-                    no_push: bool = False) -> tuple[Path, Path]:
+                    no_push: bool = False,
+                    working_branch: str = "main") -> tuple[Path, Path]:
     """A local run dir (no Fly/EC2 sidecar) plus a scratch USER_REPO.
 
     Deliberately writes NO `finished_at` unless asked: that is the exact
@@ -465,12 +465,16 @@ def _make_local_run(state_dir: Path, tmp_path: Path, run_id: str, *,
     """
     repo = tmp_path / "user_repo"
     repo.mkdir(parents=True, exist_ok=True)
-    _git(repo, "init", "-q", "-b", "main")
-    _git(repo, "config", "user.email", "t@example.com")
-    _git(repo, "config", "user.name", "t")
-    (repo / "f.txt").write_text("base\n")
-    _git(repo, "add", "f.txt")
-    _git(repo, "commit", "-q", "-m", "base")
+    # Idempotent: a test may build two runs against ONE scratch repo (that is
+    # how the cwd-scoping guard makes its two sources disagree), and a second
+    # `git commit` with an unchanged tree exits non-zero.
+    if not (repo / ".git").is_dir():
+        _git(repo, "init", "-q", "-b", "main")
+        _git(repo, "config", "user.email", "t@example.com")
+        _git(repo, "config", "user.name", "t")
+        (repo / "f.txt").write_text("base\n")
+        _git(repo, "add", "f.txt")
+        _git(repo, "commit", "-q", "-m", "base")
 
     branch = f"leerie/runs/{run_id}"
     if create_branch:
@@ -484,8 +488,8 @@ def _make_local_run(state_dir: Path, tmp_path: Path, run_id: str, *,
     run_json = {
         "run_id": run_id,
         "branch": branch,
-        "working_branch": "main",
-        "pr_base_branch": "main",
+        "working_branch": working_branch,
+        "pr_base_branch": working_branch,
     }
     if finished:
         run_json["finished_at"] = "2026-08-24T22:00:00+00:00"
@@ -499,10 +503,14 @@ def _make_local_run(state_dir: Path, tmp_path: Path, run_id: str, *,
 
 
 def _finalize(args, state_dir: Path, repo: Path):
-    env = _launcher_env(state_dir)
-    env["USER_REPO"] = str(repo)
+    # cwd, not env: see the note above — `USER_REPO` in the environment is
+    # overwritten by `leerie:39` before any verb runs.
+    return _launcher_in(args, _launcher_env(state_dir), repo)
+
+
+def _launcher_in(args, env, repo: Path):
     return _run_launcher_shared(
-        args, env, launcher=REPO_ROOT_LAUNCHER, timeout=60
+        args, env, launcher=REPO_ROOT_LAUNCHER, timeout=60, cwd=repo
     )
 
 
@@ -511,10 +519,15 @@ def test_finalize_local_run_without_finished_at_reaches_host_finalize(tmp_path):
     """THE reported bug: a local run interrupted before `finished_at` was
     written must finalize locally, never ask for flyctl.
 
-    `no_push` is set so `host_finalize` short-circuits at its own early gate
-    (host-finalize.sh:294) — that return is *inside* host_finalize, so
-    observing it proves the launcher handed off, without this test needing a
-    git remote or a rebaser worker.
+    `no_push` is set in run.json AND `--no-push` is passed, so `host_finalize`
+    short-circuits at its own early gate (host-finalize.sh:294) — a return from
+    *inside* host_finalize, which proves the launcher handed off, without this
+    test needing a git remote or a rebaser worker.
+
+    The CLI flag is load-bearing, not belt-and-braces: without it the launcher
+    reaches its mechanism-vs-intent block and STRIPS `no_push` from run.json
+    whenever the run branch exists locally, so the gate would never fire and
+    this test would run on into the rebase and push.
 
     Note the existing local-shaped fixtures in
     tests/test_launcher_finalize_no_work.py cannot catch this regression:
@@ -525,7 +538,7 @@ def test_finalize_local_run_without_finished_at_reaches_host_finalize(tmp_path):
     run_dir, repo = _make_local_run(state_dir, tmp_path, "r1", no_push=True)
     assert "finished_at" not in json.loads((run_dir / "run.json").read_text())
 
-    r = _finalize(["finalize", "r1"], state_dir, repo)
+    r = _finalize(["finalize", "r1", "--no-push"], state_dir, repo)
 
     combined = r.stdout + r.stderr
     assert "flyctl" not in combined.lower(), combined
@@ -540,7 +553,8 @@ def test_finalize_local_accepts_explicit_runtime_local(tmp_path):
     equivalent yet"). It is now a supported selector for the same arm."""
     state_dir = tmp_path / "state"
     _, repo = _make_local_run(state_dir, tmp_path, "r1", no_push=True)
-    r = _finalize(["finalize", "r1", "--runtime", "local"], state_dir, repo)
+    r = _finalize(["finalize", "r1", "--runtime", "local", "--no-push"],
+                  state_dir, repo)
     assert "no local-runtime equivalent" not in r.stderr, r.stderr
     assert "flyctl" not in (r.stdout + r.stderr).lower()
     assert r.returncode == 0, r.stdout + r.stderr
@@ -571,6 +585,57 @@ def test_finalize_local_fails_closed_when_run_branch_absent(tmp_path):
     assert "flyctl" not in (r.stdout + r.stderr).lower()
 
 
+def test_finalize_local_passes_the_branch_gate_when_the_branch_exists(tmp_path):
+    """The positive twin of the fail-closed case above: with the run branch
+    present the gate must PASS, not refuse unconditionally.
+
+    Without this, `test_..._fails_closed_when_run_branch_absent` alone cannot
+    tell a real check from a blanket refusal — the fixture's `create_branch`
+    parameter would be inert.
+
+    `working_branch`/`pr_base_branch` name a branch that does not exist, which
+    makes `host_finalize`'s rebase base unresolvable so it skips the rebase
+    block (scripts/host-finalize.sh:457-461) rather than spawning the real
+    `rebaser` worker. The push then fails for want of an `origin`, which is
+    fine — everything this test asserts happens before it.
+    """
+    state_dir = tmp_path / "state"
+    _, repo = _make_local_run(state_dir, tmp_path, "r1",
+                              create_branch=True,
+                              working_branch="no-such-base")
+
+    r = _finalize(["finalize", "r1"], state_dir, repo)
+
+    combined = r.stdout + r.stderr
+    assert "state and branch already on this host" in r.stderr, r.stderr
+    assert "has no run branch" not in r.stderr, r.stderr
+    assert "flyctl" not in combined.lower(), combined
+
+
+def test_finalize_local_branch_gate_is_scoped_to_the_launcher_cwd(tmp_path):
+    """`USER_REPO` comes from the launcher's working directory, never the
+    environment (`leerie:39` overwrites it), so the branch gate must read the
+    scratch repo.
+
+    Guards the plumbing itself: if `_finalize` regressed to exporting
+    `USER_REPO`, the gate would consult whatever repo pytest was started from
+    and this would flip. Two sources that disagree — a repo WITH the branch,
+    and a run id whose branch exists nowhere — so a bypass cannot pass.
+    """
+    state_dir = tmp_path / "state"
+    _, repo = _make_local_run(state_dir, tmp_path, "r1", create_branch=True,
+                              working_branch="no-such-base")
+    # Same scratch repo, a second run whose branch was never created.
+    _make_local_run(state_dir, tmp_path, "r2", create_branch=False,
+                    working_branch="no-such-base")
+
+    present = _finalize(["finalize", "r1"], state_dir, repo)
+    absent = _finalize(["finalize", "r2"], state_dir, repo)
+
+    assert "has no run branch" not in present.stderr, present.stderr
+    assert "has no run branch" in absent.stderr, absent.stderr
+
+
 def test_finalize_fly_sidecar_still_promotes_to_fly_no_regression(tmp_path):
     """The local default must not swallow a genuine Fly run."""
     state_dir = tmp_path / "state"
@@ -591,6 +656,16 @@ def test_finalize_usage_strings_offer_local(tmp_path):
     asserts what a user is actually shown, not a source substring."""
     state_dir = tmp_path / "state"
     _, repo = _make_local_run(state_dir, tmp_path, "r1")
-    r = _finalize(["finalize", "r1", "--foorce"], state_dir, repo)
-    assert r.returncode != 0
-    assert "--runtime local|fly|ec2" in r.stderr, r.stderr
+
+    # Each rejection path prints its own copy of the string; the change
+    # touched four, so assert on more than one of them.
+    unknown_flag = _finalize(["finalize", "r1", "--foorce"], state_dir, repo)
+    dangling = _finalize(["finalize", "r1", "--runtime"], state_dir, repo)
+    extra_pos = _finalize(["finalize", "r1", "r2"], state_dir, repo)
+
+    for label, r in (("unknown flag", unknown_flag),
+                     ("dangling --runtime", dangling),
+                     ("extra positional", extra_pos)):
+        assert r.returncode != 0, f"{label}: expected non-zero"
+        assert "--runtime local|fly|ec2" in r.stderr, f"{label}: {r.stderr}"
+        assert "--runtime fly|ec2]" not in r.stderr, f"{label}: {r.stderr}"

--- a/tests/test_no_duplicate_ec2_run_launcher_helper.py
+++ b/tests/test_no_duplicate_ec2_run_launcher_helper.py
@@ -116,12 +116,22 @@ def test_run_launcher_matches_the_common_call_shape():
 
     sig = inspect.signature(ec2_stub.run_launcher)
     params = sig.parameters
-    assert list(params) == ["args", "env", "launcher", "timeout", "use_bash"]
-    assert params["launcher"].kind == inspect.Parameter.KEYWORD_ONLY
-    assert params["timeout"].kind == inspect.Parameter.KEYWORD_ONLY
-    assert params["use_bash"].kind == inspect.Parameter.KEYWORD_ONLY
+    # `cwd` joined the shape deliberately: `leerie:39` assigns
+    # `USER_REPO="$(pwd -P)"` unconditionally, so a test that needs the
+    # launcher to act on a scratch repo can only say so through the child's
+    # working directory — setting `USER_REPO` in `env` is silently ignored.
+    # It defaults to None so every existing caller is unaffected.
+    #
+    # NOTE: tests/test_no_duplicate_launcher_invoke_helper.py asserts this
+    # same shape. Both must move together; a change to one that misses the
+    # other lands red.
+    assert list(params) == [
+        "args", "env", "launcher", "timeout", "use_bash", "cwd"]
+    for name in ("launcher", "timeout", "use_bash", "cwd"):
+        assert params[name].kind == inspect.Parameter.KEYWORD_ONLY
     assert params["timeout"].default == 30
     assert params["use_bash"].default is False
+    assert params["cwd"].default is None
 
 
 def test_no_local_run_launcher_reimplementations_outside_the_allowlist():

--- a/tests/test_no_duplicate_launcher_invoke_helper.py
+++ b/tests/test_no_duplicate_launcher_invoke_helper.py
@@ -148,12 +148,22 @@ def test_run_launcher_matches_the_common_call_shape():
 
     sig = inspect.signature(ec2_stub.run_launcher)
     params = sig.parameters
-    assert list(params) == ["args", "env", "launcher", "timeout", "use_bash"]
-    assert params["launcher"].kind == inspect.Parameter.KEYWORD_ONLY
-    assert params["timeout"].kind == inspect.Parameter.KEYWORD_ONLY
-    assert params["use_bash"].kind == inspect.Parameter.KEYWORD_ONLY
+    # `cwd` joined the shape deliberately: `leerie:39` assigns
+    # `USER_REPO="$(pwd -P)"` unconditionally, so a test that needs the
+    # launcher to act on a scratch repo can only say so through the child's
+    # working directory — setting `USER_REPO` in `env` is silently ignored.
+    # It defaults to None so every existing caller is unaffected.
+    #
+    # NOTE: tests/test_no_duplicate_ec2_run_launcher_helper.py asserts this
+    # same shape. Both must move together; a change to one that misses the
+    # other lands red.
+    assert list(params) == [
+        "args", "env", "launcher", "timeout", "use_bash", "cwd"]
+    for name in ("launcher", "timeout", "use_bash", "cwd"):
+        assert params[name].kind == inspect.Parameter.KEYWORD_ONLY
     assert params["timeout"].default == 30
     assert params["use_bash"].default is False
+    assert params["cwd"].default is None
 
 
 def test_no_local_invoke_helper_reimplementations_outside_the_allowlist():


### PR DESCRIPTION
PR #245 (`4a34ce9e`) shipped a **red test** to `main` plus two false claims. The launcher change itself was correct — this fixes what shipped around it.

## 1. `main` is red

#245 added a local `def _git(repo, *args)` to `tests/test_auto_detect_run_runtime.py`. `tests/test_no_duplicate_git_test_helpers.py` scans every `tests/test_*.py` for `^\s*def _git\(` and asserts the hit set is empty. Two assertions went red:

```
FAILED test_no_new_local_git_runner_definitions
FAILED test_offender_lists_can_shrink_when_migration_lands
```

The helper was also a byte-for-byte reimplementation of the single owner it was consolidated into. Now imports `run_git_repo_first` from `tests/conftest.py`.

**Why CI missed it:** #245 was merged while all three `test` matrix jobs were still pending, and the targeted files run before merge were chosen by topic rather than by what the diff could break. A `def _git(` in `tests/` is guarded globally, so topic-selection could never have found it.

## 2. `USER_REPO` in the environment does nothing

#245's fixtures set `env["USER_REPO"]`, and both its docstring and `docs/TESTING.md` claimed the finalize arm honors `USER_REPO="${USER_REPO:-$PWD}"`. It cannot: `leerie:39` assigns `USER_REPO="$(pwd -P)"` unconditionally, long before verb dispatch, so that `:-` default is dead code.

Every `git -C "$USER_REPO"` ran against the leerie checkout pytest started from, where the fixture's run branch does not exist — the branch-dependent assertions passed for the wrong reason and the fixture's branch creation was inert.

`tests/ec2_stub.py`'s shared `run_launcher` grew a keyword-only `cwd=None` (the idiom `test_launcher_finalize_no_work.py` already used). `test_no_duplicate_launcher_invoke_helper.py` pins that signature, so its assertion is updated deliberately rather than worked around.

## 3. The `no_push` short-circuit was accidental

With the plumbing fixed, the two "reaches host_finalize" tests would have broken: the launcher strips `no_push` from `run.json` whenever the run branch exists locally, so the gate they assert on would never fire and they'd run into a real `rebaser` worker. They now pass `--no-push`, which skips the strip.

Two tests added (file now 31): a positive twin proving the branch gate **passes** when the branch exists (without it `create_branch` was inert and nothing distinguished a real check from a blanket refusal), and a guard pinning that the gate reads the launcher's cwd — two sources that disagree, so a regression to env-passing cannot pass it.

**Discrimination is now measured, not argued:** against `8fe6e9f7`'s pre-fix launcher, 7 of these tests fail and the 3 that pass are exactly the Fly/EC2 regression pins that should pass either way.

## 4. Docs completeness

#245 updated narrative prose but not the canonical surface. `IMPLEMENTATION.md` §2½ — which CLAUDE.md names the single source of truth for every CLI flag — still read `[--runtime fly]`. It now documents both paths, `--force`'s per-runtime refusal, and the behaviour change: a Fly/EC2 run whose sidecar was deleted resolves to local and reports "has no run branch" rather than reaching flyctl, with `--runtime fly` as the override.

## Superseding a false claim in `4a34ce9e`

Its message ended: *"shellcheck was not available on the authoring host, so CI is the first real lint of these bash changes."* Wrong, and squash-merge put it on `main` verbatim. **Nothing lints the root launcher:** `shellcheck.yml` is path-filtered to `scripts/**/*.sh` (it never triggered for #245) and lints only `scripts/*.sh scripts/remote/*.sh`; `syntax.yml` is `ast.parse` over Python; `test_launcher_integrity.py:11` says *"No test runs shellcheck."*

What that bash was actually validated by: `bash -n`; the behavioural tests; no heredoc added (the backtick class bites heredoc bodies); and no bash 4+ constructs — which matters because `test_ec2_bash32_portability.py:317` does parametrize `finalize` but skips unless the host has a real bash 3.2, so it skips in CI too.

Verified: the 7 files this touches or could break collect **80 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)