### PR TITLE
fix: gate the sub-file split on change_shape, not file size

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -1024,6 +1024,78 @@ split mechanism therefore separates by structural type:
     contiguous line-windows via the same tiling. This tier needs no range data and
     is also the whole-file fallback when tree-sitter yields no ranges.
 
+  **Gating condition — the split is for edit-*dense* work, not merely large
+  files.** The trigger is the parent's own declared `change_shape`, not the
+  file's line count. A `point` or `localized` change is left a leaf however
+  large its file is; only a `sweep` is tiled. Tiling a point fix is not merely
+  wasteful, it is actively harmful, and the failure is structural rather than
+  incidental: every region child inherits the parent's success criteria, so a
+  tiled point fix produces N children each holding a whole-file mandate that
+  exactly one of them can satisfy in scope. The other N-1 do not idle — they
+  pursue the mandate anyway, out of region. Measured on run `719c2a26`, where a
+  one-expression fix in a 9,140-line file was tiled into 14 regions: 11 of 12
+  region children touched a file outside their region, 7 of 12 edited lines
+  outside their range, and exactly one complied. Four children owning regions
+  thousands of lines apart all converged on the same ~70-line span — the actual
+  bug site. The line ranges partitioned nothing.
+
+  `change_shape` is a planner-declared JSON field, never inferred from prose
+  (§*Language-to-JSON*). The count of edit sites a change needs is a fact only
+  the planner holds; code cannot derive it from the file, and reading it out of
+  `investigation_notes` would be exactly the regex-over-prose this design
+  forbids.
+
+  **Region ownership constrains paths, not only lines.** A region child owns a
+  line range *and* owns no other path: the parent's criteria may demand a new
+  file, and "do not edit outside lines X-Y" does not constrain creating one. In
+  `719c2a26` three near-synonymous new test files were invented for one
+  inherited criterion, and two children independently chose the *same* new path
+  — an add/add conflict on a path absent from the merge base, which has no
+  resolution that keeps both sides (`-X ours`/`-X theirs` each silently discard
+  one). So exactly one region child is designated the new-file owner and the
+  rest are told, by id, which sibling to leave it to. One owner is what makes
+  the collision impossible; *which* one is arbitrary.
+
+  The invariant is **one owner per decomposition tree, not per split**, and that
+  distinction is where the obvious implementation goes wrong. A child's criteria
+  are built by appending to its parent's, so a child that is itself re-split
+  inherits a clause and would receive a second, contradictory one. Designation is
+  therefore inherited rather than recomputed: a non-owner's entire subtree stays
+  ownerless and keeps naming the original owner, and only an owner passes
+  ownership down — to one child. It is read from a structural field, never by
+  re-reading the criteria prose, and the clause is *replaced* rather than
+  stacked (unlike the neighbouring `Scope:` clauses, which stack harmlessly
+  because each narrows the last; these would each negate the last). Measured:
+  `719c2a26` re-entered three times — `r8`, `r12`, `r14` each produced `-r1`/
+  `-r2` children — so recomputing per split yields four claimed owners on that
+  run's own data, which is the multi-owner condition the rule exists to prevent.
+
+  **The same rule covers the file-level splits, without the same backstop.**
+  Region children are not the only children that inherit the parent's criteria
+  verbatim: the oversized-file peel and the migration-chunk labels do too, so a
+  parent criterion demanding a not-yet-existing file reaches every one of them
+  at once. Measured on `719c2a26`, the peel child `bugfix-001-f2` carries the
+  same criteria hash as all 12 region children — the identical collision shape
+  at 2-way instead of 14-way. One designated owner therefore applies to those
+  children as well (the dense-file child on the peel, chunk 0 on a migration
+  sweep), applied where the child is built so it also reaches the criteria the
+  label-only splitter writes for itself. Note what does *not* carry over: those
+  children have no `owned_region`, so the mechanical check below cannot see
+  them and the criteria clause is the whole mechanism there.
+
+  Both constraints are **enforced in code, not asked for in a prompt** (§12).
+  `owned_region` was prompt-only through `719c2a26` — rendered into the
+  implementer's context and never checked against what it committed — which is
+  why compliance was 1 in 12. The check now runs mechanically on the
+  implementer's actual diff. It is deliberately **corrective, not fatal**: a
+  violation feeds the offending paths back to the implementer and re-drives it
+  within the existing bounded retry budget, then degrades to advisory. Making it
+  fatal was considered and rejected on measurement — replayed against
+  `719c2a26` a fatal rule kills 11 of 12 subtasks, converting a coverage gap
+  into a total run kill, and the violations there were the children *obeying* an
+  inherited criterion they could not satisfy in region. Fix the criteria first;
+  enforcement is the backstop, not the remedy.
+
   Each child owns a region of the same file, so N children co-own it. This is
   already legitimate downstream: `_schedule()` derives waves only from
   `depends_on`/`requires` (never `files_likely_touched`), so co-owners run the
@@ -1031,7 +1103,9 @@ split mechanism therefore separates by structural type:
   artifact with incompatible APIs* and explicitly excludes "multiple primitive
   extractions in the same parent file"; and integration is a plain `git merge`
   whose 3-way merge clean-merges non-overlapping regions, escalating to the
-  integrator worker only on a true textual conflict. `check_planner_output`'s
+  integrator worker only on a true textual conflict. That merge argument is scoped to the *split file* and says nothing
+  about paths outside it, which is why path ownership above is a separate
+  constraint rather than a corollary. `check_planner_output`'s
   advisory `INTRA_DOMAIN_OVERLAP` warning is suppressed for children tagged with
   a co-ownership cluster marker, since the overlap is intentional — an
   accidental same-file overlap between unrelated subtasks still warns.

--- a/docs/IMPLEMENTATION.md
+++ b/docs/IMPLEMENTATION.md
@@ -4222,7 +4222,7 @@ orthogonal and still applies to all callers regardless of
 | `_confidence_axes_clear(conf, axes, threshold)` | Pure predicate: True when every named axis is a number ≥ threshold. Used by the loop and `_settle_subtask`'s implementer confidence check. |
 | `_format_check_feedback(issues, rnd, max_rounds)` | Formats issues into the structured feedback block injected on re-invocation. |
 | `_confidence_schema(axes)` | DRY helper building the §8 confidence sub-schema. Used by 10 worker schemas (`classifier`, `planner`, `reconciler`, `implementer`, `integrator`, `rebaser`, `conformer`, `provision`, `plan_overlap_judge`, `fit_judge` — not `splitter`, whose output carries no confidence axis). Shape: `required: [*axes, "basis"]`; `falsifiers_tested`/`contradictions_reconciled` optional; no `gap_to_close` field, no `maxLength` caps (both removed as a decoder-corruption mitigation, `anthropics/claude-code#49747`; DESIGN §8). `confidence` is **not** in any of these schemas' top-level `required` — a worker omitting it still validates. Pinned by `tests/test_confidence_not_required.py`; `tests/test_confidence_length_caps.py` covers callers that do emit it. |
-| `_subtask_item_schema(*, include_requires, include_migration_targets, include_runs_commands, include_fixes_reported_symptom)` | DRY helper (same pattern as `_confidence_schema`) building the child-subtask item schema shared by `SCHEMAS["planner"]["subtasks"]`, `SCHEMAS["reconciler"]["added_subtasks"]`, `SCHEMAS["splitter"]["children"]` — previously three independently-written literals. Each call site passes its own `include_*` set (`reconciler.added_subtasks` narrowest — no `requires`/`migration_targets`/`runs_commands`/`fixes_reported_symptom`; `splitter.children` — `requires` only; `planner.subtasks` — all four) rather than converging on one shape, so a future field change is explicit about which sites it reaches. Pinned by `tests/test_shared_subtask_item_schema.py`, including an anti-vacuity check that narrower sites reject the wider ones' fields. |
+| `_subtask_item_schema(*, include_requires, include_migration_targets, include_runs_commands, include_fixes_reported_symptom, include_change_shape)` | DRY helper (same pattern as `_confidence_schema`) building the child-subtask item schema shared by `SCHEMAS["planner"]["subtasks"]`, `SCHEMAS["reconciler"]["added_subtasks"]`, `SCHEMAS["splitter"]["children"]` — previously three independently-written literals. Each call site passes its own `include_*` set (`reconciler.added_subtasks` narrowest — no `requires`/`migration_targets`/`runs_commands`/`fixes_reported_symptom`; `splitter.children` — `requires` only; `planner.subtasks` — all five, `change_shape` among them) rather than converging on one shape, so a future field change is explicit about which sites it reaches. Pinned by `tests/test_shared_subtask_item_schema.py`, including an anti-vacuity check that narrower sites reject the wider ones' fields. |
 
 ### Finding severity — gating vs advisory
 
@@ -4271,7 +4271,7 @@ is resolved from the issue code per the table above, not the function.
 | Overlap judge | `check_overlap_judge_output(output, plans, repo_root)` | `PHANTOM_ARTIFACT`, `NO_FILE_OVERLAP`, `DROP_BREAKS_GRAPH`, `DUPLICATE_PAIR` | `judgment_check_rounds` (3) |
 | Adherence gate | `check_prescribed_command_coverage(prescribed_procedure, subtasks)` (deterministic floor) + inline `LOW_ADHERENCE` check on the `adherence_judge` result | `PRESCRIBED_CMD_UNRUN`, `LOW_ADHERENCE` | `judgment_check_rounds` (3) |
 | Provision | `check_provision_output(result, repo_root)` | `WRONG_PM`, `MISSING_WORKDIR`, `EMPTY_RECIPE` | `judgment_check_rounds` (3) |
