### PR TITLE
test: cover the two v0.29.0 paths a normal run cannot reach

### DIFF
--- a/tests/test_finalize_execution.py
+++ b/tests/test_finalize_execution.py
@@ -354,6 +354,130 @@ def _finalize_ready_state(st):
     st.data["working_branch"] = "main"
 
 
+@pytest.fixture(scope="session")
+def pristine_run_proc(leerie):
+    """leerie's genuine `run_proc`, captured before this module's autouse
+    stub can replace it.
+
+    Session-scoped on purpose: higher-scoped fixtures are instantiated
+    before the function-scoped autouse `_stub_finalize_subprocesses`, so
+    this sees the real attribute. A test that wants the real git call back
+    re-installs this over the stub.
+    """
+    return leerie.run_proc
+
+
+class TestEmptyRunBranchAgainstRealGit:
+    """The same disposition as `TestEmptyRunBranchIsNoWorkNotAnError`, but
+    with the REAL `git rev-list` running against a REAL repository.
+
+    That distinction is the whole point of this class. The sibling class
+    stubs `run_proc` wholesale, so the git command never executes — and the
+    command is precisely where the defect lived: the guard originally ran in
+    `leerie_dir` (the STATE root, not a git repo at all), which made it fail
+    open and never fire, except when the state root happened to sit inside
+    the repo. No stubbed test can catch that, because a stub answers
+    regardless of the directory it was asked from.
+    """
+
+    @staticmethod
+    def _make_run_branch(repo, ahead: int):
+        """Create `leerie/runs/r1` either equal to main or `ahead` commits
+        past it, using real git."""
+        _run(["git", "branch", "-f", "leerie/runs/r1", "main"], repo)
+        for i in range(ahead):
+            _run(["git", "checkout", "-q", "leerie/runs/r1"], repo)
+            (repo / f"landed{i}.txt").write_text(f"work {i}\n")
+            _run(["git", "add", "-A"], repo)
+            _run(["git", "commit", "-qm", f"work {i}"], repo)
+            _run(["git", "checkout", "-q", "main"], repo)
+
+    @staticmethod
+    def _install_real_git(monkeypatch, leerie, pristine_run_proc, scripts,
+                          repo):
+        """Real `run_proc`; only the shell scripts stay stubbed.
+
+        `chdir(repo)` mirrors production: leerie runs with the process cwd
+        set to the target repo, which is what `_run_script` relies on
+        (`cwd=os.getcwd()`) and what phase_finalize's post-cleanup
+        `git show-ref` — which passes no explicit cwd — resolves against.
+        Without it the real git calls would resolve against pytest's own
+        cwd and fail for reasons that have nothing to do with the guard.
+        """
+        monkeypatch.chdir(repo)
+
+        async def _fake_run_script(name, *args):
+            scripts.append(name)
+            return subprocess.CompletedProcess(["bash", name], 0, "", "")
+
+        async def _fake_compose(*a, **k):
+            return None
+
+        monkeypatch.setattr(leerie, "run_proc", pristine_run_proc)
+        monkeypatch.setattr(leerie, "_run_script", _fake_run_script)
+        monkeypatch.setattr(leerie, "_compose_pr_via_llm", _fake_compose)
+
+    def test_real_empty_branch_routes_to_no_work(
+            self, leerie, monkeypatch, st, repo, pristine_run_proc):
+        self._make_run_branch(repo, ahead=0)
+        scripts = []
+        self._install_real_git(monkeypatch, leerie, pristine_run_proc,
+                               scripts, repo)
+        _finalize_ready_state(st)
+
+        asyncio.run(leerie.phase_finalize(
+            st.leerie_root, st, no_push=True, no_verify=False,
+            caps=_caps(leerie), models={}, efforts={}))
+
+        assert st.data["current_phase"] == "done: no work required"
+        assert st.data["no_work_required"] is True
+        assert "finalize.sh" not in scripts
+        assert "cleanup.sh" in scripts
+
+    def test_real_nonempty_branch_finalizes_normally(
+            self, leerie, monkeypatch, st, repo, pristine_run_proc):
+        """The dangerous direction: a false positive here would discard a
+        completed run as 'no work required'."""
+        self._make_run_branch(repo, ahead=2)
+        scripts = []
+        self._install_real_git(monkeypatch, leerie, pristine_run_proc,
+                               scripts, repo)
+        _finalize_ready_state(st)
+
+        asyncio.run(leerie.phase_finalize(
+            st.leerie_root, st, no_push=True, no_verify=False,
+            caps=_caps(leerie), models={}, efforts={}))
+
+        assert st.data["current_phase"] == "phase 6: finalize"
+        assert not st.data.get("no_work_required")
+        assert "finalize.sh" in scripts
+
+    def test_guard_reads_the_repo_not_the_state_root(
+            self, leerie, monkeypatch, st, repo, pristine_run_proc):
+        """Pins the cwd fix directly. `st.leerie_root` is a plain directory
+        under tmp_path with no `.git`, so a guard that ran there would get a
+        non-zero returncode, fail open, and reach `finalize.sh` even though
+        the branch is genuinely empty. Asserting the no-work disposition on
+        an empty branch therefore proves the count was taken in the repo.
+        """
+        self._make_run_branch(repo, ahead=0)
+        assert not (st.leerie_root / ".git").exists(), (
+            "precondition: the state root must NOT be a git repo, or this "
+            "test cannot distinguish the two directories")
+        scripts = []
+        self._install_real_git(monkeypatch, leerie, pristine_run_proc,
+                               scripts, repo)
+        _finalize_ready_state(st)
+
+        asyncio.run(leerie.phase_finalize(
+            st.leerie_root, st, no_push=True, no_verify=False,
+            caps=_caps(leerie), models={}, efforts={}))
+
+        assert st.data["no_work_required"] is True, (
+            "guard did not see the empty branch — it likely ran outside "
+            "st.repo_root and failed open")
+
+
 class TestEmptyRunBranchIsNoWorkNotAnError:
     """Corpus runs `d1987e8b` ($9.68) and `05f65221` ($3.03) reached finalize
     with every subtask `complete` and a run branch carrying no commits, and

--- a/tests/test_main_exception_arms.py
+++ b/tests/test_main_exception_arms.py
@@ -343,6 +343,115 @@ class TestRateLimitedExit:
         assert slept["wait"] > 0
 
 
+class TestRateLimitEventWireFormatToPause:
+    """The wire-format -> exception -> handler chain, end to end.
+
+    Every other test in this file CONSTRUCTS `RateLimitedExit` by hand, so
+    the step that actually parses Claude Code's stream JSON has never been
+    exercised together with the handler that acts on it. A field renamed in
+    `_summarize_stream_event`'s parser (or a `limit_type` that silently
+    stops being populated) would leave all of those green while the real
+    pause path stopped working.
+
+    The payload shape below is not invented: `leerie.py`'s parser documents
+    it as verified from captured worker logs, and the 0.28.0 run corpus
+    contains real instances of exactly this triple, e.g.
+    `rate_limit_event status=rejected rateLimitType=five_hour resetsAt=...`.
+    """
+
+    @staticmethod
+    def _event(limit_type, offset_hours):
+        import time
+        return {"type": "rate_limit_event",
+                "rate_limit_info": {
+                    "status": "rejected",
+                    "rateLimitType": limit_type,
+                    "resetsAt": int(time.time()) + int(offset_hours * 3600)}}
+
+    def test_parser_raises_with_limit_type_and_reset_at(self, leerie):
+        """Parse, don't construct."""
+        with pytest.raises(leerie.RateLimitedExit) as ei:
+            leerie._summarize_stream_event(
+                "feat-001", self._event("seven_day", 48), "stream")
+        exc = ei.value
+        assert exc.limit_type == "seven_day"
+        assert exc.out_of_credits is False
+        assert exc.reset_at is not None
+        delta = (exc.reset_at
+                 - leerie.datetime.now(leerie.timezone.utc)).total_seconds()
+        assert 47 * 3600 < delta < 49 * 3600, (
+            f"resetsAt did not round-trip into reset_at: {exc.reset_at}")
+
+    @pytest.mark.parametrize("status", ["allowed", "allowed_warning"])
+    def test_allowed_statuses_do_not_raise(self, leerie, status):
+        """The negative direction: a normal utilization event must not be
+        mistaken for a rejection, or every run would pause at the first
+        threshold crossing."""
+        ev = self._event("five_hour", 3)
+        ev["rate_limit_info"]["status"] = status
+        leerie._summarize_stream_event("feat-001", ev, "stream")
+
+    def test_parsed_exception_drives_the_pause(self, leerie, monkeypatch,
+                                               repo):
+        """The whole chain: the parser's own exception object is what
+        reaches `main()`'s handler. A 48h reset exceeds the 6h default
+        ceiling, so the disposition must be the resumable pause."""
+        parsed = {}
+        try:
+            leerie._summarize_stream_event(
+                "feat-001", self._event("seven_day", 48), "stream")
+        except leerie.RateLimitedExit as e:
+            parsed["exc"] = e
+        assert "exc" in parsed, "parser did not raise — chain is broken"
+
+        def _must_not_sleep(st, wait_seconds, reason):
+            raise AssertionError(f"slept {wait_seconds}s instead of pausing")
+
+        monkeypatch.setattr(leerie, "_sleep_then_reexec", _must_not_sleep)
+
+        async def _boom(*a, **kw):
+            raise parsed["exc"]
+
+        exit_code, run_dir = _run_main(
+            leerie, monkeypatch, repo, "main-rl-wire-format",
+            orchestrate_stub=_boom)
+
+        assert exit_code == leerie.EXIT_LOCKED
+        assert isinstance(_state_json(run_dir), dict)
+
+    def test_parsed_five_hour_within_ceiling_still_sleeps(
+            self, leerie, monkeypatch, repo):
+        """Same chain, bounded window: a 2h five-hour reset is under the
+        default ceiling and must auto-resume, not pause. Makes the two
+        wire-format cases DISAGREE, so a handler ignoring `reset_at`
+        entirely cannot pass both."""
+        try:
+            leerie._summarize_stream_event(
+                "feat-001", self._event("five_hour", 2), "stream")
+            raise AssertionError("parser did not raise")
+        except leerie.RateLimitedExit as e:
+            parsed = e
+
+        slept = {}
+
+        def _record(st, wait_seconds, reason):
+            slept["wait"] = wait_seconds
+            return 130
+
+        monkeypatch.setattr(leerie, "_sleep_then_reexec", _record)
+
+        async def _boom(*a, **kw):
+            raise parsed
+
+        exit_code, _ = _run_main(
+            leerie, monkeypatch, repo, "main-rl-wire-five-hour",
+            orchestrate_stub=_boom)
+
+        assert exit_code == 130
+        assert slept["wait"] > 3600, (
+            f"expected a ~2h wait, got {slept.get('wait')}")
+
+
 class TestRateLimitWaitCapResolution:
     """CLI > env > leerie.toml > DEFAULT_CAPS, the same ladder
     `resolve_worker_timeout_sec` uses."""


