### PR TITLE
leerie: Declare under_scope_warnings in STATE_FIELDS (repairs red main)

### DIFF
--- a/orchestrator/leerie.py
+++ b/orchestrator/leerie.py
@@ -438,7 +438,7 @@ STATE_FIELDS = (
     # silent containment failure — this makes it visible in state.json.
     "cgroup_containment",
     "verbosity", "inspect_dirs",
-    "integrator_warnings", "scope_warnings",
+    "integrator_warnings", "scope_warnings", "under_scope_warnings",
     # Per-run memo of orchestrator-measured build/lint/test verdicts, keyed
     # by (axis, command, tree sha) — see `_measure_axes`. Deliberately placed
     # BEFORE `conformance` rather than between it and `unreviewed_subtasks`:


### PR DESCRIPTION
`main` is red. #255 added a new run-state key and updated only one of the two
places the repo requires it to be declared.

## What failed

```
FAILED tests/test_state_fields.py::test_state_fields_matches_spec_table
FAILED tests/test_state_fields.py::test_every_st_data_write_is_declared
2 failed, 8582 passed
```

Nothing else. `check_diff_scope` writes `st.data["under_scope_warnings"]`
(the under-scope half of the diff-scope check, added in #255). The
IMPLEMENTATION.md §8 field-table row landed; the `STATE_FIELDS` entry did not.
`tests/test_state_fields.py` enforces both halves symmetrically.

## The fix

One line — the missing name, beside its sibling `scope_warnings`:

```python
"integrator_warnings", "scope_warnings", "under_scope_warnings",
```

## How it got through

Not a CI-only failure: **it reproduces locally in 1.2 s.** #255 was validated
with `-k` filters shaped after the feature (`duplicate or overlap or scope or
finalize`), and `scope` selects `test_check_diff_scope_uses_run_branch.py` but
never `test_state_fields.py`.

The generalisable point: guards named after a **mechanism** — `STATE_FIELDS`,
`DISALLOWED_TOOLS`, the launcher's `_value_flags` — share no keyword with the
feature under change, so a feature-shaped filter cannot select them. Two of
the three defects caught while preparing #255 came from exactly that kind of
guard.

Verified here with the full suite, not a filtered subset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