-| Implementer | `check_implementer_output(result, subtask, actual_files)` | `NO_PLANNED_FILES_TOUCHED` (advisory — excluded from retry by `_gating_issues`), `UNMET_CRITERION`, plus `check_production_evidence`'s four (below) | `implementer_confidence_retries` (2) |
+| Implementer | `check_implementer_output(result, subtask, actual_files)` | `NO_PLANNED_FILES_TOUCHED` (advisory — excluded from retry by `_gating_issues`), `UNMET_CRITERION`, `OWNED_REGION_FILE_ESCAPE` (gating; sub-file region children only), plus `check_production_evidence`'s four (below) | `implementer_confidence_retries` (2) |
 | Integrator | `check_integrator_output(result)` | — | `judgment_check_rounds` (3) |
 | Conformer | (`_conformance_clean` on observable signals) | — | `conformance_rounds` (3) |
 
@@ -4433,6 +4433,18 @@ is code-enforced*)
 Fully shipped. `SCHEMAS["classifier"]` carries `prescribed_procedure`
 (`{is_prescribed, commands, forbid_manual, evidence}`, persisted to
 `st.data["prescribed_procedure"]` — see §3 "Worker output schemas"),
+`SCHEMAS["planner"]` carries the **required** per-subtask `change_shape`
+(`point` | `localized` | `sweep`) — the planner's declaration of how many edit
+sites its change needs. Required, not optional, for the same reason
+`migration_targets.is_real_identifier` is: a planner must not be able to skip an
+attestation a gate depends on by omitting the field. `_subfile_split()` reads it
+and refuses to tile anything but a `sweep` (DESIGN §5½ (P1) *Sub-file*
+*Gating condition*). It cannot be derived in code — the number of sites a change
+needs is not a property of the file — and it must never be read out of
+`investigation_notes`, which is planner prose (DESIGN §*Language-to-JSON*).
+Absent on `reconciler.added_subtasks` and `splitter.children`, where absence
+means "not declared" and the gate falls through to the pre-gate behaviour.
+
 `SCHEMAS["planner"]` carries the optional per-subtask `runs_commands`
 array, the `adherence_judge` worker is fully registered (schema, prompt,
 `WORKER_TYPES`, sonnet/`"medium"` model-effort defaults — see "The
@@ -4721,7 +4733,8 @@ accept the subtask as leaf); then splits via one of:
   falls back to a distinct deterministic label (`_deterministic_chunk_label()`).
 - **Coupled path** (≤ 8 files): `splitter` LLM worker — structural seam detection.
 - **Sub-file path** (exactly 1 file, low fit, file/region span >
-  `subfile_split_max_span`): checked **before** the file-count fork, since a
+  `subfile_split_max_span`, **and `change_shape == "sweep"`**): checked
+  **before** the file-count fork, since a
   single dense file falls into the coupled path today where the LLM splitter
   cannot break one file. Splits the file *intra*-file in two tiers (both
   deterministic): tier 1 tiles `[1, EOF]` on tree-sitter function-boundary
@@ -4733,7 +4746,62 @@ accept the subtask as leaf); then splits via one of:
   listing the same single file plus an `owned_region` field, a
   `_cofile_cluster` marker, and a **region-scoped `intent`** — mechanically
   derived from the parent's intent plus the region's line range and symbols,
-  not a byte-identical copy. `_check_intra_file_surface()` is the
+  not a byte-identical copy.
+
+  **`change_shape` gate (first entry only).** `_subfile_split()` returns `[]`
+  without tiling when the subtask declares `change_shape` of `point` or
+  `localized`; only `sweep` (or an absent field — the reconciler/splitter
+  schemas do not carry it, and absence preserves the pre-gate behaviour) is
+  tiled. Read from the parent subtask, so `_migration_child()` carries
+  `change_shape` forward for the same reason it carries `migration_targets`:
+  the peel path builds a migration child that then re-enters `_subfile_split()`,
+  and dropping the field there would route straight past this gate. The
+  re-entry (tier-2) branch is deliberately **not** gated — a child carrying
+  `owned_region` is already inside an approved sweep.
+
+  **New-file ownership.** Region child index 0 is the designated new-file
+  owner. Its criteria carry an explicit grant; every other child's criteria
+  name that sibling's id and forbid creating new files. Deterministic, so the
+  designation is stable across a resume. Which child is arbitrary; that there
+  is exactly one is the point (DESIGN §5½ *Sub-file*).
+
+  The same rule applies to the two file-level split paths, via
+  `_migration_child()`'s `newfile_owner_id` keyword (default `None` = no
+  designation, criteria untouched): `_peel_oversized_file()` designates the
+  **dense-file child** (`<base>-f1`), and `_label_migration_chunks()`
+  designates **chunk 0** (`ids[0]`) on both its budget-exceeded and normal
+  returns. Applied inside `_migration_child()` rather than in the label
+  helpers so it also reaches the `success_criteria_seed` the label-only
+  splitter composes per chunk, which `_deterministic_chunk_label()` never
+  sees. These children carry no `owned_region`, so
+  `OWNED_REGION_FILE_ESCAPE` does **not** back them up — the criteria clause
+  is the entire mechanism on those paths.
+
+  **Re-entry.** The clause is emitted after `_NEWFILE_CLAUSE_MARKER` and
+  `_apply_newfile_clause()` truncates at the last marker before appending, so a
+  re-split child carries exactly one — splitting our own generated delimiter,
+  not prose (*Language-to-JSON* bars the latter). `_newfile_designation()`
+  resolves `(owner_id, parent_may_designate)` from the child's structural
+  `_newfile_owner` / `_newfile_owner_id` fields (set by both `_subfile_child()`
+  and `_migration_child()`, alongside `_cofile_cluster`): a subtask with
+  `_newfile_owner is False` yields its inherited `_newfile_owner_id` and
+  `False`, so none of its children can match the owner id and the whole subtree
+  stays ownerless; anything else designates its own first child. Invariant:
+  exactly one leaf in the decomposition tree owns new files, at any depth.
+
+  **`OWNED_REGION_FILE_ESCAPE` (mechanical, corrective).** `owned_region` is
+  enforced by `check_implementer_output()`, which already receives the
+  implementer's actual touched paths: a subtask carrying `owned_region` that
+  commits any path other than `owned_region["file"]` yields a **gating** issue,
+  routed through the existing `_format_check_feedback()` → `note` →
+  `continuation=True` retry, bounded by `implementer_confidence_retries`, and
+  degrading to advisory once that budget is spent. Gating rather than advisory
+  (unlike `NO_PLANNED_FILES_TOUCHED`, whose subject `files_likely_touched` is a
+  planner *guess*) precisely because `owned_region["file"]` is code-computed by
+  `_subfile_split()`, so there is no false-positive surface. Never routed
+  through `check_diff_scope()`'s fatal return: that string reaches
+  `fail("broken", ...)`, which `_retryable_failure()` treats as non-retryable,
+  and replaying `719c2a26` shows a fatal rule there kills 11 of 12 subtasks. `_check_intra_file_surface()` is the
   zero-tolerance coverage/overlap backstop (union == `[1, EOF]`,
   pairwise-disjoint). Same-file co-ownership is legitimate downstream
   (schedule ignores `files_likely_touched`; `git merge` reconciles);

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -607,8 +607,114 @@ ranking. No LLM calls; deterministic.
 
 ## P1 recursive decomposition
 