### PR DESCRIPTION
Closes the two coverage gaps left by #255. **Test-only — no production code
is touched.**

Both fixes shipped in `v0.29.0` without production exposure: an empty run
branch at finalize needs every subtask to complete with zero commits, and the
rate-limit ceiling needs a reset further out than the cap. A live run on an
external repo exercised the other changes but could not create either
condition.

## 1. Real git, not a stub

`TestEmptyRunBranchIsNoWorkNotAnError` stubs `run_proc` wholesale, so the real
`git rev-list` never runs — and that command is where the defect lived. The
guard originally ran in `leerie_dir` (the **state** root, not a git repo under
`LEERIE_STATE_DIR`), failed open, and never fired except when the state root
happened to sit inside the repo.

A stub cannot catch that: it answers the same regardless of which directory it
was asked from.

**Ablation proves the difference.** Restoring `cwd=str(leerie_dir)`:

| | result |
|---|---|
| new real-git tests | **RED** ✅ catches it |
| existing stubbed tests | green ❌ blind to it |

## 2. Wire format, not a hand-built exception

Every existing rate-limit test **constructs** `RateLimitedExit` directly, so
the parser that reads Claude Code's stream JSON has never run together with
the handler that acts on it. A renamed field would leave them all green while
the pause path silently broke.

The payload isn't invented — the parser documents the shape as verified from
captured worker logs, and the 0.28.0 corpus holds real instances of the same
triple (`status=rejected rateLimitType=five_hour resetsAt=<unix>`).

Two cases deliberately **disagree** on the same wire format — a 48h
`seven_day` reset must pause, a 2h `five_hour` reset must still sleep — so a
handler ignoring `reset_at` cannot pass both. Ablating the `limit_type`
plumbing turns the parser test red; the ceiling tests correctly stay green,
since the ceiling keys on the computed wait, not the type name.

Also pinned: `allowed` / `allowed_warning` must **not** raise, or a routine
utilization event would pause every run at its first threshold crossing.

## Verification

`test_finalize_execution.py` (35) and `test_main_exception_arms.py` (27) pass;
80 together with `test_state_fields.py` and `test_no_undefined_names.py` — the
mechanism-named guards a feature-shaped `-k` filter doesn't select, which is
how #255 reached `main` red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
