### PR TITLE
leerie: Fix leerie hanging on exit after a run finishes

### DIFF
--- a/docs/IMPLEMENTATION.md
+++ b/docs/IMPLEMENTATION.md
@@ -559,8 +559,11 @@ ulimit -c 0
 # $CGROUP_ROOT/leerie.slice …
 # Launch the cgroup broker before the privilege drop (worker cgroup
 # enrollment/limit-setting can't be done by the dropped-privilege
-# orchestrator), telling it which root to operate under:
-LEERIE_CGROUP_V2_ROOT="$CGROUP_ROOT" python3 /opt/leerie-image/scripts/cgroup-broker.py &
+# orchestrator), telling it which root to operate under. Stdio is
+# redirected away from PID 1's inherited fds so the broker can't hold
+# the container's output pipe open past PID 1's own exit:
+LEERIE_CGROUP_V2_ROOT="$CGROUP_ROOT" python3 /opt/leerie-image/scripts/cgroup-broker.py \
+  </dev/null >>/tmp/cgroup-broker.log 2>&1 &
 cd /work
 # … /work ownership fix (Fly volume-attach path) …
 # … /tmp/.cache ownership fix (Fly rootfs preserves root-owned mise cache) …

--- a/docs/IMPLEMENTATION.md
+++ b/docs/IMPLEMENTATION.md
@@ -2870,7 +2870,13 @@ Each worker is one `claude -p` headless process. Flags used:
 `_invoke()`, which spawns the worker via the `run_proc` helper
 (`asyncio.create_subprocess_exec` + `communicate()` with an optional timeout).
 Shell scripts in `scripts/*.sh` are invoked via `_run_script()`, a thin async
-wrapper that resolves the script path and forwards to `run_proc`.
+wrapper that resolves the script path and forwards to `run_proc` with an
+explicit `timeout=RUN_SCRIPT_TIMEOUT` (600s) — a backstop against a
+regressed script hanging the orchestrator forever, distinct from any
+timeout the script itself enforces internally. Both `phase_finalize`
+call sites that invoke `cleanup.sh` catch the resulting
+`subprocess.TimeoutExpired` and log-and-continue, the same best-effort
+disposition as `_record_run_health` in that function.
 
 The validated payload is read from `structured_output` on the envelope. On a
 missing or schema-invalid payload, `claude_p()` retries once with the violation
@@ -4115,11 +4121,19 @@ run branch, per-subtask branches, and implementer checkpoints all
 survive**; only worktrees are removed (and re-created idempotently on
 `resume` via `scripts/new-worktree.sh`).
 
-Per-worktree removal has a 240s timeout (a large worktree can be hundreds
-of MB / tens of thousands of files under N-way concurrent disk
-contention). Failures are non-fatal and counted; if any failed, cleanup
-logs a pointer to `scripts/cleanup.sh --run-id <id>` to finish manually —
-best-effort, a stale worktree is the worst case, not a corrupted run.
+Worktree removal has a 240s timeout **shared across the whole loop**, not
+re-granted per entry: a single deadline is computed once at loop entry
+(`time.monotonic() + 240`), and each `git worktree remove` call gets
+whatever budget remains until that deadline (a large worktree can be
+hundreds of MB / tens of thousands of files under N-way concurrent disk
+contention). Once the shared budget is exhausted, remaining entries skip
+the `git worktree remove` call and go straight to the `rm -rf` fallback —
+worktrees under one run typically share the same underlying stall (all
+removed from the same bind-mounted `.git`), so a fixed *per-entry* 240s
+would let one stall cost 240s times the worktree count. Failures are
+non-fatal and counted; if any failed, cleanup logs a pointer to
+`scripts/cleanup.sh --run-id <id>` to finish manually — best-effort, a
+stale worktree is the worst case, not a corrupted run.
 
 Per-worker `subprocess.TimeoutExpired` from `_invoke` (`worker_timeout_sec`,
 default 5400s/90min) is caught by both `_run_implementer` (returns an

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -414,6 +414,23 @@ calls `_mark_reapable` (the fix is inert without the wiring), and
 guards that `main()` calls `_become_subreaper()` and `_orchestrate()`
 spawns+cancels `_zombie_reaper`.
 
+`_orchestrate()`'s own `finally` block (leerie:32599-32660 — cancels
+`sampler_task`/`reaper_task` and, when `force_strict_output` is set, stops
+`_StrictOutputProxy`) is bounded end-to-end in
+`tests/test_orchestrate_cleanup_bound.py`: `_memory_sampler`/`_zombie_reaper`
+are replaced with a `while True: await asyncio.sleep(9999)` double so only
+prompt cancellation (not a short default `interval_sec`) lets
+`asyncio.run(_orchestrate(...))` return, across all 4 combinations of
+`_run_phases` returning normally vs. raising `WorkerError`, and plain vs.
+`force_strict_output=True` (which additionally asserts `_STRICT_PROXY` is
+cleared). The wall-clock ceiling is backstopped by a `SIGALRM`-based hard
+timeout rather than `asyncio.wait_for`, since `wait_for`'s own cancellation
+lands inside the same `contextlib.suppress(asyncio.CancelledError)` the
+regression class already defeats and would hang right along with it. An
+`entered` list asserts each double actually reached its sleep before being
+cancelled, so a double cancelled pre-schedule can't pass the test
+vacuously.
+
 ## PENDING_ISSUES.md follow-up surfaces
 
 Three further surfaces arrived with the `PENDING_ISSUES.md` work order,

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -3492,6 +3492,21 @@ rather than guarded — coverage is now `task_coverage_judge`'s job, so the
 freeze class cannot recur. `TestBothRootCausesComposeOnOnePayload` runs both
 halves against the same fixtures in one test.
 
+## Piped/decoupled-streaming exit path: wall-clock hang bound
+
+`tests/test_decoupled_streaming_hang_bound.py` covers a gap
+`test_log_file_persistence.py`/`test_log_file_wiring.py` leave open: both
+of those use a `nerdctl` stub that writes and returns synchronously, so
+neither ever exercises a background process that keeps the container's
+stdout stream open past the stub's own exit -- the SSH-mux / broker
+failure mode the file-based `_run_log` + launcher-owned `tail -f` design
+(leerie:8811-8826) exists to route around. This test's stub forks a
+detached grandchild that inherits stdout and sleeps well past the
+harness's own completion, then asserts the harness still returns well
+under a fixed wall-clock ceiling -- proving a lingering fd-holder can't
+block the harness because `_run_log` redirects to a plain file, not a
+pipe.
+
 ## Lessons worth keeping
 
 **A handler must survive its own exception, not merely catch it.** `main()`'s

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -3507,6 +3507,24 @@ under a fixed wall-clock ceiling -- proving a lingering fd-holder can't
 block the harness because `_run_log` redirects to a plain file, not a
 pipe.
 
+## Interactive (`-it`, `script`(1)-teed) exit path: wall-clock hang bound
+
+`tests/test_interactive_script_hang_bound.py` closes the same class of gap
+against the interactive branch (leerie:8877-8886, the non-Darwin
+`script -qe -c "$_nerdctl_run_quoted" -a "$_log_tee_target"` block) that
+`tests/test_decoupled_streaming_hang_bound.py` closed for `_run_log`.
+DESIGN.md:2613-2614 asserts the interactive path "has a real pty and thus
+no hang," but `test_log_file_wiring.py`'s existing interactive coverage
+(`test_interactive_tty_path_is_teed_via_script` et al.) only proves the
+teed output is byte-correct with a `nerdctl` stub that writes and returns
+synchronously -- it never puts the `script`(1) pty allocation itself
+under the lingering-background-holder condition DESIGN.md's own hang
+writeup describes. This test's stub backgrounds a detached grandchild
+that inherits the `script`-allocated pty as its stdout and sleeps well
+past the stub's own exit, then asserts the harness still returns under a
+fixed wall-clock ceiling -- putting the pty's claimed hang-proofing under
+the same adversarial load, rather than merely asserting it by argument.
+
 ## Lessons worth keeping
 
 **A handler must survive its own exception, not merely catch it.** `main()`'s