-The P1 recursive decomposition surface (DESIGN §5½ (P1)) is tested across
-four files.
+The P1 recursive decomposition surface (DESIGN §5½ (P1)) is tested across the
+files named below. (No count here on purpose: the previous one said "four"
+while the section already enumerated seven, and a bare number goes stale on
+every addition without anything failing.)
+
+### Sub-file split: the `change_shape` gate, new-file ownership, and `owned_region` enforcement
+
+`tests/test_subfile_split_change_shape_gate.py` pins the three defects behind
+run `719c2a26`, where a **one-expression** fix in a 9,140-line file was tiled
+into 14 region children.
+
+Replaying that run's actual subtask branches against the merge base is what
+turned the diagnosis from inference into measurement, and the numbers are the
+reason each pin exists: **11 of 12 region children touched a file outside their
+`owned_region`, 7 of 12 edited lines outside their range, and exactly one
+(`bugfix-001-f1-r7`) complied.** Four children owning regions thousands of lines
+apart all converged on the same ~70 lines — the actual bug site. Two children
+independently created the *same* new test file, an add/add conflict on a path
+absent from the merge base; verified in a throwaway repo that no strategy
+resolves it without discarding a side (`-X ours`/`-X theirs` each silently keep
+one). The integration judge caught it, post-merge, and killed the run.
+
+Three causes, three pins:
+
+1. **`_subfile_split` triggered on file *size* alone** (`subfile_split_max_span`,
+   700 — 9,140/700 → 14 regions) with no signal about how many sites the change
+   needed. Gated now on the planner-declared `change_shape`; only `sweep` tiles.
+   The gate is driven and its **return value** asserted, with an anti-vacuity
+   twin (same file, same cap, `sweep` → still tiles) so a `_subfile_split` that
+   returned `[]` unconditionally cannot pass. A third case pins that an *absent*
+   field preserves pre-gate behaviour — `reconciler.added_subtasks` and
+   `splitter.children` do not carry it, and defaulting those to "don't split"
+   would silently disable the mechanism for them.
+2. **`_subfile_child` cloned the parent's whole-file criteria verbatim** into
+   all 14 (measured: a single criteria hash, `8b372445`, across all 13 entries
+   carrying it in `plan_snapshot` — the 12 surviving region children plus
+   `bugfix-001-f2`), and that criterion
+   opened *"A new runtime e2e test … reproduces …"*. Exactly one child now owns
+   new files; the rest are told **which sibling's id** owns them. Asserted on the
+   clause's actual text and the owner's real id, not on presence.
+3. **`owned_region` was never checked** — written by `_subfile_split`, rendered
+   into the implementer prompt, read back only for re-splitting. Now
+   `OWNED_REGION_FILE_ESCAPE` in `check_implementer_output`, driven with r13's
+   real shape (one committed file, and not the one it owned).
+
+The **not-fatal** pin is load-bearing and is a retracted-on-measurement record:
+routing this through `check_diff_scope`'s return would reach
+`fail("broken", …)`, which `_retryable_failure` treats as non-retryable, and
+replayed against `719c2a26` that kills **11 of 12** subtasks — converting a
+coverage gap into a total run kill. Worse, those violations were children
+*obeying* an inherited criterion they could not satisfy in region. The test
+asserts the string is absent from `check_diff_scope`'s source and present in
+`check_implementer_output`'s, and re-asserts the premise (`"broken"` is still
+non-retryable) so the pin fails loudly rather than silently if that changes.
+
+`OWNED_REGION_FILE_ESCAPE` is **gating** where the neighbouring
+`NO_PLANNED_FILES_TOUCHED` is advisory, and the distinction is provenance, not
+shape: `files_likely_touched` is a planner *guess* (re-driving on it produced a
+measured pure-rename commit, POSTMORTEM-2026-08-14 F23), while
+`owned_region["file"]` is code-computed by `_subfile_split`. Two anti-vacuity
+pins keep it from firing where it shouldn't — `r7`'s compliant shape, and an
+ordinary subtask with no `owned_region` at all.
+
+The **peel and migration-chunk paths** carry the same one-owner rule and are
+pinned alongside, because gating the tiling alone would have narrowed the defect
+rather than fixed it: `bugfix-001-f2` is a *peel* child, not a region child, and
+carries the same criteria hash as all 12 region children — the identical
+collision at 2-way. Those children have no `owned_region`, so
+`OWNED_REGION_FILE_ESCAPE` cannot back them up and the criteria clause is the
+whole mechanism; one pin covers the peel pair, one covers N migration chunks,
+one pins that `newfile_owner_id=None` leaves criteria byte-identical, and one
+pins that the clause reaches **LLM-authored** chunk labels (the rule lives in
+`_migration_child`, not in `_deterministic_chunk_label`, precisely so the
+dominant Mode A path is not left uncovered). A fifth re-pins the pre-existing
+guarantee that deterministic chunk labels stay distinct per chunk — identical
+criteria across children is the shape this whole change exists to prevent.
+
+**Re-entry is pinned separately, and it is the gap that shipped a real bug.**
+The first version of this suite tested depth-1 splits only; because each helper
+appends its clause to the parent's criteria, a re-split non-owner received both
+its parent's "create no new files" and its own "you are the owner", and the
+one-owner invariant broke across the tree. Re-entry is not exotic — tier 2
+exists for it, and `719c2a26` re-entered three times (`r8`, `r12`, `r14`), so
+that run's own data would have produced four claimed owners. Pinned now: a
+re-split non-owner mints no owner and keeps naming the original; a re-split
+owner passes ownership to exactly one child (the anti-vacuity twin — "never
+designate on re-entry" would leave nothing owning new files); the peel of a
+non-owner chunk behaves the same; and a whole-tree walk asserts exactly one
+owner among the leaves with exactly one clause each. Five of these fail against
+the pre-fix behaviour, which is what makes them worth having.
+
+**Tier 1 is stubbed rather than left to the host.** `HAS_TREESITTER` is False on
+some dev machines but TRUE on CI (`requirements.txt` pins tree-sitter;
+`.github/workflows/test.yml` installs it), so a suite exercising only the tier-2
+line-window fallback locally would first meet tier-1 symbol tiling on CI — the
+green-locally/red-on-CI shape PR #211 already cost once. Two tests monkeypatch
+`_extract_symbol_ranges`, one with an over-cap symbol, which is the actual
+re-entry trigger (uniform line-windows can never produce one). The fixture is
+sized just over the cap rather than at the incident's 9,140 lines, so CI does
+not tree-sitter-parse a 9,000-line file five times for assertions that only
+need "more than one region".
+
+Two carry-forward traps are pinned separately: `_migration_child` must carry
+`change_shape` (the peel path builds a migration child that **re-enters**
+`_subfile_split`, so dropping it routes the dominant dense-file shape — a file
+bundled with its test file — straight past the gate), and the gate's
+`_NON_SWEEP_CHANGE_SHAPES` frozenset must equal the schema enum minus `sweep`,
+so a value added to one and not the other cannot silently become tileable.
 
 `tests/test_fit_judge_schema.py` covers `SCHEMAS["fit_judge"]` — required
 fields (`score`, `rationale`, `diffuse`, `confidence`), `score` bounds

--- a/orchestrator/leerie.py
+++ b/orchestrator/leerie.py
@@ -1752,6 +1752,7 @@ def _subtask_item_schema(
     include_migration_targets: bool = False,
     include_runs_commands: bool = False,
     include_fixes_reported_symptom: bool = False,
+    include_change_shape: bool = False,
 ) -> dict:
     """Build the child-subtask item schema shared by planner.subtasks,
     reconciler.added_subtasks, and splitter.children.
@@ -1840,9 +1841,31 @@ def _subtask_item_schema(
         # absence means "no" — the check is advisory, so a silent check is
         # strictly better than one at a 100% false-positive rate.
         properties["fixes_reported_symptom"] = {"type": "boolean"}
+    required = ["id", "title", "success_criteria_seed"]
+    if include_change_shape:
+        # How many edit sites does this change need? `_subfile_split` gates on
+        # it: only a `sweep` is tiled into per-region children, because every
+        # region child inherits the parent's criteria and a tiled point fix
+        # hands N children a whole-file mandate exactly one can satisfy in
+        # scope (DESIGN §5½ (P1) *Sub-file* *Gating condition*).
+        #
+        # REQUIRED, not optional, on the same reasoning as
+        # `migration_targets.is_real_identifier`: a planner must not be able to
+        # skip an attestation a gate depends on simply by omitting the field.
+        #
+        # It cannot be a code-side inference. The number of sites a change
+        # needs is not a property of the file, and reading it out of
+        # `investigation_notes` would be regex-over-prose, which CLAUDE.md
+        # *Language-to-JSON* forbids — the owning worker surfaces the fact as
+        # JSON, and Python only compares strings.
+        properties["change_shape"] = {
+            "type": "string",
+            "enum": ["point", "localized", "sweep"],
+        }
+        required.append("change_shape")
     return {
         "type": "object",
-        "required": ["id", "title", "success_criteria_seed"],
+        "required": required,
         "properties": properties,
     }
 
@@ -1986,6 +2009,7 @@ SCHEMAS: dict[str, dict] = {
                     include_migration_targets=True,
                     include_runs_commands=True,
                     include_fixes_reported_symptom=True,
+                    include_change_shape=True,
                 ),
             },
         },
@@ -7973,8 +7997,59 @@ def _check_intra_file_surface(
     return issues
 
 
+# Sentinel introducing the new-file-ownership clause in a child's
+# `success_criteria_seed`. Load-bearing for RE-ENTRY: a child's criteria is built
+# by appending to its parent's, and a re-split child's parent criteria already
+# carries a clause. Without replacing it, a non-owner's child receives its
+# parent's "create no new files" AND its own "you are the owner" — directly
+# contradictory, and it breaks the one-owner invariant across the tree (measured:
+# run 719c2a26 re-entered three times, at r8/r12/r14, so it would have produced
+# four claimed owners instead of one).
+#
+# Splitting on this marker is string surgery on a string THIS MODULE generated,
+# which is what makes it legitimate: CLAUDE.md *Language-to-JSON* bars reading
+# meaning out of prose or a worker's response, not slicing our own mechanical
+# output at a delimiter we emit. The neighbouring `Scope:` clauses stack instead
+# of replacing, which is fine for them (each narrows the last) and exactly wrong
+# for this one (each would negate the last).
+_NEWFILE_CLAUSE_MARKER = "\nNEW-FILE OWNERSHIP: "
+
+
+def _apply_newfile_clause(criteria: str, *, is_owner: bool,
+                          owner_id: str) -> str:
+    """Return `criteria` with exactly one new-file-ownership clause, replacing
+    any clause inherited from a parent split (DESIGN §5½ (P1) *Sub-file*)."""
+    base = criteria.split(_NEWFILE_CLAUSE_MARKER)[0].rstrip()
+    if is_owner:
+        body = ("you are this split's designated new-file owner. If the "
+                "criteria above require a file that does not exist yet, create "
+                "it here. No sibling will.")
+    else:
+        body = (f"create no new files. If the criteria above require a file "
+                f"that does not exist yet, it belongs to {owner_id}; leave it "
+                f"to that subtask rather than creating your own copy.")
+    return f"{base}{_NEWFILE_CLAUSE_MARKER}{body}"
+
+
+def _newfile_designation(subtask: dict, first_child_id: str) -> tuple[str, bool]:
+    """Resolve (owner_id, parent_is_owner) for a split's children.
+
+    A non-owner's ENTIRE subtree must contain no owner: if a child that was told
+    "leave new files to X" is itself split, none of its own children may claim
+    ownership, and they must keep naming X rather than a fresh sibling. Only an
+    owner (or an undesignated top-level subtask) passes ownership down, to its
+    first child. That is what keeps exactly one leaf owner in the whole tree.
+
+    Read from a structural field rather than by re-reading the criteria text —
+    the same discipline as `_cofile_cluster`."""
+    if subtask.get("_newfile_owner") is False:
+        return subtask.get("_newfile_owner_id") or first_child_id, False
+    return first_child_id, True
+
+
 def _migration_child(subtask: dict, chunk: list[str], cid: str,
-                     title: str, criteria: str) -> dict:
+                     title: str, criteria: str,
+                     newfile_owner_id: str | None = None) -> dict:
     """Build one migration-chunk child subtask from its (code-fixed) file
     partition plus a title + success_criteria_seed. Inherits the parent's
     graph edges/intent; the files are the pre-computed chunk, never re-decided.
@@ -7998,6 +8073,28 @@ def _migration_child(subtask: dict, chunk: list[str], cid: str,
     same pattern its parent did, and dropping the fields would silently
     make that fact unrecoverable for anything that reads a leaf in
     isolation later (a human reviewing the plan, or a future consumer)."""
+    # Same one-owner rule as `_subfile_child`, for the same reason: every child
+    # here also inherits the parent's `success_criteria_seed`, so a parent
+    # criterion demanding a file that does not exist yet ("A new runtime e2e
+    # test ...") is handed to all of them at once. Measured on run 719c2a26,
+    # `bugfix-001-f2` — a peel child, not a region child — carries the same
+    # criteria hash (8b372445) as all 12 region children, so the peel pair is
+    # the identical collision shape at 2-way instead of 14-way.
+    #
+    # UNLIKE the region children, there is NO mechanical backstop here: these
+    # children carry no `owned_region`, so `OWNED_REGION_FILE_ESCAPE` cannot
+    # see them and the criteria clause is the whole mechanism. Applied in
+    # `_migration_child` rather than in each label helper so it reaches the
+    # peel pair, the deterministic chunk-label fallback, AND the labels the
+    # label-only splitter writes — that last one composes its own criteria per
+    # chunk and would otherwise carry no clause at all.
+    #
+    # `None` means "no designation" and leaves `criteria` untouched, so a
+    # caller that has no sibling set to speak of keeps the previous behaviour.
+    is_owner = newfile_owner_id is not None and cid == newfile_owner_id
+    if newfile_owner_id is not None:
+        criteria = _apply_newfile_clause(
+            criteria, is_owner=is_owner, owner_id=newfile_owner_id)
     return {
         "id": cid,
         "title": title,
@@ -8013,6 +8110,19 @@ def _migration_child(subtask: dict, chunk: list[str], cid: str,
         "migration_targets": copy.deepcopy(
             subtask.get("migration_targets", []) or []),
         "performs_replacement": subtask.get("performs_replacement", False),
+        # Carried forward for the same reason as migration_targets, plus one
+        # load-bearing one: `_peel_oversized_file` builds a migration child for
+        # the dense file, and that child re-enters `_subfile_split`, whose
+        # `change_shape` gate reads this field. Dropping it here routes the
+        # dominant dense-file shape (a file bundled with its test file)
+        # straight past the gate.
+        "change_shape": subtask.get("change_shape"),
+        # Structural record of the clause above, so a re-split of this child
+        # resolves ownership from a field instead of re-reading its criteria
+        # prose (`_newfile_designation`). A non-owner's whole subtree stays
+        # ownerless and keeps naming the original owner.
+        "_newfile_owner": is_owner if newfile_owner_id is not None else None,
+        "_newfile_owner_id": newfile_owner_id,
     }
 
 
@@ -8033,7 +8143,8 @@ def _deterministic_chunk_label(subtask: dict, chunk: list[str],
 
 def _subfile_child(subtask: dict, file: str, region: tuple[int, int],
                    symbols: list[str], cid: str, cluster: str,
-                   idx: int, total: int) -> dict:
+                   idx: int, total: int, newfile_owner_id: str,
+                   is_owner: bool) -> dict:
     """Build one sub-file child owning a *region* (``(start, end)`` lines) of a
     single *file* (DESIGN §5½ (P1) *Sub-file*). The analog of ``_migration_child``
     for intra-file splitting.
@@ -8061,12 +8172,28 @@ def _subfile_child(subtask: dict, file: str, region: tuple[int, int],
     parent_title = subtask.get("title", "file change")
     sym_txt = ", ".join(symbols) if symbols else "(no named symbols in range)"
     title = f"{parent_title} (region {idx + 1}/{total}: lines {lo}-{hi})"
-    criteria = (
-        f"{subtask.get('success_criteria_seed', '')}\n"
-        f"Scope: only lines {lo}-{hi} of {file} "
-        f"(symbols: {sym_txt}). Do not edit outside this range; a sibling "
-        f"subtask owns the rest of the file."
-    ).strip()
+    # New-file ownership is a SEPARATE constraint from the line range, not a
+    # corollary of it: the parent's criteria may demand a new file, and "do not
+    # edit outside lines X-Y" does not constrain creating one. In run 719c2a26
+    # every region child inherited a criterion opening "A new runtime e2e test
+    # ... reproduces ...", three near-synonymous files were invented for it, and
+    # two children independently chose the SAME new path — an add/add conflict
+    # on a path absent from the merge base, which has no resolution that keeps
+    # both sides. Exactly one child may create files; the rest are told which
+    # sibling owns that work, by id, so they can declare an edge instead of
+    # racing it. Which child is arbitrary; that there is exactly one is the
+    # point (DESIGN §5½ (P1) *Sub-file*).
+    # `is_owner` comes from the CALLER, not from `idx == 0`: on a re-split the
+    # parent may itself be a non-owner, and then no child of it may own new
+    # files however it is indexed (`_newfile_designation`).
+    criteria = _apply_newfile_clause(
+        (
+            f"{subtask.get('success_criteria_seed', '')}\n"
+            f"Scope: only lines {lo}-{hi} of {file} "
+            f"(symbols: {sym_txt}). Do not edit outside this range; a sibling "
+            f"subtask owns the rest of the file."
+        ).strip(),
+        is_owner=is_owner, owner_id=newfile_owner_id)
     # Region-scoped, not a verbatim parent copy (unlike _migration_child,
     # where verbatim inheritance is safe because chunks own disjoint files).
     # Region children co-own the SAME file, so an unscoped intent gives
@@ -8096,6 +8223,11 @@ def _subfile_child(subtask: dict, file: str, region: tuple[int, int],
         "provides": list(subtask.get("provides", []) or []),
         "size": "medium",
         "investigation_notes": subtask.get("investigation_notes", ""),
+        "change_shape": subtask.get("change_shape"),
+        # See `_migration_child`'s copy of these two: a re-split resolves
+        # ownership from here, never by re-reading the criteria text.
+        "_newfile_owner": is_owner,
+        "_newfile_owner_id": newfile_owner_id,
     }
 
 
@@ -8132,8 +8264,10 @@ async def _label_migration_chunks(
         log(f"_recursive_decompose: decomposition budget exceeded before "
             f"label-only splitter for {base_id}; using deterministic "
             "chunk labels")
+        owner_id, _ = _newfile_designation(subtask, ids[0])
         return [
-            _migration_child(subtask, chunk, cid, *labels[cid])
+            _migration_child(subtask, chunk, cid, *labels[cid],
+                             newfile_owner_id=owner_id)
             for cid, chunk in zip(ids, chunks)
         ]
     sys_prompt = _load_prompt("splitter")
@@ -8175,10 +8309,19 @@ async def _label_migration_chunks(
         log(f"_recursive_decompose: label-only splitter failed for "
             f"{base_id}; using deterministic chunk labels")
 
+    owner_id, _ = _newfile_designation(subtask, ids[0])
     return [
-        _migration_child(subtask, chunk, cid, *labels[cid])
+        _migration_child(subtask, chunk, cid, *labels[cid],
+                         newfile_owner_id=owner_id)
         for cid, chunk in zip(ids, chunks)
     ]
+
+
+# Declared `change_shape` values that must NOT be tiled intra-file. The enum's
+# third member, "sweep", is the only shape the sub-file split exists for
+# (DESIGN §5½ (P1) *Sub-file*). Kept as a frozenset rather than inlined so the
+# gate and its test name the same object.
+_NON_SWEEP_CHANGE_SHAPES = frozenset({"point", "localized"})
 
 
 def _subfile_split(subtask: dict, repo_root: Path,
@@ -8224,6 +8367,27 @@ def _subfile_split(subtask: dict, repo_root: Path,
         symbols_per = [[] for _ in regions]
     else:
         # First entry: tier-1 function-boundary tiling of the whole file.
+        #
+        # Gate on the parent's declared change shape BEFORE looking at the
+        # file at all (DESIGN §5½ (P1) *Sub-file* *Gating condition*). Size
+        # alone is the wrong trigger: tiling is for an edit-DENSE sweep, and a
+        # point fix in a large file yields N children that each inherit a
+        # whole-file mandate only one of them can satisfy in region. Measured
+        # on run 719c2a26 — a one-expression fix in a 9,140-line file tiled
+        # into 14 regions — 11 of 12 children touched a file outside their
+        # region and 7 of 12 edited lines outside their range; exactly one
+        # complied.
+        #
+        # Absence is NOT treated as a refusal: `reconciler.added_subtasks` and
+        # `splitter.children` do not carry the field, and defaulting those to
+        # "don't split" would silently disable the mechanism for them. Only an
+        # explicit non-sweep declaration gates.
+        if subtask.get("change_shape") in _NON_SWEEP_CHANGE_SHAPES:
+            log(f"_recursive_decompose: {subtask.get('id', '?')} declares "
+                f"change_shape={subtask['change_shape']!r} — not tiling "
+                f"{file!r} intra-file (sub-file split is for sweeps; see "
+                f"DESIGN §5½ (P1) *Sub-file*)")
+            return []
         abs_path = repo_root / file
         try:
             total_lines = abs_path.read_text(errors="replace").count("\n") + 1
@@ -8252,9 +8416,14 @@ def _subfile_split(subtask: dict, repo_root: Path,
         return []  # nothing gained — leaf
 
     total = len(regions)
+    # Index 0's id, derived the same way its own cid is, so the designation is
+    # stable across a resume — but only when this subtask is entitled to hand
+    # ownership down at all. Re-entering a NON-owner must not mint a new owner.
+    owner_id, parent_owns = _newfile_designation(subtask, f"{base_id}-r1")
     return [
         _subfile_child(subtask, file, region, symbols_per[i],
-                       f"{base_id}-r{i + 1}", cluster, i, total)
+                       f"{base_id}-r{i + 1}", cluster, i, total,
+                       owner_id, parent_owns and i == 0)
         for i, region in enumerate(regions)
     ]
 
@@ -8302,16 +8471,24 @@ def _peel_oversized_file(subtask: dict, repo_root: Path,
     base_id = subtask.get("id", "split")
     parent_title = subtask.get("title", "file change")
     seed = subtask.get("success_criteria_seed", "")
+    # f1 owns new files rather than an arbitrary child: it holds the dense file
+    # the work is actually about, while f2 exists only to carry the leftovers.
+    # Unless this subtask is itself a non-owner, in which case the resolved id
+    # is an ancestor's and no child's cid can match it — so neither peel child
+    # claims ownership, and both keep naming the real owner.
+    newfile_owner, _ = _newfile_designation(subtask, f"{base_id}-f1")
     dense_child = _migration_child(
         subtask, [dense], f"{base_id}-f1",
         f"{parent_title} (dense file: {dense})",
         (f"{seed}\nScope: only {dense}. A sibling subtask owns the "
-         f"remaining file(s).").strip())
+         f"remaining file(s).").strip(),
+        newfile_owner_id=newfile_owner)
     rest_child = _migration_child(
         subtask, rest, f"{base_id}-f2",
         f"{parent_title} (remaining: {', '.join(rest)})",
         (f"{seed}\nScope: only these files — {', '.join(rest)}. A sibling "
-         f"subtask owns {dense}.").strip())
+         f"subtask owns {dense}.").strip(),
+        newfile_owner_id=newfile_owner)
     return [dense_child, rest_child]
 
 
@@ -9489,6 +9666,45 @@ def check_implementer_output(
                 f"NO_PLANNED_FILES_TOUCHED: none of the planned "
                 f"files were modified — planned: "
                 f"{sorted(planned)[:5]}")
+
+    # OWNED_REGION_FILE_ESCAPE — GATING, unlike NO_PLANNED_FILES_TOUCHED above.
+    # The distinction is the provenance of the expectation, not its shape:
+    # `files_likely_touched` is a planner GUESS, so re-driving on it asks a
+    # worker to match a prediction. `owned_region["file"]` is computed by
+    # `_subfile_split` from a tree-sitter tiling of one file the subtask was
+    # deliberately confined to — there is no false-positive surface, because a
+    # region child touching another path is by construction outside its
+    # mandate.
+    #
+    # Corrective, never fatal. The caller routes a gating issue through
+    # `_format_check_feedback` -> `note` -> `continuation=True`, bounded by
+    # `implementer_confidence_retries`, after which it degrades to advisory.
+    # It must NOT be moved into `check_diff_scope`'s fatal return, whose string
+    # reaches `fail("broken", ...)` and is non-retryable: replayed against run
+    # 719c2a26 a fatal rule kills 11 of 12 subtasks, converting a coverage gap
+    # into a total run kill — and those violations were children OBEYING an
+    # inherited criterion they could not satisfy in region (DESIGN §5½ (P1)
+    # *Sub-file*).
+    owned_region = subtask.get("owned_region") or {}
+    owned_file = owned_region.get("file")
+    if owned_file and actual_files:
+        escaped = sorted(f for f in actual_files if f != owned_file)
+        if escaped:
+            # The count is reported alongside the sample, not implied by it.
+            # `NO_PLANNED_FILES_TOUCHED` above truncates to 5 bare, which is
+            # fine for an ADVISORY nobody acts on; this string is fed back to
+            # the implementer as the list to revert, so a silent cap tells a
+            # worker that escaped into ten files to revert five and burn
+            # another retry on the rest.
+            sample = escaped[:5]
+            more = "" if len(escaped) == len(sample) else \
+                f" (showing {len(sample)} of {len(escaped)})"
+            issues.append(
+                f"OWNED_REGION_FILE_ESCAPE: this subtask owns only lines "
+                f"{owned_region.get('start', '?')}-{owned_region.get('end', '?')} "
+                f"of {owned_file}, but the commit touches "
+                f"{len(escaped)} other path(s){more}: {sample} — revert them; "
+                f"a sibling region subtask owns them")
 
     if result.get("status") == "complete":
         for cr in result.get("criteria_results", []) or []:
@@ -26354,7 +26570,13 @@ def _format_owned_region_section(leerie_dir: Path, sid: str) -> str | None:
         "risk an integration merge conflict the sibling would otherwise "
         "resolve cleanly. If the change genuinely requires touching a "
         "shared declaration outside your range (e.g. a type used by several "
-        "regions), make the minimal edit and note it in your summary."
+        "regions), make the minimal edit and note it in your summary.\n"
+        f"  You own no path other than {file}. Do not create or edit any "
+        "other file — not a new test, not a new helper — even if your "
+        "success criteria appear to ask for one; your criteria say which "
+        "sibling owns that. This is checked mechanically against your "
+        "commit (OWNED_REGION_FILE_ESCAPE) and you will be re-driven to "
+        "revert it."
     )
 
 

--- a/prompts/planner.md
+++ b/prompts/planner.md
@@ -147,6 +147,24 @@ The orchestrator gives you, in your prompt:
    prose. Leave `runs_commands` empty (or omit it) for subtasks that
    invoke no prescribed command — most subtasks do not.
 
+   **Set `change_shape` on every subtask.** Required — there is no default.
+   It declares how many places in the code this subtask actually edits:
+
+   - `point` — one site, or a couple of adjacent lines. A single wrong
+     condition, one missing guard, one bad default.
+   - `localized` — a handful of sites inside one function or one closely
+     related cluster.
+   - `sweep` — the same mechanical change repeated across many sites: a
+     rename, an API migration, a signature change threaded through a file.
+
+   Judge the *change*, not the file. A one-line fix inside a 9,000-line file is
+   `point`, not `sweep` — the file's size says nothing about how much of it you
+   are touching. This is not cosmetic bookkeeping: the orchestrator splits a
+   `sweep` subtask on a large file into parallel per-region children, and doing
+   that to a `point` change hands a dozen workers a mandate only one of them can
+   satisfy in scope. Declaring `sweep` because the file is big is the specific
+   mistake this field exists to prevent.
+
    **Set `fixes_reported_symptom: true`** only on a subtask whose job is to
    fix a failure the task text reports as *currently happening*. Leave it
    false or absent for everything else — new features, refactors, subtasks
@@ -436,6 +454,7 @@ Return **only** this JSON object as your final message — no prose, no fences:
       "provides": ["capability-tag-produced"],
       "success_criteria_seed": "The concrete checkable condition; an automated test where possible.",
       "size": "small | medium",
+      "change_shape": "point | localized | sweep",
       "investigation_notes": "What you found that materially helps the implementer.",
       "migration_targets": [
         {"old_pattern": "<literal symbol grepped from this repo>",

--- a/tests/test_decompose_child_helpers.py
+++ b/tests/test_decompose_child_helpers.py
@@ -137,7 +137,7 @@ def test_subfile_child_owns_region(leerie):
     parent = _base_parent()
     child = leerie._subfile_child(
         parent, "flow-runner.ts", (1, 700), ["runFrame", "FrameTarget"],
-        "feat-005-r1", "flow-runner.ts", 0, 3)
+        "feat-005-r1", "flow-runner.ts", 0, 3, "feat-005-r1", True)
 
     assert child["id"] == "feat-005-r1"
     assert child["files_likely_touched"] == ["flow-runner.ts"]
@@ -160,7 +160,7 @@ def test_subfile_child_deep_copies_requires_and_provides_no_aliasing(leerie):
     parent = _base_parent()
     child = leerie._subfile_child(
         parent, "flow-runner.ts", (1, 700), ["runFrame"],
-        "feat-005-r1", "flow-runner.ts", 0, 2)
+        "feat-005-r1", "flow-runner.ts", 0, 2, "feat-005-r1", True)
 
     assert child["depends_on"] == parent["depends_on"]
     assert child["depends_on"] is not parent["depends_on"]
@@ -191,7 +191,7 @@ def test_subfile_child_intent_is_region_scoped_not_verbatim(leerie):
     parent = _base_parent()
     child = leerie._subfile_child(
         parent, "flow-runner.ts", (701, 1400), ["otherFn"],
-        "feat-005-r2", "flow-runner.ts", 1, 3)
+        "feat-005-r2", "flow-runner.ts", 1, 3, "feat-005-r1", False)
 
     assert child["intent"] != parent["intent"]
     assert parent["intent"] in child["intent"]
@@ -203,7 +203,7 @@ def test_subfile_child_no_symbols_in_range(leerie):
     parent = _base_parent()
     child = leerie._subfile_child(
         parent, "flow-runner.ts", (1, 50), [], "feat-005-r1",
-        "flow-runner.ts", 0, 2)
+        "flow-runner.ts", 0, 2, "feat-005-r1", True)
 
     assert "(no named symbols in range)" in child["intent"]
     assert "(no named symbols in range)" in child["success_criteria_seed"]

--- a/tests/test_planner_runs_commands_schema.py
+++ b/tests/test_planner_runs_commands_schema.py
@@ -48,6 +48,7 @@ def test_subtask_with_runs_commands_validates(leerie):
         "title": "Run recon:generate",
         "success_criteria_seed": "recon:generate is invoked and succeeds",
         "runs_commands": ["recon:browser", "recon:generate"],
+        "change_shape": "point",
     }
     _validate_subtask_item(leerie, instance)
 
