### PR TITLE
leerie: Reframe README, DESIGN, and plugin manifests as graph engineering

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "name": "leerie",
       "source": ".",
       "version": "0.28.0",
-      "description": "Deterministic, headless task orchestrator for Claude Code. Classifies a task, decomposes it into dependency-ordered waves, and executes each subtask in an isolated git worktree under an evidence-gated implement/validate loop. Runs entirely on the Claude Code CLI/subscription via `claude -p` workers."
+      "description": "Graph-engineered task driver for Claude Code. Classifies a task, decomposes it into a dependency graph of granular subtasks, topo-sorts it into waves, and executes each node in an isolated git worktree under an evidence-gated implement/validate loop. Runs entirely on the Claude Code CLI/subscription via `claude -p` workers."
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "leerie",
   "displayName": "Leerie",
   "version": "0.28.0",
-  "description": "Deterministic, headless task orchestrator for Claude Code. Classifies a task, decomposes it into granular subtasks, schedules them into dependency-ordered waves, and executes each in an isolated git worktree under an evidence-gated implement/validate loop. Runs entirely on the Claude Code CLI/subscription via `claude -p` workers.",
+  "description": "Graph-engineered task driver for Claude Code. Classifies a task, decomposes it into a dependency graph of granular subtasks, topo-sorts it into waves, and executes each node in an isolated git worktree under an evidence-gated implement/validate loop. Runs entirely on the Claude Code CLI/subscription via `claude -p` workers.",
   "author": { "name": "Andres Restrepo", "email": "andres@enricai.com", "url": "https://enricai.com" },
   "license": "MIT",
   "homepage": "https://github.com/enricai/leerie",

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Leerie
 
-**Leerie** is an autonomous task driver for Claude Code. One prompt. Finished, committed, validated code. No steering mid-run, no polishing when it's done.
+**Leerie** is a graph-engineered task driver for Claude Code. One prompt. Finished, committed, validated code. No steering mid-run, no polishing when it's done.
 
-It classifies the task, decomposes it, implements each piece in parallel isolated worktrees, validates the integrated result, and merges — beginning to end, unattended.
+It classifies the task, decomposes it into subtasks wired into a dependency graph — nodes are subtasks, edges are `requires`/`provides` — then a deterministic Python scheduler topo-sorts that graph into waves, implements each wave in parallel isolated worktrees, validates the integrated result, and merges — beginning to end, unattended.
 
 It runs entirely on the **Claude Code CLI and your existing subscription** — no Anthropic API key, no per-call billing.
 
-**Why it finishes without you:** most AI "orchestrators" let the model pilot — decide what's next, declare when it's done, judge its own success. Leerie inverts that: **the model writes code, the program runs everything else.** Phases, scheduling, retries, caps, merge logic, and success-criteria enforcement are ordinary Python. Every worker output is JSON-schema-validated, and completion is gated by an independent adversarial verifier, not the implementer's self-report. See [`docs/DESIGN.md`](docs/DESIGN.md) for the full rationale.
+**Why it finishes without you:** most AI "orchestrators" let the model pilot — decide what's next, declare when it's done, judge its own success. Leerie inverts that: **the model writes code, the program runs everything else.** The graph — its structure, its scheduling, its edges — is owned by ordinary Python, not by agents negotiating with each other; workers are headless, one-shot `claude -p` calls at each node, not a multi-agent conversation. Phases, scheduling, retries, caps, merge logic, and success-criteria enforcement are ordinary Python. Every worker output is JSON-schema-validated, and completion is gated by an independent adversarial verifier, not the implementer's self-report. See [`docs/DESIGN.md`](docs/DESIGN.md) for the full rationale.
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Python 3.10+](https://img.shields.io/badge/Python-3.10%2B-blue.svg)](https://www.python.org/downloads/)

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -1,9 +1,9 @@
 # Leerie — Design Document
 
-> Deterministic, headless task orchestrator for Claude Code. Classifies an
-> engineering task, decomposes it into granular subtasks, schedules them into
-> dependency-ordered waves, and executes each in an isolated git worktree
-> under an evidence-gated implement/validate loop — with the fewest possible
+> Graph-engineered task driver for Claude Code. Classifies an engineering
+> task, decomposes it into a dependency graph of granular subtasks, topo-sorts
+> it into waves, and executes each node in an isolated git worktree under an
+> evidence-gated implement/validate loop — with the fewest possible
 > interruptions to the user.
 
 **Scope of this document.** This is the *theory*: the architecture, the


### PR DESCRIPTION
## Summary

Repositions leerie's pitch around its dependency-graph structure — subtasks as nodes, `requires`/`provides` as edges, a deterministic topo-sort into waves — rather than "task orchestrator" language, and updates README.md, docs/DESIGN.md, and both plugin manifests to match.

## Which layer(s) does this PR touch?

(See [`CLAUDE.md`](../CLAUDE.md) for the three-layer rule.)

- [x] `docs/DESIGN.md` (architecture)
- [ ] `docs/IMPLEMENTATION.md` (code surface)
- [ ] `orchestrator/leerie.py` (code)
- [x] docs / tests / CI

If multiple, has the change propagated top-down (DESIGN → IMPLEMENTATION → code)?

Yes. README's pitch and both plugin manifest descriptions were reframed first, then DESIGN.md's opening blurb was brought into line with the same graph-engineering language via a conformer pass. No IMPLEMENTATION.md or code-surface change was needed — this is prose only.

## Checklist

- [ ] `pytest tests/` passes
- [x] `git diff --stat` reviewed for scope

## Related issue

<!-- Closes #N -->

## Conformance notes

- tests: `pytest`: bash: line 1: pytest: command not found
- warning: tests-failed: 'pytest': bash: line 1: pytest: command not found