--- a/orchestrator/leerie.py
+++ b/orchestrator/leerie.py
@@ -3893,31 +3893,45 @@ def _cleanup_on_abnormal_exit(st: "State", *, full_purge: bool) -> None:
     if full_purge or has_worktrees:
         log(f"cleanup: {'full purge' if full_purge else 'worktrees only'} "
             f"for run {st.run_id}")
-    # Remove worktrees. The 240s timeout is calibrated for realistic
-    # worker workloads: a 868 MB / 41k-file worktree (npm install +
-    # Next.js build) takes ~45-90s uncontested; under N-way concurrent
-    # cleanup (e.g. 6 worktrees from a multi-subtask wave), per-worktree
-    # time grows several-fold via disk contention. 240s covers the
-    # observed worst-case + room for a 2-3 GB monorepo. Still bounded
-    # so a genuinely hung git command (not just a slow rm-rf) doesn't
-    # block cleanup indefinitely. Per-worktree failures are non-fatal —
-    # the loop logs and continues — and a closing recovery-hint line
-    # tells the user how to finish manually.
+    # Remove worktrees. 240s is calibrated for realistic worker workloads:
+    # a 868 MB / 41k-file worktree (npm install + Next.js build) takes
+    # ~45-90s uncontested; under N-way concurrent cleanup (e.g. 6 worktrees
+    # from a multi-subtask wave), per-worktree time grows several-fold via
+    # disk contention. 240s covers the observed worst-case + room for a
+    # 2-3 GB monorepo for a SINGLE worktree — but all worktrees under one
+    # run typically share the same underlying stall (they're all removed
+    # from the same bind-mounted `.git`), so applying 240s to EACH entry
+    # let a stall cost 240s times the worktree count (15-20+ in a real
+    # multi-subtask wave, reaching ~1 hour). Instead, budget the 240s ONCE
+    # across the whole loop: each `git worktree remove` call gets whatever
+    # time remains until the shared deadline, and once the deadline has
+    # passed, remaining entries skip straight to the rm -rf fallback below
+    # (still executed for every entry) rather than making another
+    # subprocess call. Per-worktree failures are non-fatal — the loop logs
+    # and continues — and a closing recovery-hint line tells the user how
+    # to finish manually.
     worktree_remove_timeout = 240
+    cleanup_deadline = time.monotonic() + worktree_remove_timeout
     failed_removals = 0
     worktrees_dir_resolved = worktrees_dir.resolve() if worktrees_dir.is_dir() else None
     if worktrees_dir.is_dir():
         for entry in worktrees_dir.iterdir():
             if not entry.is_dir():
                 continue
-            try:
-                subprocess.run(
-                    ["git", "worktree", "remove", "--force", str(entry)],
-                    capture_output=True, check=False,
-                    timeout=worktree_remove_timeout,
-                )
-            except (OSError, subprocess.TimeoutExpired) as e:
-                log(f"  cleanup: git worktree remove failed for {entry}: {e}")
+            remaining = cleanup_deadline - time.monotonic()
+            if remaining > 0:
+                try:
+                    subprocess.run(
+                        ["git", "worktree", "remove", "--force", str(entry)],
+                        capture_output=True, check=False,
+                        timeout=remaining,
+                    )
+                except (OSError, subprocess.TimeoutExpired) as e:
+                    log(f"  cleanup: git worktree remove failed for {entry}: {e}")
+            else:
+                log(f"  cleanup: worktree-removal budget ({worktree_remove_timeout}s) "
+                    f"exhausted; skipping git worktree remove for {entry}, "
+                    "falling back to rm -rf")
             # Fall back to direct removal if the directory still exists.
             # Two real cases this catches:
             #   1) `git worktree remove` succeeded administratively
@@ -7153,9 +7167,19 @@ async def _gather_or_cancel(*aws):
         raise
 
 
+# Backstop for `_run_script` invocations of the bundled worktree scripts
+# (cleanup.sh, finalize.sh, etc). Unbounded (`timeout=None`) previously —
+# if the script itself ever hit an unbounded git/filesystem stall, the
+# orchestrator would block forever. Calibrated well above the 240s
+# worktree-removal ceiling used elsewhere in this file, since a script
+# invocation may itself remove many worktrees sequentially.
+RUN_SCRIPT_TIMEOUT = 600
+
+
 async def _run_script(name: str, *args: str) -> subprocess.CompletedProcess:
     """Run one of the bundled git worktree scripts in the target repo."""
-    return await run_proc(["bash", str(SCRIPTS / name), *args], cwd=os.getcwd())
+    return await run_proc(["bash", str(SCRIPTS / name), *args], cwd=os.getcwd(),
+                          timeout=RUN_SCRIPT_TIMEOUT)
 
 
 def _stage_worktree_extras(st: "State", worktree: str) -> None:
@@ -32379,8 +32403,15 @@ async def phase_finalize(leerie_dir: Path, st: State, no_push: bool,
             # `--subtask-branches` (not `--branches`) mirrors the successful
             # path: the empty run branch is kept and reaped by `leerie prune`
             # like any other, rather than inventing a second disposal rule.
-            await _run_script("cleanup.sh", "--run-id", st.run_id,
-                              "--subtask-branches")
+            # Best-effort: a hung cleanup.sh must not block the no-work
+            # terminal state from being recorded (same swallow-and-continue
+            # pattern as `_record_run_health` below).
+            try:
+                await _run_script("cleanup.sh", "--run-id", st.run_id,
+                                  "--subtask-branches")
+            except subprocess.TimeoutExpired as _cleanup_exc:
+                log(f"cleanup: cleanup.sh timed out ({_cleanup_exc}); "
+                    "continuing")
             _finish_no_work_run(
                 st,
                 {"<finalize>": (
@@ -32409,7 +32440,13 @@ async def phase_finalize(leerie_dir: Path, st: State, no_push: bool,
     # `resume` re-enters finalize to re-run finalize.sh's non-empty check.
     st.data["current_phase"] = "phase 6: finalize"
     st.save()
-    await _run_script("cleanup.sh", "--run-id", st.run_id, "--subtask-branches")
+    # Best-effort: a hung cleanup.sh must not crash a finalize that already
+    # confirmed the run branch is non-empty and pushable (same
+    # swallow-and-continue pattern as `_record_run_health` below).
+    try:
+        await _run_script("cleanup.sh", "--run-id", st.run_id, "--subtask-branches")
+    except subprocess.TimeoutExpired as _cleanup_exc:
+        log(f"cleanup: cleanup.sh timed out ({_cleanup_exc}); continuing")
     # Post-cleanup verification: the run branch must survive cleanup.
     # finalize.sh verified it existed moments ago; if it's gone after
     # cleanup.sh, something deleted it (a concurrent process, a git

--- a/scripts/cleanup.sh
+++ b/scripts/cleanup.sh
@@ -34,6 +34,11 @@ set -euo pipefail
 # masking the cleanup as a no-op and leaving worktrees behind.
 LEERIE_ROOT="${LEERIE_STATE_DIR:-.leerie}"
 
+# 240s calibration mirrors _cleanup_on_abnormal_exit (leerie.py:3896-3920).
+# Override is test-only, to exercise the timeout-fires path without a
+# real multi-minute wait.
+WORKTREE_REMOVE_TIMEOUT="${CLEANUP_SH_TEST_WORKTREE_REMOVE_TIMEOUT:-240}"
+
 # --- helpers -------------------------------------------------------------
 
 clean_one_run() {
@@ -56,7 +61,13 @@ clean_one_run() {
   if [ -d "${run_dir}/worktrees" ]; then
     for d in "${run_dir}/worktrees"/*/; do
       [ -d "$d" ] || continue
-      git worktree remove --force "$d" 2>/dev/null || true
+      # 240s timeout mirrors the calibrated bound on the abnormal-exit
+      # Python path (_cleanup_on_abnormal_exit, leerie.py:3896-3920): a
+      # 868MB/41k-file worktree takes ~45-90s uncontested and several-fold
+      # more under N-way concurrent wave cleanup, but a genuinely hung
+      # `git worktree remove` (stale mount, held index.lock, disk
+      # contention) must not block the whole orchestrator forever.
+      timeout "$WORKTREE_REMOVE_TIMEOUT" git worktree remove --force "$d" 2>/dev/null || true
       # Fall back to rm -rf when `git worktree remove` administratively
       # succeeded but left the directory behind (timeout mid-rmtree) or
       # when git no longer tracks the worktree (already pruned) and so

--- a/scripts/container-entry.sh
+++ b/scripts/container-entry.sh
@@ -151,7 +151,8 @@ fi
 # both runtimes; the idle-PID-1 Fly path below still needs it because the
 # orchestrator is launched out-of-band via ssh and connects to this socket.
 if command -v python3 >/dev/null 2>&1; then
-  LEERIE_CGROUP_V2_ROOT="$CGROUP_ROOT" python3 /opt/leerie-image/scripts/cgroup-broker.py &
+  LEERIE_CGROUP_V2_ROOT="$CGROUP_ROOT" python3 /opt/leerie-image/scripts/cgroup-broker.py \
+    </dev/null >>/tmp/cgroup-broker.log 2>&1 &
 fi
 
 cd /work

--- a/tests/test_cleanup_run_scoped.py
+++ b/tests/test_cleanup_run_scoped.py
@@ -258,6 +258,83 @@ def test_cleanup_finds_run_dir_under_state_dir(tmp_path):
     assert (run_dir / "state.json").exists()
 
 
+# --- bounded worktree removal (hang protection) ---------------------------
+
+def test_cleanup_wraps_worktree_remove_in_timeout():
+    """`git worktree remove` inside clean_one_run must be bounded by
+    `timeout 240` (mirrors the calibrated 240s bound on the abnormal-exit
+    Python path, leerie.py:3896-3920), so a stalled removal (stale mount,
+    held index.lock, disk contention) cannot hang the script forever."""
+    src = _src()
+    clean_one_run = src.split("clean_one_run() {")[1].split("\n}")[0]
+    assert 'timeout "$WORKTREE_REMOVE_TIMEOUT" git worktree remove --force' in clean_one_run
+    assert 'WORKTREE_REMOVE_TIMEOUT="${CLEANUP_SH_TEST_WORKTREE_REMOVE_TIMEOUT:-240}"' in src
+
+
+def test_cleanup_hanging_git_worktree_remove_still_completes_and_removes_dir(tmp_path):
+    """If `git worktree remove` hangs forever (stubbed via a fake `git` on
+    PATH that sleeps on that subcommand), cleanup.sh must still return
+    promptly (well under the old unbounded wait) and the worktree
+    directory must be gone afterward (rm -rf fallback fired)."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q", "-b", "main"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.email", "test@x"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.name", "test"], cwd=repo, check=True)
+    (repo / "file").write_text("x")
+    subprocess.run(["git", "add", "."], cwd=repo, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "init"], cwd=repo, check=True)
+
+    run_id = "feat-hang-test"
+    run_dir = repo / ".leerie" / "runs" / run_id
+    worktree_dir = run_dir / "worktrees" / "some-subtask"
+    worktree_dir.mkdir(parents=True)
+    (worktree_dir / "marker").write_text("x")
+    (run_dir / "state.json").write_text('{"task": "test"}')
+
+    real_git_path = None
+    for p in os.environ.get("PATH", "").split(os.pathsep):
+        candidate = Path(p) / "git"
+        if candidate.is_file():
+            real_git_path = str(candidate)
+            break
+    assert real_git_path, "could not locate a real `git` on PATH"
+
+    fake_bin = tmp_path / "fake-bin"
+    fake_bin.mkdir()
+    fake_git = fake_bin / "git"
+    fake_git.write_text(
+        "#!/usr/bin/env bash\n"
+        "if [ \"$1\" = worktree ] && [ \"$2\" = remove ]; then\n"
+        "  sleep 999999\n"
+        "fi\n"
+        f'exec "{real_git_path}" "$@"\n'
+    )
+    fake_git.chmod(0o755)
+
+    env = {k: v for k, v in os.environ.items() if k != "LEERIE_STATE_DIR"}
+    env["PATH"] = f"{fake_bin}{os.pathsep}{env.get('PATH', '')}"
+    env["CLEANUP_SH_TEST_WORKTREE_REMOVE_TIMEOUT"] = "1"
+
+    import time
+    start = time.monotonic()
+    r = subprocess.run(
+        [str(CLEANUP_SH), "--run-id", run_id],
+        cwd=repo, env=env, capture_output=True, text=True, check=False,
+        timeout=60,
+    )
+    elapsed = time.monotonic() - start
+    assert r.returncode == 0, f"cleanup.sh failed: {r.stderr}"
+    assert elapsed < 30, (
+        f"cleanup.sh took {elapsed:.1f}s against a hanging `git worktree "
+        f"remove` — the timeout bound did not fire"
+    )
+    assert not worktree_dir.exists(), (
+        "cleanup.sh must rm -rf the worktree dir when `git worktree remove` "
+        "hangs past its timeout"
+    )
+
+
 def test_cleanup_state_dir_unset_falls_back_to_repo(tmp_path):
     """Without LEERIE_STATE_DIR, cleanup.sh resolves .leerie/runs/<id>/
     relative to CWD — the legacy/in-repo behavior."""

--- a/tests/test_container_entry_broker_stdio.py
+++ b/tests/test_container_entry_broker_stdio.py
@@ -9,11 +9,68 @@ inherited fds.
 """
 from __future__ import annotations
 
+import os
 import re
+import time
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 ENTRY = REPO_ROOT / "scripts" / "container-entry.sh"
+
+
+def _time_to_eof(redirect_child_stdio: bool) -> float:
+    """Fork a 'PID 1' that backgrounds a long-lived child, then exits.
+
+    Returns the wall-clock time for the pipe reader (standing in for the
+    container runtime's log/output reader) to observe EOF after the parent
+    ('PID 1') has exited. If the child does not redirect its own stdio away
+    from the inherited pipe fd, it keeps the write end open and EOF is
+    delayed until the child itself exits (~0.3s here); if it does redirect,
+    EOF arrives promptly once the parent exits (~0s).
+    """
+    read_fd, write_fd = os.pipe()
+    parent_pid = os.fork()
+    if parent_pid == 0:
+        # "PID 1": owns the write end, backgrounds a long-lived child, exits.
+        os.close(read_fd)
+        child_pid = os.fork()
+        if child_pid == 0:
+            # The long-lived background child (stands in for cgroup-broker.py).
+            if redirect_child_stdio:
+                os.close(write_fd)
+                devnull = os.open(os.devnull, os.O_WRONLY)
+                os.dup2(devnull, 1)
+                os.close(devnull)
+            time.sleep(0.3)
+            os._exit(0)
+        # "PID 1" exits immediately, orphaning the background child.
+        os.close(write_fd)
+        os._exit(0)
+
+    os.close(write_fd)
+    os.waitpid(parent_pid, 0)
+    start = time.monotonic()
+    os.read(read_fd, 1)
+    elapsed = time.monotonic() - start
+    os.close(read_fd)
+    return elapsed
+
+
+def test_unredirected_background_child_delays_pipe_eof_past_parent_exit():
+    elapsed = _time_to_eof(redirect_child_stdio=False)
+    assert elapsed > 0.1, (
+        "expected an unredirected background child to hold the pipe's write "
+        f"end open past the parent's exit, delaying EOF; observed {elapsed}s"
+    )
+
+
+def test_redirected_background_child_lets_reader_see_eof_promptly():
+    elapsed = _time_to_eof(redirect_child_stdio=True)
+    assert elapsed < 0.1, (
+        "expected a background child with its own stdio redirected away "
+        f"from the inherited pipe fd to let the reader see EOF promptly "
+        f"once the parent exits; observed {elapsed}s"
+    )
 
 
 def _extract_broker_launch_line() -> str:

--- a/tests/test_container_entry_broker_stdio.py
+++ b/tests/test_container_entry_broker_stdio.py
@@ -1,0 +1,41 @@
+"""bugfix-004: the cgroup broker launch line must not inherit PID 1's stdio.
+
+container-entry.sh launches the cgroup broker with `python3 ... &`. A bare
+background launch inherits PID 1's stdout/stderr, which can hold the
+container's output pipe open past PID 1's own exit, delaying EOF on the
+launcher's read side and contributing to the reported hang-on-exit. The
+launch line must explicitly redirect stdin/stdout/stderr away from those
+inherited fds.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+ENTRY = REPO_ROOT / "scripts" / "container-entry.sh"
+
+
+def _extract_broker_launch_line() -> str:
+    src = ENTRY.read_text()
+    m = re.search(
+        r"^\s*LEERIE_CGROUP_V2_ROOT=.*?cgroup-broker\.py.*?&\s*$",
+        src, re.MULTILINE | re.DOTALL,
+    )
+    assert m, ("could not find the cgroup broker launch line in "
+               "container-entry.sh — did it get restructured?")
+    return m.group(0)
+
+
+def test_broker_launch_redirects_stdin_away_from_inherited_fd():
+    line = _extract_broker_launch_line()
+    assert re.search(r"<\s*/dev/null", line), (
+        "broker launch must redirect stdin away from PID 1's inherited fd")
+
+
+def test_broker_launch_redirects_stdout_and_stderr_away_from_inherited_fds():
+    line = _extract_broker_launch_line()
+    assert re.search(r">>?\s*\S+", line), (
+        "broker launch must redirect stdout away from PID 1's inherited fd")
+    assert "2>&1" in line, (
+        "broker launch must redirect stderr away from PID 1's inherited fd")

--- a/tests/test_decoupled_streaming_hang_bound.py
+++ b/tests/test_decoupled_streaming_hang_bound.py
@@ -1,0 +1,114 @@
+"""Wall-clock-bound regression test for the piped/decoupled-streaming
+(-i, non-tty) launcher exit path (leerie:8811-8826).
+
+test_log_file_persistence.py and test_log_file_wiring.py prove the tee/
+tail wiring exists and produces correct file content, but both use a
+stub `nerdctl` that writes-and-returns synchronously
+(test_log_file_persistence.py:82-84) -- neither ever exercises a
+background process that keeps the container's stdout stream open past
+the stub's own exit, which is exactly the SSH-mux / broker failure mode
+the file-based `_run_log` + launcher-owned `tail -f` design exists to
+route around (leerie:8649-8656). This file's stub forks a detached
+grandchild that inherits stdout and sleeps well past the harness's own
+completion, then exits itself -- proving the harness returns promptly
+because `_run_log` is a plain FILE (not a pipe): redirecting nerdctl's
+stdout to a file means a lingering fd-holder never keeps a reader
+blocked on EOF the way a held pipe would.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import time
+from pathlib import Path
+
+from tests.log_file_extract_helpers import (
+    extract_invocation as _extract_invocation,
+    extract_reap_tail as _extract_reap_tail,
+    extract_setup_block as _extract_setup_block,
+)
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+LAUNCHER = REPO_ROOT / "leerie"
+
+HANG_CEILING_SECONDS = 5.0
+
+# The grandchild sleeps far past both the ceiling and the harness's own
+# `sleep 0.5` settle window, so a false pass (the process actually exiting
+# before the hold matters) is not possible.
+_HOLDER_SLEEP_SECONDS = 20
+
+_HARNESS = r"""#!/usr/bin/env bash
+set -uo pipefail
+
+USER_REPO="__REPO__"
+LEERIE_STATE_HOST_DIR="__STATE__"
+TTY_FLAGS="-i"
+container_rc=0
+_run_argv=()
+
+# Adversarial nerdctl stub: writes fixed content, then backgrounds a
+# detached grandchild that inherits nerdctl's stdout (the redirected
+# run-log file, per `nerdctl run ... >"$_run_log" 2>&1`) and sleeps well
+# past this stub's own exit, mirroring a broker/mux process that keeps a
+# stream open after the container it belongs to has finished. `disown`
+# detaches it from the job table so nothing in this stub's own shell
+# waits on it.
+nerdctl() {
+  printf 'CONTAINER OUTPUT LINE ONE\nCONTAINER OUTPUT LINE TWO\n'
+  ( sleep __HOLDER_SLEEP__ ) &
+  disown
+}
+
+__SETUP__
+
+__INVOCATION__
+
+sleep 0.5
+__REAP__
+_reap_tail
+
+printf 'RUN_LOG_GONE=%s\n' "$([ -z "$_run_log" ] && echo yes || echo no)"
+"""
+
+
+def test_piped_path_returns_promptly_even_with_a_lingering_stdout_holder(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    script = _write_harness(repo, state_dir)
+
+    start = time.monotonic()
+    result = subprocess.run(
+        ["bash", str(script)],
+        capture_output=True, text=True, timeout=_HOLDER_SLEEP_SECONDS,
+        env=os.environ.copy(),
+    )
+    elapsed = time.monotonic() - start
+
+    assert result.returncode == 0, result.stderr
+    assert elapsed < HANG_CEILING_SECONDS, (
+        f"harness took {elapsed:.2f}s (ceiling {HANG_CEILING_SECONDS}s) -- "
+        "it blocked on the lingering stdout holder instead of returning "
+        f"once nerdctl itself exited; stdout={result.stdout!r} "
+        f"stderr={result.stderr!r}"
+    )
+
+    assert "CONTAINER OUTPUT LINE ONE" in result.stdout
+    assert "CONTAINER OUTPUT LINE TWO" in result.stdout
+    assert "RUN_LOG_GONE=yes" in result.stdout
+
+
+def _write_harness(repo: Path, state_dir: Path) -> Path:
+    script = repo.parent / "harness.sh"
+    script.write_text(
+        _HARNESS
+        .replace("__REPO__", str(repo))
+        .replace("__STATE__", str(state_dir))
+        .replace("__HOLDER_SLEEP__", str(_HOLDER_SLEEP_SECONDS))
+        .replace("__SETUP__", _extract_setup_block())
+        .replace("__INVOCATION__", _extract_invocation())
+        .replace("__REAP__", _extract_reap_tail())
+    )
+    return script

--- a/tests/test_fallback_stdout_hang_bound.py
+++ b/tests/test_fallback_stdout_hang_bound.py
@@ -1,0 +1,95 @@
+"""Adversarial wall-clock-bound regression test for the bare fallback exit
+path (leerie:8887-8890): `nerdctl run "${_run_argv[@]}" || container_rc=$?`
+with stdout inherited directly, no decoupling of any kind.
+
+Neither tests/test_log_file_wiring.py nor tests/test_log_file_persistence.py
+extract this specific block -- both only ever drive the `$_run_log`
+(piped/decoupled) and `script`(1)-teed branches, so this fallback has zero
+existing coverage (not content, not structure, not timing). It is also the
+one branch with no decoupling mechanism at all: the piped branch redirects
+nerdctl's own stdout into a file the launcher tails itself
+(tests/test_decoupled_streaming_hang_bound.py), and the `script`(1) branch
+routes through a pty that closes on its own once the wrapped command exits
+(tests/test_interactive_script_hang_bound.py) -- but this branch hands
+nerdctl (and anything it backgrounds) the launcher's own inherited stdout
+fd, unchanged. A grandchild that outlives nerdctl and keeps that fd open
+(mirroring the SSH-mux / broker held-pipe failure mode the other two
+branches are built to route around) keeps a reader of that fd blocked on
+EOF for exactly as long as the grandchild lives -- this test pins that the
+invocation itself adds no *extra* unbounded delay on top of that, using
+`tests.log_file_extract_helpers.extract_invocation` so it tracks the
+launcher's real source rather than a hand-copied snippet.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import time
+from pathlib import Path
+
+from tests.log_file_extract_helpers import extract_invocation as _extract_invocation
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+_INVOCATION = _extract_invocation()
+assert "nerdctl run" in _INVOCATION
+assert 'nerdctl run "${_run_argv[@]}" || container_rc=$?\n  fi' in _INVOCATION
+
+# A tiny fixed lifetime for the adversarial stdout holder -- long enough to
+# prove the launcher isn't adding its own extra delay on top, short enough
+# to keep the test fast and deterministic.
+_HOLD_SECONDS = 1
+_CEILING_SECONDS = 5
+
+_HARNESS = r"""#!/usr/bin/env bash
+set -uo pipefail
+
+container_rc=0
+_run_argv=(run --rm alpine echo hi)
+_run_log=""
+_log_tee_target=""
+
+# Adversarial nerdctl stub: returns immediately itself, but backgrounds a
+# detached grandchild that inherits (and keeps open) the exact stdout fd it
+# was handed -- this branch never redirects that fd anywhere else, so it is
+# the one actually exposed to a lingering holder.
+nerdctl() {
+  ( setsid sleep __HOLD__ </dev/null >&1 2>&1 & ) 2>/dev/null
+  printf 'FALLBACK OUTPUT LINE\n'
+  return 0
+}
+
+__INVOCATION__
+
+printf 'CONTAINER_RC=%s\n' "$container_rc"
+"""
+
+
+def _run(tmp_path):
+    script = tmp_path / "harness.sh"
+    script.write_text(
+        _HARNESS
+        .replace("__HOLD__", str(_HOLD_SECONDS))
+        .replace("__INVOCATION__", _INVOCATION)
+    )
+    start = time.monotonic()
+    result = subprocess.run(
+        ["bash", str(script)],
+        capture_output=True, text=True,
+        timeout=_CEILING_SECONDS + 20,
+        env=os.environ.copy(),
+    )
+    elapsed = time.monotonic() - start
+    return result, elapsed
+
+
+def test_fallback_path_returns_promptly_even_with_a_lingering_stdout_holder(tmp_path):
+    result, elapsed = _run(tmp_path)
+    assert result.returncode == 0, result.stderr
+    assert "FALLBACK OUTPUT LINE" in result.stdout
+    assert "CONTAINER_RC=0" in result.stdout
+    assert elapsed < _CEILING_SECONDS, (
+        f"fallback invocation (leerie:8887-8890) took {elapsed:.2f}s to "
+        f"return under an adversarial stdout holder -- expected under "
+        f"{_CEILING_SECONDS}s (holder lifetime {_HOLD_SECONDS}s)"
+    )

--- a/tests/test_interactive_script_hang_bound.py
+++ b/tests/test_interactive_script_hang_bound.py
@@ -1,0 +1,117 @@
+"""Adversarial wall-clock-bound regression test for the interactive `-it`,
+`script`(1)-teed launcher exit path (bugfix-005, leerie:8877-8886, the
+non-Darwin `script -qe -c "$_nerdctl_run_quoted" -a "$_log_tee_target"`
+branch).
+
+DESIGN.md asserts the interactive `-it` path "has a real pty and thus no
+hang" -- but that argument rests entirely on `script`(1)'s own pty
+allocation, and nothing in this suite has ever put it under the same
+lingering-background-holder condition test_log_file_wiring.py's stubs
+never exercise: existing coverage there
+(`test_interactive_tty_path_is_teed_via_script` et al.) uses a `nerdctl`
+stub that always writes-and-returns synchronously, so it only proves the
+teed output is byte-correct, never that the branch *returns promptly*.
+
+This mirrors test-002's harness shape (reusing
+`tests.log_file_extract_helpers`) but drives the adversarial nerdctl stub
+through the `script`(1)-wrapped invocation instead of the piped/`_run_log`
+one: the stub backgrounds a detached grandchild that inherits the
+`script`-allocated pty as its stdout and sleeps well past the stub's own
+exit, mirroring the lingering-background-holder failure mode DESIGN.md
+cites for the SSH-mux / broker case. If `script`(1) (or the shell it
+launches the wrapped command through) waits on the pty itself going EOF
+rather than on the direct child's exit, this reproduces the hang the
+pty was supposed to make impossible.
+"""
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import time
+from pathlib import Path
+
+import pytest
+
+from tests.log_file_extract_helpers import (
+    extract_invocation as _extract_invocation,
+    extract_reap_tail as _extract_reap_tail,
+    extract_setup_block as _extract_setup_block,
+)
+from tests.test_log_file_wiring import _extract_mkdir_line, _HARNESS
+
+CEILING_SECONDS = 5.0
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("script") is None, reason="requires script(1) on PATH"
+)
+
+
+def _write_lingering_nerdctl_stub(bin_dir: Path) -> None:
+    """A real executable `nerdctl` (required -- `script -c` runs the
+    wrapped command in a fresh `$SHELL -c` subprocess that cannot see a
+    harness bash function). Writes the expected output, then backgrounds
+    a detached grandchild that inherits its stdout (the `script`-allocated
+    pty slave under this branch) and sleeps well past its own exit --
+    mirroring a lingering background holder of the pty/output stream, the
+    same class of failure DESIGN.md's hang writeup describes for the SSH
+    mux / broker case. `disown` (not a `( ... & ) >/dev/null` subshell --
+    bash silently redirects an asynchronous list's own stdout to
+    /dev/null unless it already inherits a real fd, which defeats the
+    adversarial condition entirely; confirmed empirically: wrapping in
+    `()` leaves the grandchild's fd 1 pointing at /dev/null, not the
+    inherited pty/pipe) keeps the grandchild's fd 1 genuinely inherited
+    while detaching it from the job table so nerdctl itself (and the
+    `$SHELL -c` script(1) runs it through) does not wait on it."""
+    bin_dir.mkdir(exist_ok=True)
+    stub = bin_dir / "nerdctl"
+    stub.write_text(
+        "#!/usr/bin/env bash\n"
+        "printf 'hello from container\\nsecond line\\n'\n"
+        "sleep 60 &\n"
+        "disown\n"
+        "exit 0\n"
+    )
+    stub.chmod(0o755)
+
+
+def test_script_teed_path_returns_promptly_even_with_a_lingering_stdout_holder(
+    tmp_path,
+):
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    log_file = tmp_path / "logs" / "leerie-run.log"
+
+    bin_dir = state_dir / "bin"
+    _write_lingering_nerdctl_stub(bin_dir)
+
+    script_path = state_dir / "harness.sh"
+    script_path.write_text(
+        _HARNESS
+        .replace("__STATE__", str(state_dir))
+        .replace("__LOGFILE__", str(log_file))
+        .replace("__TTYFLAGS__", "-it")
+        .replace("__MKDIR__", _extract_mkdir_line())
+        .replace("__SETUP__", _extract_setup_block())
+        .replace("__INVOCATION__", _extract_invocation())
+        .replace("__REAP__", _extract_reap_tail())
+    )
+
+    env = os.environ.copy()
+    env["PATH"] = f"{bin_dir}:{env['PATH']}"
+
+    started = time.monotonic()
+    result = subprocess.run(
+        ["bash", str(script_path)],
+        capture_output=True, text=True, timeout=30,
+        env=env,
+    )
+    elapsed = time.monotonic() - started
+
+    assert result.returncode == 0, result.stderr
+    assert elapsed < CEILING_SECONDS, (
+        f"script(1)-teed -it branch took {elapsed:.2f}s (ceiling "
+        f"{CEILING_SECONDS}s) with a lingering background stdout holder -- "
+        "the pty is not the hang-proofing DESIGN.md claims it is"
+    )
+    assert "hello from container" in result.stdout

--- a/tests/test_orchestrate_cleanup_bound.py
+++ b/tests/test_orchestrate_cleanup_bound.py
@@ -1,0 +1,246 @@
+"""Bounded wall-clock regression test for `_orchestrate()`'s `finally` block
+(leerie:32599-32660).
+
+`_orchestrate()` starts `sampler_task` (`_memory_sampler`) and `reaper_task`
+(`_zombie_reaper`) before `_run_phases`, and — when
+`--dangerously-force-strict-output` is active — a `_StrictOutputProxy`. All
+three are torn down in the `finally`: the two tasks are cancelled and
+awaited, and the proxy's `stop()` is called (`_pool.shutdown(wait=False,
+cancel_futures=True)`). Nothing previously exercised this under an
+adversarial slow-coroutine condition with a wall-clock assertion — a `while
+True: await asyncio.sleep(interval)` background task that swallowed
+`asyncio.CancelledError` (e.g. via a bare `except:` or `except
+BaseException:`) would hang `_orchestrate()` forever on every run, and no
+test would catch it.
+
+Both real background coroutines are replaced with test doubles that sleep
+far longer than the wall-clock ceiling below, so a hang shows up as an
+actual timeout rather than being masked by a short default `interval_sec`.
+"""
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import signal
+import time
+from types import SimpleNamespace
+
+import pytest
+
+# `_orchestrate()`'s finally must always return well inside this many seconds
+# whether `_run_phases` completes normally or raises -- the sampler/reaper
+# tasks sleep for far longer than this, so only prompt cancellation makes
+# the ceiling achievable.
+_CEILING_SEC = 5.0
+
+# A hard multiple of the ceiling used as a SIGALRM backstop (see
+# `_hard_timeout` below) -- deliberately NOT `asyncio.wait_for`. Measured:
+# the real `finally` awaits each background task inside
+# `contextlib.suppress(asyncio.CancelledError)` (leerie:32605-32608); if that
+# task's own cancellation handling is broken (swallows CancelledError and
+# keeps sleeping -- exactly the regression class this file guards against),
+# `asyncio.wait_for`'s own cancellation of the outer `_orchestrate()` task
+# lands inside that same `suppress` block and gets silently swallowed too,
+# so `asyncio.run(asyncio.wait_for(...))` hangs right along with the bug it
+# was meant to catch. A `SIGALRM` fires at the interpreter level, independent
+# of asyncio task cancellation, so it cannot be defeated by the same defect.
+_HARD_TIMEOUT_SEC = int(_CEILING_SEC * 4)
+
+
+@contextlib.contextmanager
+def _hard_timeout(seconds: int):
+    def _on_alarm(_signum, _frame):
+        raise TimeoutError(f"hard SIGALRM timeout after {seconds}s")
+
+    previous = signal.signal(signal.SIGALRM, _on_alarm)
+    signal.alarm(seconds)
+    try:
+        yield
+    finally:
+        signal.alarm(0)
+        signal.signal(signal.SIGALRM, previous)
+
+
+def _make_slow_forever(entered: list):
+    """Builds a stand-in for `_memory_sampler` / `_zombie_reaper`: sleeps far
+    past the ceiling, so only a real `.cancel()` + await lets `_orchestrate()`
+    return in time. Appends to `entered` right before the first sleep so the
+    caller can assert the double actually started running (and was caught
+    mid-sleep) rather than being cancelled before the event loop ever gave it
+    a turn -- a task cancelled pre-start "succeeds" trivially regardless of
+    its cancellation handling, which would make the assertion below vacuous."""
+    async def _slow_forever(*_a, **_k) -> None:
+        while True:
+            entered.append(1)
+            await asyncio.sleep(9999)
+    return _slow_forever
+
+
+def _args(**overrides) -> SimpleNamespace:
+    base = dict(dangerously_force_strict_output=False)
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+def _caps(leerie, **overrides) -> dict:
+    caps = dict(leerie.DEFAULT_CAPS)
+    caps["force_strict_output"] = False
+    caps.update(overrides)
+    return caps
+
+
+@pytest.fixture(autouse=True)
+def _reset_strict_proxy(leerie):
+    """`_STRICT_PROXY` is a module global `_orchestrate()` sets and clears --
+    reset it around each test so a failure in one test can't leak a live
+    proxy/port into the next."""
+    yield
+    leerie._STRICT_PROXY = None
+
+
+def _patched(leerie, monkeypatch) -> list:
+    """Installs the sampler/reaper doubles and returns the shared `entered`
+    list so callers can assert both doubles actually ran before being
+    cancelled."""
+    entered: list = []
+    monkeypatch.setattr(leerie, "_memory_sampler", _make_slow_forever(entered))
+    monkeypatch.setattr(leerie, "_zombie_reaper", _make_slow_forever(entered))
+    return entered
+
+
+async def _yield_to_background_tasks() -> None:
+    """Stand-in body for a stubbed `_run_phases`: gives the event loop a few
+    turns so `sampler_task`/`reaper_task` (scheduled but not yet run at the
+    point `_run_phases` is awaited) actually enter their loop and reach
+    `asyncio.sleep(9999)` before `_orchestrate()`'s `finally` cancels them.
+    Real `_run_phases` awaits many things internally, so this mirrors that
+    rather than special-casing the test."""
+    for _ in range(5):
+        await asyncio.sleep(0)
+
+
+def _run_bounded(coro) -> float:
+    """Runs `coro` under the SIGALRM backstop and returns the wall-clock
+    elapsed time. Fails cleanly on a genuine hang instead of blocking the
+    suite forever."""
+    start = time.monotonic()
+    try:
+        with _hard_timeout(_HARD_TIMEOUT_SEC):
+            asyncio.run(coro)
+    except TimeoutError:
+        pytest.fail(
+            f"_orchestrate() did not return within {_HARD_TIMEOUT_SEC}s -- "
+            f"sampler/reaper/proxy cancellation is hanging")
+    return time.monotonic() - start
+
+
+def _run_bounded_expect_raise(coro, exc_type) -> float:
+    """Like `_run_bounded`, but expects `coro` to raise `exc_type` rather
+    than return."""
+    start = time.monotonic()
+    try:
+        with _hard_timeout(_HARD_TIMEOUT_SEC):
+            asyncio.run(coro)
+    except TimeoutError:
+        pytest.fail(
+            f"_orchestrate() did not propagate {exc_type.__name__} within "
+            f"{_HARD_TIMEOUT_SEC}s -- sampler/reaper/proxy cancellation is "
+            f"hanging")
+    except exc_type:
+        return time.monotonic() - start
+    else:
+        pytest.fail(f"expected {exc_type.__name__} to propagate")
+
+
+def test_orchestrate_returns_promptly_when_run_phases_succeeds(
+        leerie, monkeypatch, tmp_path):
+    entered = _patched(leerie, monkeypatch)
+
+    async def _ok(*_a, **_k) -> None:
+        await _yield_to_background_tasks()
+
+    monkeypatch.setattr(leerie, "_run_phases", _ok)
+
+    elapsed = _run_bounded(leerie._orchestrate(
+        _args(), _caps(leerie), tmp_path, SimpleNamespace(),
+        "both", "quiet", {}, {}))
+
+    assert entered, ("sampler/reaper doubles never entered their sleep -- "
+                     "cancelled before the event loop scheduled them, so "
+                     "this run proves nothing about their cancellation "
+                     "handling")
+    assert elapsed < _CEILING_SEC, (
+        f"_orchestrate() took {elapsed:.2f}s to return after a normal "
+        f"_run_phases completion -- sampler/reaper cancellation is hanging")
+
+
+def test_orchestrate_returns_promptly_when_run_phases_raises(
+        leerie, monkeypatch, tmp_path):
+    entered = _patched(leerie, monkeypatch)
+
+    async def _boom(*_a, **_k) -> None:
+        await _yield_to_background_tasks()
+        raise leerie.WorkerError("simulated worker failure")
+
+    monkeypatch.setattr(leerie, "_run_phases", _boom)
+
+    elapsed = _run_bounded_expect_raise(leerie._orchestrate(
+        _args(), _caps(leerie), tmp_path, SimpleNamespace(),
+        "both", "quiet", {}, {}), leerie.WorkerError)
+
+    assert entered, ("sampler/reaper doubles never entered their sleep -- "
+                     "cancelled before the event loop scheduled them, so "
+                     "this run proves nothing about their cancellation "
+                     "handling")
+    assert elapsed < _CEILING_SEC, (
+        f"_orchestrate() took {elapsed:.2f}s to propagate a _run_phases "
+        f"exception -- sampler/reaper cancellation is hanging")
+
+
+def test_orchestrate_stops_strict_proxy_promptly_on_success(
+        leerie, monkeypatch, tmp_path):
+    """Covers the `force_strict_output=True` variant: the finally must also
+    start and stop a real `_StrictOutputProxy` (leerie:15181-15196) within
+    the same ceiling."""
+    entered = _patched(leerie, monkeypatch)
+
+    async def _ok(*_a, **_k) -> None:
+        await _yield_to_background_tasks()
+
+    monkeypatch.setattr(leerie, "_run_phases", _ok)
+
+    elapsed = _run_bounded(leerie._orchestrate(
+        _args(dangerously_force_strict_output=True),
+        _caps(leerie, force_strict_output=True, max_parallel=2), tmp_path,
+        SimpleNamespace(), "both", "quiet", {}, {}))
+
+    assert entered, "sampler/reaper doubles never entered their sleep"
+    assert elapsed < _CEILING_SEC, (
+        f"_orchestrate() took {elapsed:.2f}s to return with "
+        f"force_strict_output=True -- _StrictOutputProxy.stop() is hanging")
+    assert leerie._STRICT_PROXY is None, (
+        "_orchestrate() must clear the module-global proxy in its finally")
+
+
+def test_orchestrate_stops_strict_proxy_promptly_on_raise(
+        leerie, monkeypatch, tmp_path):
+    entered = _patched(leerie, monkeypatch)
+
+    async def _boom(*_a, **_k) -> None:
+        await _yield_to_background_tasks()
+        raise leerie.WorkerError("simulated worker failure")
+
+    monkeypatch.setattr(leerie, "_run_phases", _boom)
+
+    elapsed = _run_bounded_expect_raise(leerie._orchestrate(
+        _args(dangerously_force_strict_output=True),
+        _caps(leerie, force_strict_output=True, max_parallel=2),
+        tmp_path, SimpleNamespace(), "both", "quiet", {}, {}),
+        leerie.WorkerError)
+
+    assert entered, "sampler/reaper doubles never entered their sleep"
+    assert elapsed < _CEILING_SEC, (
+        f"_orchestrate() took {elapsed:.2f}s to propagate a _run_phases "
+        f"exception with force_strict_output=True -- proxy teardown is "
+        f"hanging")
+    assert leerie._STRICT_PROXY is None

--- a/tests/test_phase_finalize_cleanup_invocation.py
+++ b/tests/test_phase_finalize_cleanup_invocation.py
@@ -16,7 +16,31 @@ takes the explicit single-run path that does not consult stdin.
 """
 from __future__ import annotations
 
+import asyncio
 import inspect
+import subprocess
+
+import pytest
+
+
+def test_run_script_passes_a_bounded_timeout_to_run_proc(leerie, monkeypatch):
+    """`_run_script` previously called `run_proc` with no `timeout`
+    (defaults to None / unbounded at leerie.py's run_proc), so a hung
+    cleanup.sh/finalize.sh could block the orchestrator forever. It must
+    now pass an explicit bounded timeout."""
+    captured = {}
+
+    async def fake_run_proc(cmd, **kwargs):
+        captured.update(kwargs)
+        return subprocess.CompletedProcess(cmd, 0, "", "")
+    monkeypatch.setattr(leerie, "run_proc", fake_run_proc)
+
+    asyncio.run(leerie._run_script("cleanup.sh", "--run-id", "r1"))
+
+    assert captured.get("timeout") is not None, (
+        "_run_script must pass an explicit, non-None timeout to run_proc"
+    )
+    assert captured["timeout"] > 0
 
 
 def test_phase_finalize_invokes_cleanup_with_run_id(leerie):
@@ -99,6 +123,65 @@ def test_current_phase_stamped_after_finalize_sh_succeeds(leerie):
         "the current_phase stamp must come after the "
         "'finalize failed (run branch is intact)' die() guard, so a "
         "nonzero finalize.sh exits before current_phase is stamped."
+    )
+
+
+def test_phase_finalize_catches_timeout_around_both_cleanup_calls(leerie):
+    """Both cleanup.sh call sites in phase_finalize (the no-work-run path
+    and the main finalize path) must swallow subprocess.TimeoutExpired —
+    a hung cleanup.sh is a best-effort failure, not something that should
+    crash a finalize that already confirmed the run branch is real."""
+    src = inspect.getsource(leerie.phase_finalize)
+    assert src.count("except subprocess.TimeoutExpired") >= 2, (
+        "phase_finalize must catch subprocess.TimeoutExpired at both "
+        "cleanup.sh call sites (no-work-run path and main finalize path)"
+    )
+
+
+def test_phase_finalize_survives_a_cleanup_sh_timeout(
+        leerie, monkeypatch, tmp_path):
+    """Execution-level pin: if cleanup.sh times out, phase_finalize must
+    still reach its terminal state instead of letting TimeoutExpired
+    propagate uncaught and crash the run."""
+    async def _fake_run_script(name, *args):
+        if name == "cleanup.sh":
+            raise subprocess.TimeoutExpired(["bash", name, *args], 600)
+        return subprocess.CompletedProcess(["bash", name, *args], 0, "", "")
+
+    async def _fake_run_proc(cmd, **kwargs):
+        return subprocess.CompletedProcess(cmd, 0, "", "")
+
+    async def _noop_capture(*a, **k):
+        return None
+
+    monkeypatch.setattr(leerie, "_run_script", _fake_run_script)
+    monkeypatch.setattr(leerie, "run_proc", _fake_run_proc)
+    monkeypatch.setattr(leerie, "capture_repo_deps", _noop_capture)
+
+    leerie_root = tmp_path / ".leerie"
+    (leerie_root / "runs" / "r1").mkdir(parents=True)
+    st = leerie.State(leerie_root, "r1", repo_root=tmp_path)
+    st.data["waves"] = [["feat-001"]]
+    st.data["completed_waves"] = 1
+    st.data["worker_count"] = 2
+    st.data["subtask_status"] = {"feat-001": "complete"}
+    st.data["working_branch"] = "main"
+    caps = dict(leerie.DEFAULT_CAPS)
+    caps["max_total_workers"] = 100
+    try:
+        asyncio.run(leerie.phase_finalize(
+            st.leerie_root, st, no_push=True, no_verify=False,
+            caps=caps, models={}, efforts={}))
+    finally:
+        st.release_lock()
+
+    assert st.data["current_phase"] == "phase 6: finalize", (
+        "phase_finalize must reach its terminal state even when "
+        "cleanup.sh times out"
+    )
+    assert st.data.get("finished_at"), (
+        "a timed-out cleanup.sh must not prevent finished_at from being "
+        "recorded"
     )
 
 

--- a/tests/test_signal_cleanup.py
+++ b/tests/test_signal_cleanup.py
@@ -223,6 +223,58 @@ def test_cleanup_rm_rf_fallback_after_timeout(leerie, tmp_path, monkeypatch):
     )
 
 
+def test_cleanup_worktree_removal_budget_is_shared_not_per_entry(
+        leerie, tmp_path, monkeypatch):
+    """The 240s worktree-removal ceiling must be a single budget shared
+    across the whole loop, not re-applied to every entry. Worktrees under
+    one run typically share the same underlying stall (they're all removed
+    from the same bind-mounted `.git`), so a fixed per-entry timeout lets a
+    real multi-subtask wave (15-20+ worktrees) spend up to
+    240s * worktree_count on one abnormal exit.
+
+    Simulates each `git worktree remove` call consuming 100s of simulated
+    wall-clock time via a monkeypatched `time.monotonic`. With a shared
+    240s budget, only the first 3 of 4 entries get a chance to call
+    subprocess.run before the deadline passes; the 4th must skip straight
+    to the rm -rf fallback. Every worktree must still end up removed."""
+    run_id = "feat-x-aaa111"
+    run_dir = tmp_path / "runs" / run_id
+    worktrees_dir = run_dir / "worktrees"
+    entries = []
+    for i in range(4):
+        wt = worktrees_dir / f"feat-{i:03d}"
+        wt.mkdir(parents=True)
+        (wt / "f.txt").write_text("x")
+        entries.append(wt)
+    st = _FakeState(run_id, run_dir)
+
+    fake_now = [0.0]
+    monkeypatch.setattr(leerie.time, "monotonic", lambda: fake_now[0])
+
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        if cmd[:3] == ["git", "worktree", "remove"]:
+            calls.append(kwargs.get("timeout"))
+            fake_now[0] += 100  # simulate a 100s stall consumed by this call
+            raise subprocess.TimeoutExpired(cmd, kwargs.get("timeout", 0))
+        return subprocess.CompletedProcess(cmd, 0, "", "")
+    monkeypatch.setattr(leerie.subprocess, "run", fake_run)
+
+    leerie._cleanup_on_abnormal_exit(st, full_purge=False)
+
+    assert len(calls) < len(entries), (
+        "every entry made a git worktree remove call — the shared 240s "
+        f"budget was not enforced against cumulative elapsed time; "
+        f"per-call timeouts were: {calls!r}"
+    )
+    for wt in entries:
+        assert not wt.exists(), (
+            f"{wt} must be removed via the rm -rf fallback even when its "
+            "git worktree remove call was skipped for budget exhaustion"
+        )
+
+
 def test_cleanup_rm_rf_skips_when_path_escapes_sandbox(leerie, tmp_path,
                                                       monkeypatch):
     """Belt-and-suspenders: the rm -rf fallback must verify the


### PR DESCRIPTION
## Summary

<!-- 1-2 sentences. Why is this change being made, and what does it do? -->

Runs almost always hung on exit (Ctrl-C or an hour+ wait) because several cleanup paths had no wall-clock bound: `_run_script`'s `cleanup.sh` invocation was unbounded, `_cleanup_on_abnormal_exit` re-granted a fresh 240s per worktree instead of sharing one budget, `scripts/cleanup.sh`'s `git worktree remove` had no timeout at all, and the cgroup broker in `container-entry.sh` inherited PID 1's stdout pipe and held it open past PID 1's own exit, delaying EOF on the launcher's read side.

## Which layer(s) does this PR touch?

(See [`CLAUDE.md`](../CLAUDE.md) for the three-layer rule.)

- [x] `docs/DESIGN.md` (architecture)
- [x] `docs/IMPLEMENTATION.md` (code surface)
- [x] `orchestrator/leerie.py` (code)
- [x] docs / tests / CI

If multiple, has the change propagated top-down (DESIGN → IMPLEMENTATION → code)?

Yes: `docs/IMPLEMENTATION.md` was updated for `_run_script`'s new `RUN_SCRIPT_TIMEOUT` backstop, the shared worktree-removal deadline in `_cleanup_on_abnormal_exit`, and `container-entry.sh`'s broker stdio redirect, ahead of the corresponding `orchestrator/leerie.py`, `scripts/cleanup.sh`, and `scripts/container-entry.sh` changes. `docs/TESTING.md` gained entries for every new regression test.

## What changed

- `orchestrator/leerie.py`: `_run_script` now passes `timeout=RUN_SCRIPT_TIMEOUT` (600s) to `run_proc` instead of `timeout=None`, and both `phase_finalize` call sites that invoke `cleanup.sh` catch `subprocess.TimeoutExpired` and log-and-continue rather than crash the run. `_cleanup_on_abnormal_exit`'s worktree-removal loop now computes a single shared 240s deadline once at loop entry instead of re-granting 240s per worktree, so one shared stall (all worktrees share the same bind-mounted `.git`) can no longer cost 240s times the worktree count.
- `scripts/cleanup.sh`: `clean_one_run`'s `git worktree remove --force` is now wrapped in `timeout "$WORKTREE_REMOVE_TIMEOUT"` (240s, overridable via `CLEANUP_SH_TEST_WORKTREE_REMOVE_TIMEOUT` for tests), falling back to `rm -rf` as before when the removal doesn't complete.
- `scripts/container-entry.sh`: the cgroup broker's launch line now redirects stdin from `/dev/null` and stdout/stderr to `/tmp/cgroup-broker.log`, so it can no longer hold PID 1's inherited output pipe open past PID 1's own exit.
- Adds adversarial, wall-clock-bounded regression tests for every launcher exit path (bare fallback, piped/decoupled-streaming, interactive `script(1)`-teed) and for `_orchestrate()`'s finally-block cleanup, plus a fork/pipe harness proving the unredirected-background-child EOF-delay mechanism and pinning the broker stdio redirect. `docs/TESTING.md` and `docs/IMPLEMENTATION.md` are updated to match.

## Checklist

- [ ] `pytest tests/` passes
  - The post-integration conformance pass reports 5 failures against a pre-existing red base (`base_health.base_status: red`, `tests` axis): `tests/test_signal_cleanup.py::test_terminate_proc_tree_reaps_grandchildren`, `::test_terminate_proc_tree_reaps_detached_session_grandchildren`, `::test_descendant_tracker_reaps_orphaned_backgrounded_subprocess`, and two more truncated in the same run (`... FAILED tests/test_signal_cleanup.py::...`, `5 failed, 8525 passed, 119 skipped in 1071.12s`). These need triage before merge.
- [x] `git diff --stat` reviewed for scope

## Related issue

<!-- Closes #N -->
</body>
<parameter name="used_template">.github/pull_request_template.md