@@ -57,6 +58,7 @@ def test_subtask_without_runs_commands_validates(leerie):
         "id": "feat-002",
         "title": "Add the /volumes endpoint",
         "success_criteria_seed": "POST /volumes returns 201",
+        "change_shape": "point",
     }
     _validate_subtask_item(leerie, instance)
 
@@ -67,6 +69,7 @@ def test_subtask_with_empty_runs_commands_validates(leerie):
         "title": "Refactor the auth middleware",
         "success_criteria_seed": "existing auth tests still pass",
         "runs_commands": [],
+        "change_shape": "point",
     }
     _validate_subtask_item(leerie, instance)
 
@@ -78,6 +81,7 @@ def test_runs_commands_rejects_non_string_items(leerie):
         "title": "Bad subtask",
         "success_criteria_seed": "n/a",
         "runs_commands": [123],
+        "change_shape": "point",
     }
     with pytest.raises(jsonschema.exceptions.ValidationError):
         jsonschema.validate(instance, _subtask_item_schema(leerie))

--- a/tests/test_shared_subtask_item_schema.py
+++ b/tests/test_shared_subtask_item_schema.py
@@ -22,6 +22,7 @@ def test_planner_subtasks_items_built_by_shared_helper(leerie):
         include_migration_targets=True,
         include_runs_commands=True,
         include_fixes_reported_symptom=True,
