### PR TITLE
leerie: Advertise Sonnet-5-only workers and subscription token savings in docs

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "name": "leerie",
       "source": ".",
       "version": "0.28.0",
-      "description": "Graph-engineered task driver for Claude Code. Classifies a task, decomposes it into a dependency graph of granular subtasks, topo-sorts it into waves, and executes each node in an isolated git worktree under an evidence-gated implement/validate loop. Runs entirely on the Claude Code CLI/subscription via `claude -p` workers."
+      "description": "Graph-engineered task driver for Claude Code. Classifies a task, decomposes it into a dependency graph of granular subtasks, topo-sorts it into waves, and executes each node in an isolated git worktree under an evidence-gated implement/validate loop. Runs entirely on the Claude Code CLI/subscription via `claude -p` workers. Sonnet-only, saving subscription tokens over an Opus-heavy pipeline."
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "leerie",
   "displayName": "Leerie",
   "version": "0.28.0",
-  "description": "Graph-engineered task driver for Claude Code. Classifies a task, decomposes it into a dependency graph of granular subtasks, topo-sorts it into waves, and executes each node in an isolated git worktree under an evidence-gated implement/validate loop. Runs entirely on the Claude Code CLI/subscription via `claude -p` workers.",
+  "description": "Graph-engineered task driver for Claude Code. Classifies a task, decomposes it into a dependency graph of granular subtasks, topo-sorts it into waves, and executes each node in an isolated git worktree under an evidence-gated implement/validate loop. Runs entirely on the Claude Code CLI/subscription via `claude -p` workers. Sonnet-only, saving subscription tokens over an Opus-heavy pipeline.",
   "author": { "name": "Andres Restrepo", "email": "andres@enricai.com", "url": "https://enricai.com" },
   "license": "MIT",
   "homepage": "https://github.com/enricai/leerie",

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 It classifies the task, decomposes it into subtasks wired into a dependency graph — nodes are subtasks, edges are `requires`/`provides` — then a deterministic Python scheduler topo-sorts that graph into waves, implements each wave in parallel isolated worktrees, validates the integrated result, and merges — beginning to end, unattended.
 
-It runs entirely on the **Claude Code CLI and your existing subscription** — no Anthropic API key, no per-call billing.
+It runs entirely on the **Claude Code CLI and your existing subscription** — no Anthropic API key, no per-call billing. Every worker, judgment and implementer alike, runs on **Sonnet 5**, so a run burns subscription usage rather than metered API tokens.
 
 **Why it finishes without you:** most AI "orchestrators" let the model pilot — decide what's next, declare when it's done, judge its own success. Leerie inverts that: **the model writes code, the program runs everything else.** The graph — its structure, its scheduling, its edges — is owned by ordinary Python, not by agents negotiating with each other; workers are headless, one-shot `claude -p` calls at each node, not a multi-agent conversation. Phases, scheduling, retries, caps, merge logic, and success-criteria enforcement are ordinary Python. Every worker output is JSON-schema-validated, and completion is gated by an independent adversarial verifier, not the implementer's self-report. See [`docs/DESIGN.md`](docs/DESIGN.md) for the full rationale.
 

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -23,7 +23,10 @@ Given one task description, Leerie drives it to a validated, integrated
 result without further human input except where input is genuinely
 impossible to derive. Every loop is bounded, every decision is made from the
 codebase or research, and state is kept on disk so a run is observable and
-resumable.
+resumable. Every worker — judgment and workhorse alike — runs on Sonnet 5 (§12
+*Opus-judgment, sonnet-workhorse*); a many-worker graph stays cheap against
+a subscription instead of accumulating per-call API charges the way a
+fleet of Opus-tier agents would.
 
 **On the term "graph engineering."** Leerie's task graph is literal, not
 metaphorical: nodes are subtasks, edges are `requires`/`provides`

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -24,9 +24,9 @@ result without further human input except where input is genuinely
 impossible to derive. Every loop is bounded, every decision is made from the
 codebase or research, and state is kept on disk so a run is observable and
 resumable. Every worker — judgment and workhorse alike — runs on Sonnet 5 (§12
-*Opus-judgment, sonnet-workhorse (historical)*); a many-worker graph stays
-cheap against a subscription instead of accumulating per-call API charges
-the way a fleet of Opus-tier agents would.
+*Opus-judgment, sonnet-workhorse (historical) — now sonnet for both*); a
+many-worker graph stays cheap against a subscription instead of accumulating
+per-call API charges the way a fleet of Opus-tier agents would.
 
 **On the term "graph engineering."** Leerie's task graph is literal, not
 metaphorical: nodes are subtasks, edges are `requires`/`provides`

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -24,9 +24,9 @@ result without further human input except where input is genuinely
 impossible to derive. Every loop is bounded, every decision is made from the
 codebase or research, and state is kept on disk so a run is observable and
 resumable. Every worker — judgment and workhorse alike — runs on Sonnet 5 (§12
-*Opus-judgment, sonnet-workhorse*); a many-worker graph stays cheap against
-a subscription instead of accumulating per-call API charges the way a
-fleet of Opus-tier agents would.
+*Opus-judgment, sonnet-workhorse (historical)*); a many-worker graph stays
+cheap against a subscription instead of accumulating per-call API charges
+the way a fleet of Opus-tier agents would.
 
 **On the term "graph engineering."** Leerie's task graph is literal, not
 metaphorical: nodes are subtasks, edges are `requires`/`provides`

--- a/orchestrator/leerie.py
+++ b/orchestrator/leerie.py
@@ -2,10 +2,12 @@
 """
 Leerie — graph-engineered task driver for Claude Code.
 
-Runs entirely on the Claude Code CLI / subscription. Every unit of LLM work is
-a `claude -p` headless invocation. This script owns ALL control flow — phase
-sequencing, wave scheduling, caps, retries, integration — in real Python, so
-the orchestration cannot drift the way an LLM-driven controller can.
+Runs entirely on the Claude Code CLI / subscription, every worker defaulting
+to Sonnet 5 (no opus tier) to keep subscription token usage down. Every unit
+of LLM work is a `claude -p` headless invocation. This script owns ALL control
+flow — phase sequencing, wave scheduling, caps, retries, integration — in real
+Python, so the orchestration cannot drift the way an LLM-driven controller
+can.
 
 Each worker is a separate `claude -p` process, so there is no subagent nesting
 anywhere. The script is the orchestrator; each `claude -p` call is a leaf.


### PR DESCRIPTION
## Summary

Adds messaging across README, DESIGN, module docstring, and plugin manifests that leerie runs entirely on Sonnet 5 — no Opus tier — so a run stays cheap against a Claude Code subscription instead of accumulating per-call API charges.

## Which layer(s) does this PR touch?

(See [`CLAUDE.md`](../CLAUDE.md) for the three-layer rule.)

- [x] `docs/DESIGN.md` (architecture)
- [ ] `docs/IMPLEMENTATION.md` (code surface)
- [x] `orchestrator/leerie.py` (code)
- [x] docs / tests / CI

Documentation-only change: README, DESIGN.md, the `leerie.py` module docstring, and both plugin manifest descriptions were each updated with a one-line addition; no propagation was needed since no behavior changed.

## Checklist

- [ ] `pytest tests/` passes
- [x] `git diff --stat` reviewed for scope

## Related issue

<!-- Closes #N -->

## Conformance notes

- tests: `pytest: command not found` — pytest was not available in the conformance environment; run `pytest tests/` before merge.
