### PR TITLE
leerie: Reframe repo as a graph engineering framework in DESIGN.md and CLI docstring

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -25,6 +25,17 @@ impossible to derive. Every loop is bounded, every decision is made from the
 codebase or research, and state is kept on disk so a run is observable and
 resumable.
 
+**On the term "graph engineering."** Leerie's task graph is literal, not
+metaphorical: nodes are subtasks, edges are `requires`/`provides`
+dependencies, and topology is topo-sorted into waves — see §5. "Graph
+engineering" (design the topology a multi-agent system runs in, as opposed
+to "loop engineering," the single-agent-loop layer below it) is recent
+industry framing, and some treat it as a rebrand of pre-existing
+DAG/dataflow orchestration rather than a new discipline; we take no
+position on that debate. Where Leerie departs from most systems using the
+term: the graph is authored and scheduled by ordinary Python before any
+worker runs, not negotiated by agents routing at runtime (§12).
+
 ---
 
 ## 2. The two constraints that produced this architecture

--- a/orchestrator/leerie.py
+++ b/orchestrator/leerie.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Leerie — deterministic task orchestrator for Claude Code.
+Leerie — graph-engineered task driver for Claude Code.
 
 Runs entirely on the Claude Code CLI / subscription. Every unit of LLM work is
 a `claude -p` headless invocation. This script owns ALL control flow — phase


### PR DESCRIPTION
## Summary

Positions Leerie as a graph engineering framework: grounds the term in DESIGN.md as a literal (not metaphorical) description of Leerie's task graph, and updates the `leerie.py` module docstring (the `--help` description) to match the wording already used in README.md/DESIGN.md/plugin.json.

## Which layer(s) does this PR touch?

(See [`CLAUDE.md`](../CLAUDE.md) for the three-layer rule.)

- [x] `docs/DESIGN.md` (architecture)
- [ ] `docs/IMPLEMENTATION.md` (code surface)
- [x] `orchestrator/leerie.py` (code)
- [ ] docs / tests / CI

If multiple, has the change propagated top-down (DESIGN → IMPLEMENTATION → code)? Yes: DESIGN.md §1 gains a grounding paragraph defining nodes/edges/topology and the exception versus multi-agent conversational graph-orchestration frameworks (the graph is authored and scheduled by ordinary Python, not negotiated by agents at runtime), and `leerie.py`'s docstring is updated to match — a wording-only change with no logic impact, so IMPLEMENTATION.md needed no update.

## Checklist

- [ ] `pytest tests/` passes
- [x] `git diff --stat` reviewed for scope

## Conformance notes

- tests-failed: `pytest`: bash: line 1: pytest: command not found
- rule-residual: 'build/lint/tests must pass' not fixed — pytest is not on PATH in this environment; BLT_RESULTS reports COULD NOT MEASURE and no baseline exists for tests, so this cannot be attributed as a regression from this diff. The touched code is a one-line docstring string change with no logic impact.

## Related issue

<!-- Closes #N -->