+        include_change_shape=True,
     )
     assert json.dumps(items, sort_keys=True) == json.dumps(
         rebuilt, sort_keys=True)

--- a/tests/test_subfile_split_change_shape_gate.py
+++ b/tests/test_subfile_split_change_shape_gate.py
@@ -1,0 +1,511 @@
+"""Sub-file split must gate on the parent's declared `change_shape`, must give
+exactly one region child new-file ownership, and must have its `owned_region`
+enforced mechanically (DESIGN §5½ (P1) *Sub-file*).
+
+All three pins derive from run `719c2a26`, where a ONE-EXPRESSION fix in a
+9,140-line file was tiled into 14 regions. Replayed against that run's actual
+subtask branches: 11 of 12 region children touched a file outside their region,
+7 of 12 edited lines outside their range, and exactly one complied. Two children
+independently created the SAME new test file -- an add/add conflict on a path
+absent from the merge base, which no merge strategy can resolve without
+discarding one side.
+
+Each test here asserts SUBSTANCE, not structure (CLAUDE.md *A test asserting
+STRUCTURE must be paired with one asserting SUBSTANCE*): the gate is driven and
+its return value asserted; the criteria string is read for the clause's actual
+text; the check is driven with a real escaping file set and its issue is
+asserted to be gating rather than merely present.
+"""
+from __future__ import annotations
+
+import pytest
+
+
+# --- helpers -----------------------------------------------------------------
+
+def _owns(child) -> bool:
+    """Structural read of the new-file designation. Preferred over grepping the
+    criteria prose: the clause wording is ours to change, the field is the
+    contract a re-split actually resolves against."""
+    return child.get("_newfile_owner") is True
+
+
+def _clause_count(leerie, child) -> int:
+    """How many ownership clauses the criteria carries. MUST be 1 — the
+    re-entry bug was two, and they contradicted each other."""
+    return child["success_criteria_seed"].count(leerie._NEWFILE_CLAUSE_MARKER)
+
+
+def _owners(children) -> list:
+    return [c for c in children if _owns(c)]
+
+
+def _dense_file(tmp_path, lines=2100):
+    """A file comfortably over `subfile_split_max_span` (700), so the ONLY
+    thing that can keep it from being tiled is the change_shape gate."""
+    p = tmp_path / "dense.ts"
+    p.write_text("\n".join(f"const x{i} = {i};" for i in range(lines)) + "\n")
+    return p
+
+
+def _subtask(change_shape, *, file="dense.ts"):
+    return {
+        "id": "bugfix-001",
+        "title": "Stop foldReturn being dropped when a paging signal exists",
+        "success_criteria_seed": (
+            "A new runtime e2e test reproduces the flow and asserts the "
+            "generated contract emits the drill call."),
+        "intent": "Restore additive fold behavior.",
+        "files_likely_touched": [file],
+        **({} if change_shape is None else {"change_shape": change_shape}),
+    }
+
+
+# --- C1: the change_shape gate ----------------------------------------------
+
+@pytest.mark.parametrize("shape", ["point", "localized"])
+def test_non_sweep_change_shape_is_not_tiled(leerie, tmp_path, shape):
+    """The regression itself: a point fix in a huge file must stay a leaf.
+
+    Asserts the RETURN VALUE (no children), not that the constant is consulted
+    -- a presence check would pass against a gate that computed the right
+    answer and ignored it.
+    """
+    _dense_file(tmp_path)
+    children = leerie._subfile_split(_subtask(shape), tmp_path, 700)
+    assert children == [], (
+        f"change_shape={shape!r} was tiled into {len(children)} region "
+        "children; a non-sweep change must stay a leaf regardless of file size")
+
+
+def test_sweep_on_the_same_file_is_still_tiled(leerie, tmp_path):
+    """Anti-vacuity: the gate must not be disabling the mechanism outright.
+
+    Same file, same span cap, same everything -- only `change_shape` differs.
+    Without this, a `_subfile_split` that returned [] unconditionally would
+    pass the test above.
+    """
+    _dense_file(tmp_path)
+    children = leerie._subfile_split(_subtask("sweep"), tmp_path, 700)
+    assert len(children) > 1, (
+        "a declared sweep over an over-cap file must still tile; the gate "
+        "must discriminate on change_shape, not suppress all splitting")
+
+
+def test_absent_change_shape_preserves_pre_gate_behavior(leerie, tmp_path):
+    """`reconciler.added_subtasks` and `splitter.children` do not carry the
+    field. Absence means "not declared", NOT "refuse to split" -- otherwise the
+    gate silently disables the mechanism for those two call sites."""
+    _dense_file(tmp_path)
+    children = leerie._subfile_split(_subtask(None), tmp_path, 700)
+    assert len(children) > 1
+
+
+def test_gate_reads_the_named_constant(leerie):
+    """The enum's non-sweep members and the gate's constant must not drift
+    apart: a value added to the schema but not the frozenset would be tiled."""
+    enum = set(leerie._subtask_item_schema(include_change_shape=True)
+               ["properties"]["change_shape"]["enum"])
+    assert leerie._NON_SWEEP_CHANGE_SHAPES == enum - {"sweep"}
+
+
+def test_change_shape_is_required_on_planner_subtasks(leerie):
+    """Required, not optional -- a planner must not be able to skip an
+    attestation a gate depends on by omitting the field (same reasoning as
+    `migration_targets.is_real_identifier`)."""
+    items = leerie.SCHEMAS["planner"]["properties"]["subtasks"]["items"]
+    assert "change_shape" in items["required"]
+    assert "change_shape" not in leerie._subtask_item_schema().get(
+        "required", []), "must stay absent from the narrower call sites"
+
+
+def test_migration_child_carries_change_shape_forward(leerie):
+    """The peel path builds a `_migration_child` for the dense file, and that
+    child re-enters `_subfile_split`. Dropping the field there routes the
+    dominant dense-file shape (file + its test file) straight past the gate.
+
+    Asserts the VALUE survives, not that the key exists.
+    """
+    parent = _subtask("point")
+    child = leerie._migration_child(
+        parent, ["dense.ts"], "bugfix-001-f1", "t", "c")
+    assert child["change_shape"] == "point"
+
+
+def test_peel_path_child_still_hits_the_gate(leerie, tmp_path):
+    """End-to-end for the above: peel a point-fix subtask whose files are the
+    dense file plus its test file, then feed the peeled dense child back into
+    `_subfile_split`. It must not tile."""
+    _dense_file(tmp_path)
+    (tmp_path / "dense.test.ts").write_text("test\n")
+    parent = _subtask("point")
+    parent["files_likely_touched"] = ["dense.ts", "dense.test.ts"]
+    peeled = leerie._peel_oversized_file(parent, tmp_path, 700, 8)
+    assert peeled, "expected a peel for one oversized file in a small set"
+    dense_child = next(c for c in peeled
+                       if c["files_likely_touched"] == ["dense.ts"])
+    assert leerie._subfile_split(dense_child, tmp_path, 700) == []
+
+
+# --- C2: exactly one new-file owner -----------------------------------------
+
+def test_exactly_one_region_child_owns_new_files(leerie, tmp_path):
+    _dense_file(tmp_path)
+    children = leerie._subfile_split(_subtask("sweep"), tmp_path, 700)
+    owners = _owners(children)
+    assert len(owners) == 1, (
+        f"{len(owners)} of {len(children)} children claim new-file ownership; "
+        "exactly one is what makes the add/add collision impossible")
+    assert owners[0]["id"].endswith("-r1")
+    assert all(_clause_count(leerie, c) == 1 for c in children)
+
+
+def test_non_owner_children_are_told_which_sibling_owns_it(leerie, tmp_path):
+    """Substance, not presence: the clause must name the OWNER'S ACTUAL ID, so
+    a non-owner can declare an edge instead of racing it."""
+    _dense_file(tmp_path)
+    children = leerie._subfile_split(_subtask("sweep"), tmp_path, 700)
+    owner_id = children[0]["id"]
+    for c in children[1:]:
+        seed = c["success_criteria_seed"]
+        assert not _owns(c)
+        assert "create no new files" in seed.lower()
+        assert owner_id in seed, (
+            f"{c['id']} is forbidden from creating files but is not told that "
+            f"{owner_id} owns them")
+
+
+def test_children_do_not_all_carry_a_byte_identical_criteria_seed(
+        leerie, tmp_path):
+    """The direct shape of the incident: in 719c2a26 every region child's
+    criteria hashed identically, so all 13 pursued one whole-file mandate."""
+    _dense_file(tmp_path)
+    children = leerie._subfile_split(_subtask("sweep"), tmp_path, 700)
+    seeds = {c["success_criteria_seed"] for c in children}
+    assert len(seeds) == len(children), (
+        "region children share a criteria seed; each must be region-scoped")
+
+
+# --- C3: owned_region is enforced, and correctively --------------------------
+
+def _complete_result():
+    return {
+        "subtask_id": "bugfix-001-f1-r13",
+        "status": "complete",
+        "summary": "done",
+        "criteria_results": [],
+        "production_evidence": {
+            "exercised": True, "how": "ran it", "observed": "ok"},
+    }
+
+
+def test_owned_region_file_escape_is_detected(leerie):
+    """r13's real shape: it committed ONE file, and that file was not the one
+    it owned -- zero lines of `owned_region["file"]`."""
+    subtask = {
+        "id": "bugfix-001-f1-r13",
+        "files_likely_touched": ["src/scripts/recon-generate.ts"],
+        "owned_region": {"file": "src/scripts/recon-generate.ts",
+                         "start": 7824, "end": 8396, "symbols": []},
+    }
+    issues = leerie.check_implementer_output(
+        _complete_result(), subtask,
+        {"src/scripts/recon-generate-graphql-paginated-primary-fold-"
+         "runtime-e2e.test.ts"})
+    escapes = [i for i in issues if i.startswith("OWNED_REGION_FILE_ESCAPE")]
+    assert len(escapes) == 1, issues
+    assert "7824-8396" in escapes[0]
+    assert "runtime-e2e.test.ts" in escapes[0], (
+        "the feedback must name the offending path, or the implementer cannot "
+        "act on it")
+
+
+def test_owned_region_file_escape_is_gating_not_advisory(leerie):
+    """It must reach the retry loop. `NO_PLANNED_FILES_TOUCHED` is advisory
+    because `files_likely_touched` is a planner guess; `owned_region["file"]`
+    is code-computed by `_subfile_split`, so there is no false-positive
+    surface."""
+    assert leerie._gating_issues(["OWNED_REGION_FILE_ESCAPE: x"]) == [
+        "OWNED_REGION_FILE_ESCAPE: x"]
+
+
+def test_owned_region_file_escape_is_not_fatal(leerie):
+    """RETRACTED-BY-MEASUREMENT pin. Routing this through `check_diff_scope`'s
+    return would reach `fail("broken", ...)`, which `_retryable_failure`
+    treats as NON-retryable; replayed against 719c2a26 that kills 11 of 12
+    subtasks. The check must live in `check_implementer_output`, whose issues
+    are corrective."""
+    import inspect
+    assert not leerie._retryable_failure("broken"), (
+        "premise of this pin changed: 'broken' is now retryable")
+    src = inspect.getsource(leerie.check_diff_scope)
+    assert "OWNED_REGION_FILE_ESCAPE" not in src, (
+        "owned_region enforcement must not live in check_diff_scope -- its "
+        "return routes to a non-retryable fail('broken', ...)")
+    assert "OWNED_REGION_FILE_ESCAPE" in inspect.getsource(
+        leerie.check_implementer_output)
+
+
+def test_compliant_region_child_is_not_flagged(leerie):
+    """Anti-vacuity: r7, the one subtask in 719c2a26 that stayed in scope."""
+    subtask = {
+        "id": "bugfix-001-f1-r7",
+        "owned_region": {"file": "src/scripts/recon-generate.ts",
+                         "start": 3999, "end": 4198, "symbols": []},
+    }
+    issues = leerie.check_implementer_output(
+        _complete_result(), subtask, {"src/scripts/recon-generate.ts"})
+    assert not [i for i in issues
+                if i.startswith("OWNED_REGION_FILE_ESCAPE")], issues
+
+
+def test_subtask_without_owned_region_is_unaffected(leerie):
+    """Ordinary subtasks carry no `owned_region`; the check must be inert for
+    them, or every non-region subtask starts failing on its own test files."""
+    subtask = {"id": "feat-001", "files_likely_touched": ["a.py"]}
+    issues = leerie.check_implementer_output(
+        _complete_result(), subtask, {"a.py", "a_test.py", "README.md"})
+    assert not [i for i in issues
+                if i.startswith("OWNED_REGION_FILE_ESCAPE")], issues
+
+
+# --- C2 extended: the peel and migration-chunk paths carry the same rule -----
+#
+# Not a region-child path, and therefore NOT backstopped by
+# OWNED_REGION_FILE_ESCAPE (these children carry no `owned_region`) -- the
+# criteria clause is the whole mechanism, which is why it is pinned here.
+#
+# Measured on 719c2a26: `bugfix-001-f2` is a PEEL child, not a region child,
+# and it carries the same criteria hash (8b372445) as all 12 region children.
+# So the peel pair is the identical collision shape at 2-way instead of 14-way,
+# and gating the tiling alone would have narrowed the defect rather than fixed
+# it.
+
+def test_peel_pair_has_exactly_one_new_file_owner(leerie, tmp_path):
+    _dense_file(tmp_path)
+    (tmp_path / "dense.test.ts").write_text("test\n")
+    parent = _subtask("sweep")
+    parent["files_likely_touched"] = ["dense.ts", "dense.test.ts"]
+
+    children = leerie._peel_oversized_file(parent, tmp_path, 700, 8)
+    assert len(children) == 2
+
+    owners = _owners(children)
+    assert len(owners) == 1
+    assert owners[0]["files_likely_touched"] == ["dense.ts"], (
+        "the dense-file child must own new files -- it holds the file the work "
+        "is about; the sibling exists only to carry the leftovers")
+
+    other = next(c for c in children if c is not owners[0])
+    assert "create no new files" in other["success_criteria_seed"].lower()
+    assert owners[0]["id"] in other["success_criteria_seed"], (
+        "the non-owner must be told which sibling owns new files, by id")
+
+
+def test_migration_chunks_have_exactly_one_new_file_owner(leerie):
+    """Chunk 0 owns them; every other chunk names it. Arbitrary but
+    deterministic, matching `_subfile_child`'s rule."""
+    parent = _subtask("sweep")
+    ids = [f"feat-001-{i + 1}" for i in range(4)]
+    children = [
+        leerie._migration_child(parent, [f"m{i}.py"], cid, "t",
+                                f"criteria for {cid}",
+                                newfile_owner_id=ids[0])
+        for i, cid in enumerate(ids)
+    ]
+    assert [c["id"] for c in _owners(children)] == [ids[0]]
+    for c in children[1:]:
+        assert "create no new files" in c["success_criteria_seed"].lower()
+        assert ids[0] in c["success_criteria_seed"]
+        assert _clause_count(leerie, c) == 1
+
+
+def test_migration_child_without_a_designation_is_unchanged(leerie):
+    """Anti-vacuity, and a real contract: `newfile_owner_id=None` must leave
+    the criteria byte-identical, so a caller with no sibling set to speak of
+    keeps the pre-existing behaviour."""
+    parent = _subtask("sweep")
+    child = leerie._migration_child(parent, ["a.py"], "feat-001-1", "t",
+                                    "exact criteria text")
+    assert child["success_criteria_seed"] == "exact criteria text"
+
+
+def test_the_clause_reaches_llm_written_chunk_labels_too(leerie):
+    """The label-only splitter composes its OWN `success_criteria_seed` per
+    chunk. Applying the rule in `_migration_child` (rather than inside the
+    deterministic-label helper) is what makes it reach those labels as well —
+    otherwise the dominant migration path would carry no clause at all."""
+    parent = _subtask("sweep")
+    llm_authored = "Worker-written criteria that never mention file ownership."
+    child = leerie._migration_child(parent, ["a.py"], "feat-001-2", "t",
+                                    llm_authored,
+                                    newfile_owner_id="feat-001-1")
+    assert llm_authored in child["success_criteria_seed"]
+    assert "create no new files" in child["success_criteria_seed"].lower()
+    assert "feat-001-1" in child["success_criteria_seed"]
+
+
+def test_deterministic_chunk_labels_stay_distinct_per_chunk(leerie):
+    """The pre-existing guarantee must survive the clause: identical criteria
+    across chunks is the very shape this whole change exists to prevent."""
+    parent = _subtask("sweep")
+    ids = [f"feat-001-{i + 1}" for i in range(3)]
+    chunks = [["a.py"], ["b.py"], ["c.py"]]
+    seeds = {
+        leerie._migration_child(
+            parent, chunk, cid,
+            *leerie._deterministic_chunk_label(parent, chunk, i, len(chunks)),
+            newfile_owner_id=ids[0])["success_criteria_seed"]
+        for i, (cid, chunk) in enumerate(zip(ids, chunks))
+    }
+    assert len(seeds) == len(chunks)
+
+
+# --- RE-ENTRY: the one-owner invariant must hold at every depth ---------------
+#
+# Round 1 of this suite tested depth-1 splits only, and that gap shipped a real
+# bug: each helper appends its clause to the PARENT's criteria, and a re-split
+# child's parent criteria already carries one. A non-owner's child received its
+# parent's "create no new files" AND its own "you are the owner" -- directly
+# contradictory, and two subtasks claiming ownership is the exact multi-owner
+# condition that produced the add/add collision this whole change prevents.
+#
+# Re-entry is not exotic: tier 2 exists for it (a single function larger than
+# the cap), and run 719c2a26 re-entered three times (r8, r12, r14 each produced
+# -r1/-r2 children), which would have yielded four claimed owners instead of one.
+
+def _reenterable(child, lo, hi):
+    """A region child whose own span is over the cap, so `_subfile_split`
+    re-enters on it via the tier-2 line-window branch."""
+    out = dict(child)
+    out["owned_region"] = {"file": "dense.ts", "start": lo, "end": hi,
+                           "symbols": []}
+    return out
+
+
+def test_resplitting_a_non_owner_mints_no_new_owner(leerie, tmp_path):
+    _dense_file(tmp_path)
+    children = leerie._subfile_split(_subtask("sweep"), tmp_path, 700)
+    non_owner = next(c for c in children if not _owns(c))
+    original_owner = _owners(children)[0]["id"]
+
+    sub = leerie._subfile_split(_reenterable(non_owner, 1, 2100), tmp_path, 700)
+    assert len(sub) > 1, "fixture must actually re-split for this to mean anything"
+    assert _owners(sub) == [], (
+        "a non-owner's children claimed ownership; a non-owner's whole subtree "
+        "must stay ownerless")
+    for c in sub:
+        assert _clause_count(leerie, c) == 1, (
+            "inherited clause was stacked rather than replaced — the two "
+            "contradict each other")
+        assert original_owner in c["success_criteria_seed"], (
+            "children of a non-owner must keep naming the ORIGINAL owner, not "
+            "a freshly-minted sibling")
+
+
+def test_resplitting_the_owner_passes_ownership_to_exactly_one_child(
+        leerie, tmp_path):
+    """Anti-vacuity twin: the rule must not be 'never designate on re-entry'.
+    An owner that splits has to hand ownership down, or nothing owns new files."""
+    _dense_file(tmp_path)
+    children = leerie._subfile_split(_subtask("sweep"), tmp_path, 700)
+    owner = _owners(children)[0]
+
+    sub = leerie._subfile_split(_reenterable(owner, 1, 2100), tmp_path, 700)
+    assert len(_owners(sub)) == 1
+    assert _owners(sub)[0]["id"].endswith("-r1")
+    for c in sub:
+        assert _clause_count(leerie, c) == 1
+
+
+def test_peel_of_a_non_owner_chunk_mints_no_new_owner(leerie, tmp_path):
+    """Same shape on the migration side: a labelled non-owner chunk that then
+    hits the oversized-file peel runs through `_migration_child` a second time."""
+    _dense_file(tmp_path)
+    (tmp_path / "small.py").write_text("x\n")
+    parent = _subtask("sweep")
+    chunk = leerie._migration_child(parent, ["dense.ts", "small.py"],
+                                    "feat-001-2", "chunk 2", "Seed.",
+                                    newfile_owner_id="feat-001-1")
+    assert not _owns(chunk)
+
+    peeled = leerie._peel_oversized_file(chunk, tmp_path, 700, 8)
+    assert len(peeled) == 2
+    assert _owners(peeled) == []
+    for c in peeled:
+        assert _clause_count(leerie, c) == 1
+        assert "feat-001-1" in c["success_criteria_seed"]
+
+
+def test_whole_tree_has_exactly_one_new_file_owner(leerie, tmp_path):
+    """The invariant itself, measured rather than asserted per-level: recurse
+    the split to leaves and count. This is the check that would have caught the
+    re-entry bug in round 1."""
+    _dense_file(tmp_path, lines=2100)
+
+    def walk(node, depth=0):
+        # Force a re-split on the first child of each level so the tree is
+        # genuinely deeper than one, independent of how the fixture tiles.
+        kids = leerie._subfile_split(node, tmp_path, 700)
+        if not kids or depth >= 2:
+            return [node]
+        deepened = [_reenterable(kids[0], 1, 2100)] + list(kids[1:])
+        out = []
+        for k in deepened:
+            out.extend(walk(k, depth + 1))
+        return out
+
+    leaves = walk(_subtask("sweep"))
+    owners = _owners(leaves)
+    assert len(owners) == 1, (
+        f"{len(owners)} of {len(leaves)} leaves claim new-file ownership: "
+        f"{[c['id'] for c in owners]}")
+    assert all(_clause_count(leerie, c) == 1 for c in leaves)
+
+
+# --- tier 1 (tree-sitter symbol spans) — host-independent by construction -----
+#
+# `HAS_TREESITTER` is False on some dev hosts but TRUE on CI (requirements.txt
+# pins tree-sitter and .github/workflows/test.yml installs it), so a suite that
+# only ever exercised the tier-2 fallback locally would first meet tier 1 on CI
+# — the green-locally/red-on-CI shape CLAUDE.md documents from PR #211. Stubbing
+# the extractor pins the tier-1 partitioning path on EVERY host instead of
+# leaving it to whether a native parser happens to be installed.
+
+def _stub_ranges(monkeypatch, leerie, ranges):
+    monkeypatch.setattr(leerie, "_extract_symbol_ranges", lambda _p: ranges)
+
+
+def test_tier1_symbol_tiling_keeps_one_owner(leerie, tmp_path, monkeypatch):
+    _dense_file(tmp_path, lines=2100)
+    _stub_ranges(monkeypatch, leerie,
+                 [(f"fn{i}", i * 300 + 1, (i + 1) * 300) for i in range(7)])
+    children = leerie._subfile_split(_subtask("sweep"), tmp_path, 700)
+    assert len(children) > 1
+    assert len(_owners(children)) == 1
+    assert all(_clause_count(leerie, c) == 1 for c in children)
+    assert any(c["owned_region"]["symbols"] for c in children), (
+        "expected the tier-1 path — symbol names should reach owned_region")
+
+
+def test_tier1_oversized_symbol_reenters_with_one_owner(leerie, tmp_path,
+                                                        monkeypatch):
+    """The real re-entry trigger: ONE function larger than the cap. This is why
+    719c2a26's r8/r12/r14 produced -r1/-r2 children, and uniform line-windows
+    never would."""
+    _dense_file(tmp_path, lines=2100)
+    _stub_ranges(monkeypatch, leerie,
+                 [("small", 1, 200), ("huge", 201, 2100)])
+    children = leerie._subfile_split(_subtask("sweep"), tmp_path, 700)
+    oversized = [c for c in children
+                 if c["owned_region"]["end"] - c["owned_region"]["start"] + 1
+                 > 700]
+    assert oversized, "expected an over-cap region from the huge symbol"
+
+    total_owners = len(_owners(children))
+    for c in oversized:
+        sub = leerie._subfile_split(c, tmp_path, 700)
+        assert sub, "an over-cap region must re-enter tier 2"
+        total_owners += len(_owners(sub)) - (1 if _owns(c) else 0)
+        assert all(_clause_count(leerie, x) == 1 for x in sub)
+    assert total_owners == 1


