### PR TITLE
docs: correct two prompt claims and one undocumented fallthrough from #248

### DIFF
--- a/docs/IMPLEMENTATION.md
+++ b/docs/IMPLEMENTATION.md
@@ -4759,6 +4759,17 @@ accept the subtask as leaf); then splits via one of:
   re-entry (tier-2) branch is deliberately **not** gated — a child carrying
   `owned_region` is already inside an approved sweep.
 
+  A gated subtask does **not** become a leaf here. `_subfile_split()` returning
+  `[]` is its "not a candidate" signal, so `_recursive_decompose()`'s `elif`
+  chain carries a single-file subtask onward to the coupled-minority `splitter`
+  worker, which costs one call before `prompts/splitter.md`'s "if you receive a
+  subtask listing a single file … return no children" makes it a leaf. Bounded
+  by `_bump_decompose_workers()` and identical to the path a single file *under*
+  the span cap already took. Short-circuiting to a leaf earlier was considered
+  and rejected: it would also skip the file-level migration/peel split for a
+  subtask a planner mislabels `point` while listing many files, trading a
+  bounded cost for an unbounded regression.
+
   **New-file ownership.** Region child index 0 is the designated new-file
   owner. Its criteria carry an explicit grant; every other child's criteria
   name that sibling's id and forbid creating new files. Deterministic, so the

--- a/prompts/fit_judge.md
+++ b/prompts/fit_judge.md
@@ -34,9 +34,15 @@ A subtask is **well-fit** when ALL of the following hold:
    single session even though it lists one file — the mirror image of a
    many-file sweep. Score such a subtask **under-fit** (below 0.70). You do
    not need to devise the split yourself: the orchestrator region-splits an
-   over-scoped single file deterministically once you score it under the
-   threshold. Judge honestly — a large, dense single file is a split
-   candidate, not an automatic leaf.
+   over-scoped single file deterministically, without asking you how.
+
+   That region split follows your under-fit score only when the planner
+   declared the subtask a `sweep`; a `point` or `localized` change stays a leaf
+   however large its file is, because tiling a one-site fix hands every region
+   a whole-file mandate only one of them can satisfy. This does not change how
+   you score. Judge the fit honestly on its own terms — a large, dense single
+   file is a split candidate, not an automatic leaf — and let the orchestrator
+   decide what to do with the score.
 
 5. **No hidden broad surface.** The subtask's intent does not implicitly
    require touching broad surfaces (e.g., "update all callers of foo()")

--- a/prompts/planner.md
+++ b/prompts/planner.md
@@ -82,16 +82,23 @@ The orchestrator gives you, in your prompt:
    dense file can be dominant; a 20-file rename is not.
 
    You do **not** need to worry about a single file being *too large to edit in
-   one session*. If a subtask's whole scope is one very large, edit-dense file
-   (many edit sites across thousands of lines), the orchestrator splits it
-   *within* the file — on function boundaries, and by line-window when a single
-   function is itself enormous — into region-scoped subtasks that each own part
-   of the file and run in parallel. So keep such a change as one coherent
-   subtask scoped to that file; note the density in `investigation_notes`. Do
-   **not** hand-split it into artificial "part 1 / part 2" subtasks or pad
-   `files_likely_touched` with unrelated files to make it look smaller — the
-   code-owned region split does this correctly and completely, and a manual
-   split only corrupts the partition.
+   one session*. If a subtask's whole scope is one very large file it is
+   genuinely **sweeping** — many edit sites across thousands of lines — the
+   orchestrator splits it *within* the file, on function boundaries and by
+   line-window when a single function is itself enormous, into region-scoped
+   subtasks that each own part of the file and run in parallel. So keep such a
+   change as one coherent subtask scoped to that file. Do **not** hand-split it
+   into artificial "part 1 / part 2" subtasks or pad `files_likely_touched` with
+   unrelated files to make it look smaller — the code-owned region split does
+   this correctly and completely, and a manual split only corrupts the
+   partition.
+
+   **What triggers that split is `change_shape`, not the file's size** (see
+   below). Only a `sweep` is tiled; a `point` or `localized` change stays one
+   subtask however large its file is. Declare it in `change_shape` — that is the
+   field the orchestrator reads. Describing the density in `investigation_notes`
+   is useful detail for the implementer, but prose is not a signal the
+   orchestrator can act on, so it never substitutes for the declaration.
 
    **Migration sweep.** When a subtask introduces a new pattern replacing
    an old one (a new accessor, a new seam, a new abstraction), quantify


### PR DESCRIPTION
## Summary

Prompt/documentation only, no code. Three claims that #248 (mine) made stale,
found on a later audit pass and wrong in ways CI cannot detect — no test pins
either sentence, both prompts carry existence checks only. Same shape as #247.

`prompts/*.md` is product surface — sent verbatim to a worker running against
whatever repo leerie was pointed at — so a prompt that misdescribes the
mechanism is a defect, not a cosmetic issue.

| where | claim | now |
|---|---|---|
| `prompts/planner.md` | sub-file split described as unconditional; density routed to `investigation_notes` **prose** | only a `sweep` is tiled; `change_shape` named as the deciding declaration (prose is what *Language-to-JSON* forbids the orchestrator from reading) |
| `prompts/fit_judge.md` | "region-splits … **once you score it under the threshold**" | states the condition, and that it does not change how the judge scores |
| `docs/IMPLEMENTATION.md` | gate's fallthrough undocumented | a gated subtask reaches the coupled-minority splitter (one call) before leafing; why short-circuiting was rejected |

The `fit_judge` one is the least cosmetic: that sentence is the stated
*rationale* for scoring a dense single file under-fit, so it argued for a score
on grounds that may no longer apply.

**The commit message is the permanent record** (single-commit PR, squash-merge
with `COMMIT_MESSAGES`); this description is discarded on merge.

## Which layer(s) does this PR touch?

- [ ] `docs/DESIGN.md` (architecture)
- [x] `docs/IMPLEMENTATION.md` (code surface)
- [ ] `orchestrator/leerie.py` (code)
- [x] docs / tests / CI

No behaviour change, so nothing to propagate downward — the code already
behaves as corrected; only the descriptions of it were wrong.

## Checklist

- [ ] `pytest tests/` passes — **not run** (targeted files only, per the
      reviewer's standing preference). What *was* run:
  - `tests/test_prompts_have_no_foreign_identifiers.py` — **59 passed** (the
    shipped-prompt guard, since two prompts change)
  - `tests/test_fit_judge_schema.py` + `tests/test_planner_extent_out_of_scope.py` — **36 passed**
  - the 15 files covering every function #248 touched — **386 passed**
- [x] `git diff --stat` reviewed for scope

## Note on #248

Its CI is now confirmed green — `test (3.10/3.11/3.12)` all pass, with
`tree-sitter-0.26.0` + `tree-sitter-language-pack-1.12.5` installed and no
"parser unavailable" skips, so tier-1 symbol tiling really did execute (8536
passed, 40 skipped). That was the open risk flagged in #248's body; it was
merged before those jobs finished.

## Related issue

<!-- follow-up to #248 -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