### PR DESCRIPTION
## Summary

`_subfile_split` tiled on file **size** alone, so a one-expression fix in a
9,140-line file became 14 region children — each inheriting the parent's
whole-file criteria ("A new runtime e2e test … reproduces …"). Two of them
independently created the *same* new test file: an add/add conflict on a path
absent from the merge base, which no merge strategy resolves without discarding
a side. The integration judge caught the loss post-merge and killed barnacle run
`719c2a26`. This gates the split on a planner-declared `change_shape`, gives
each split exactly one new-file owner, and makes `owned_region` a mechanical
check instead of a prompt suggestion.

**The commit message is the permanent record here** (single-commit PR,
squash-merge with `COMMIT_MESSAGES`) — it carries the full measurements and the
two decisions that were retracted on evidence. This description is discarded on
merge.

## Which layer(s) does this PR touch?

- [x] `docs/DESIGN.md` (architecture)
- [x] `docs/IMPLEMENTATION.md` (code surface)
- [x] `orchestrator/leerie.py` (code)
- [x] docs / tests / CI

Propagated top-down: DESIGN → IMPLEMENTATION → code → tests.

## Checklist

- [ ] `pytest tests/` passes — **not run** (deliberately; targeted files only, per
      the reviewer's standing preference). What *was* run:
  - `tests/test_subfile_split_change_shape_gate.py` — 26 functions / 27 cases
  - the four touched test files — **55 passed**
  - the 15 files covering every touched function — **386 passed**
  - `ast.parse`, `test_no_undefined_names`, `test_prompts_have_no_foreign_identifiers`
- [x] `git diff --stat` reviewed for scope

## Reviewer notes

Two things worth a second pair of eyes:

1. **`change_shape` is REQUIRED on planner subtasks.** A planner that omits it
   fails schema validation and re-prompts. Deliberate — same reasoning as
   `migration_targets.is_real_identifier` — but it is the one change here that
   alters an existing worker contract.
2. **Tier-1 tiling is monkeypatched in tests, not exercised natively.**
   `HAS_TREESITTER` is False on the dev host this was written on but TRUE on CI
   (`requirements.txt` pins tree-sitter; `test.yml` installs it). tree-sitter
   could not be installed there to check directly (no pip/venv/uv/ensurepip), so
   the tier-1 tests stub `_extract_symbol_ranges` to be host-independent rather
   than depend on which parser happens to be present. **CI is the first real
   tier-1 run** — worth watching.

Also note what is *not* touched: `plan_overlap_judge`'s `_cofile_cluster`
exclusion. It correctly waived these siblings on its own recorded basis (it
reasons about line-range disjointness *in the split file*; the collision was in
a file none of them owned), and removing it re-opens the false-positive incident
it exists to prevent.

## Related issue

<!-- none -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
