### PR TITLE
leerie: Bound remaining unguarded git/mise subprocess calls to fix run-end hangs

### DIFF
--- a/docs/IMPLEMENTATION.md
+++ b/docs/IMPLEMENTATION.md
@@ -5451,7 +5451,11 @@ branch, after the `_write_run_json(...)` block and before
    surfaces the failing tool+version to `die()`.
 5. **Version capture.** Runs `mise ls --current --json` (the
    subcommand `mise current --json` does not exist; verified
-   against mise.usage.kdl). Output is object-keyed-by-tool, each
+   against mise.usage.kdl) via `run_proc` bounded by
+   `MISE_LS_TIMEOUT` (30s) — a timeout or non-zero exit is logged and
+   skipped, the same fail-open disposition as any other capture
+   failure, since workers install their own tools via prompt
+   injection regardless. Output is object-keyed-by-tool, each
    value an array of `{version, install_path, source}` objects.
    Raw blob stored at `st.data["provision"]["mise_versions"]`;
    `tools[name][0].version` is the value rendered in `leerie list`

--- a/docs/IMPLEMENTATION.md
+++ b/docs/IMPLEMENTATION.md
@@ -1955,6 +1955,16 @@ Multi-byte UTF-8 safety: `_cap_text` slices at the byte boundary, then
 back-decodes with `errors="ignore"` so the trimmed prefix never ends
 mid-codepoint.
 
+`PR_WRITER_GIT_TIMEOUT_SEC` (30s, module constant) is a distinct kind of
+bound — a wall-clock ceiling, not a byte cap. It wraps the nested `_git`
+helper's `proc.communicate()` inside `_compose_pr_via_llm` in
+`asyncio.wait_for`, so a stalled/lock-contended `git` process (e.g. the
+shared bind-mounted `.git` across concurrent worktree operations) cannot
+hang `phase_finalize` forever. On timeout, `_terminate_proc_tree` reaps
+the stalled process before the exception propagates into
+`_compose_pr_via_llm`'s existing fail-open `except Exception` contract —
+no PR title/body written, launcher's bash fallback takes over.
+
 **`final_conformance` payload field** — when `_run_final_conformance`
 produced a result, `_compose_pr_via_llm` reads
 `st.data["conformance"]["_final"]` and adds a compact

--- a/orchestrator/leerie.py
+++ b/orchestrator/leerie.py
@@ -4114,7 +4114,10 @@ async def _reset_subtask_worktree(sid: str, leerie_dir: Path, run_id: str) -> No
     administratively succeeded but left the directory behind."""
     worktree = leerie_dir / "worktrees" / sid
     branch = f"leerie/subtasks/{run_id}/{sid}"
-    await run_proc(["git", "worktree", "remove", "--force", str(worktree)])
+    try:
+        await run_proc(["git", "worktree", "remove", "--force", str(worktree)], timeout=240)
+    except subprocess.TimeoutExpired:
+        log(f"[{sid}] git worktree remove timed out; falling back to rmtree")
     await run_proc(["git", "branch", "-D", branch])
     await _rmtree_fallback_and_prune(worktree, leerie_dir)
 
@@ -4132,7 +4135,10 @@ async def _prune_subtask_worktree(sid: str, leerie_dir: Path) -> None:
     expected idempotent case. Never raises — a failed prune is disk
     pressure deferred to run-end cleanup, not a reason to fail the wave."""
     worktree = leerie_dir / "worktrees" / sid
-    await run_proc(["git", "worktree", "remove", "--force", str(worktree)])
+    try:
+        await run_proc(["git", "worktree", "remove", "--force", str(worktree)], timeout=240)
+    except subprocess.TimeoutExpired:
+        log(f"[{sid}] git worktree remove timed out; falling back to rmtree")
     await _rmtree_fallback_and_prune(worktree, leerie_dir)
 
 

--- a/orchestrator/leerie.py
+++ b/orchestrator/leerie.py
@@ -31901,6 +31901,11 @@ PR_WRITER_DIFF_SAMPLE_MAX_LINES = 500
 # an LLM-context budget alongside the other PR_WRITER_* caps above, not
 # an argv-size constraint.
 PR_WRITER_FINAL_CONFORMANCE_MAX_BYTES = 8_000
+# Ceiling for each `_git` plumbing call inside `_compose_pr_via_llm`. Without
+# this, a stalled/lock-contended git process (the shared bind-mounted .git
+# across concurrent worktree operations, e.g.) blocks `proc.communicate()`
+# forever, hanging phase_finalize on every normal run that pushes a PR.
+PR_WRITER_GIT_TIMEOUT_SEC = 30
 
 
 def _cap_text(s: str, max_bytes: int, label: str) -> tuple[str, bool]:
@@ -32179,7 +32184,12 @@ async def _compose_pr_via_llm(st: "State",
                 stderr=asyncio.subprocess.PIPE,
                 start_new_session=True,
             )
-            out, _err = await proc.communicate()
+            try:
+                out, _err = await asyncio.wait_for(
+                    proc.communicate(), timeout=PR_WRITER_GIT_TIMEOUT_SEC)
+            except asyncio.TimeoutError:
+                await _terminate_proc_tree(proc)
+                raise
             return out.decode("utf-8", errors="replace")
 
         commit_log_raw = await _git([

--- a/orchestrator/leerie.py
+++ b/orchestrator/leerie.py
@@ -19962,6 +19962,13 @@ def _repo_has_version_signal(repo_root: Path,
     return False
 
 
+# `mise ls --current --json` is a metadata read against the already-
+# installed toolchain (the slow part, `mise install`, already ran above
+# with its own timeout) — 30s is generous headroom over any observed
+# real-world runtime while still bounding the wait.
+MISE_LS_TIMEOUT = 30
+
+
 async def _run_mise_install(repo_root: Path, log_dir: Path,
                             st: "State",
                             override_file: Path | None = None) -> None:
@@ -20026,25 +20033,32 @@ async def _run_mise_install(repo_root: Path, log_dir: Path,
 
     # Capture resolved versions. `mise ls --current --json` is the
     # documented machine-readable view; `mise current --json` does NOT
-    # exist (verified against mise.usage.kdl).
-    proc = await asyncio.create_subprocess_exec(
-        "mise", "ls", "--current", "--json",
-        cwd=str(repo_root),
-        env=env,
-        stdout=asyncio.subprocess.PIPE,
-        stderr=asyncio.subprocess.PIPE,
-        start_new_session=True,
-    )
-    stdout, stderr = await proc.communicate()
-    if proc.returncode != 0:
+    # exist (verified against mise.usage.kdl). Bounded via `run_proc` —
+    # an unbounded `communicate()` here would hang provisioning forever
+    # if the mise-managed shim ever blocked (the same unguarded-
+    # communicate() shape fixed for `mise install` above).
+    try:
+        result = await run_proc(
+            ["mise", "ls", "--current", "--json"],
+            cwd=str(repo_root),
+            env=env,
+            timeout=MISE_LS_TIMEOUT,
+        )
+    except subprocess.TimeoutExpired:
         # Not fatal — workers run their own install commands via prompt
         # injection (DESIGN §6½ "Worker-driven install"); they don't
         # need the resolved-versions blob to do so. Log and move on.
-        log(f"mise ls --current --json failed (exit {proc.returncode}); "
+        log("mise ls --current --json timed out; skipping version capture")
+        return
+    if result.returncode != 0:
+        # Not fatal — workers run their own install commands via prompt
+        # injection (DESIGN §6½ "Worker-driven install"); they don't
+        # need the resolved-versions blob to do so. Log and move on.
+        log(f"mise ls --current --json failed (exit {result.returncode}); "
             "skipping version capture")
         return
     try:
-        versions = json.loads(stdout.decode(errors="replace") if stdout else "{}")
+        versions = json.loads(result.stdout if result.stdout else "{}")
     except (ValueError, TypeError):
         versions = {}
     prov = st.data.setdefault("provision", {})

--- a/tests/test_ensure_worktree_deps_mise_ls_bounded.py
+++ b/tests/test_ensure_worktree_deps_mise_ls_bounded.py
@@ -76,4 +76,6 @@ def test_mise_ls_hang_does_not_block_forever(leerie, tmp_path, monkeypatch):
 
     assert elapsed < 5, f"provisioning blocked for {elapsed}s on a hung mise ls"
     assert any("skipping version capture" in m for m in logged)
-    assert st.data["provision"]["mise_versions"] == {}
+    # The skip-on-timeout path returns before setting `mise_versions` —
+    # same shape as the existing non-zero-exit skip a few lines below it.
+    assert "mise_versions" not in st.data.get("provision", {})

--- a/tests/test_ensure_worktree_deps_mise_ls_bounded.py
+++ b/tests/test_ensure_worktree_deps_mise_ls_bounded.py
@@ -1,0 +1,79 @@
+"""`_run_mise_install`'s `mise ls --current --json` version-capture call
+must be bounded (DESIGN §6½): the same unguarded-`communicate()` shape
+already fixed for `mise install` itself, at the second and last such
+call site in the file.
+
+Without a timeout, a process that never exits on this call would hang
+worktree provisioning indefinitely. This exercises the real
+`_run_mise_install` coroutine with `mise install` stubbed out (so the
+test needs no real mise binary) and `asyncio.create_subprocess_exec`
+stubbed to return a process whose `communicate()` never resolves,
+proving the surrounding call is wrapped in a bounded wait rather than
+a bare `await proc.communicate()`.
+"""
+from __future__ import annotations
+
+import asyncio
+import time
+
+import pytest
+
+
+def _make_state(leerie, tmp_path):
+    leerie_root = tmp_path / ".leerie"
+    run_id = "_test-run"
+    (leerie_root / "runs" / run_id / "logs").mkdir(parents=True, exist_ok=True)
+    st = leerie.State(leerie_root, run_id)
+    st.data = {"task": "test"}
+    st.save()
+    return st
+
+
+class _HangingProc:
+    """Mimics an `asyncio.subprocess.Process` whose `communicate()` never
+    returns on its own — only cancellation (as driven by `asyncio.wait_for`
+    inside `run_proc`) unblocks it."""
+
+    returncode = None
+    pid = 999999
+
+    async def communicate(self):
+        await asyncio.sleep(3600)
+        return b"", b""  # pragma: no cover - never reached
+
+    async def wait(self):
+        # `_terminate_proc_tree`'s cleanup path reaps the leader after
+        # signalling it; a real killed process would exit promptly.
+        return -9
+
+
+@pytest.fixture(autouse=True)
+def _stub_mise_install(leerie, monkeypatch):
+    async def _fake_run_streaming(cmd, **kwargs):
+        return (0, "ok")
+    monkeypatch.setattr(leerie, "_run_streaming", _fake_run_streaming)
+
+
+def test_mise_ls_hang_does_not_block_forever(leerie, tmp_path, monkeypatch):
+    (tmp_path / "mise.toml").write_text('[tools]\nnode = "20.11.0"\n')
+    st = _make_state(leerie, tmp_path)
+    log_dir = st.run_dir / "logs"
+
+    async def _fake_create_subprocess_exec(*args, **kwargs):
+        return _HangingProc()
+    monkeypatch.setattr(asyncio, "create_subprocess_exec",
+                        _fake_create_subprocess_exec)
+    # Bound the test itself well below the real timeout so a regression to
+    # an unbounded wait fails fast instead of hanging the suite.
+    monkeypatch.setattr(leerie, "MISE_LS_TIMEOUT", 0.2)
+
+    logged = []
+    monkeypatch.setattr(leerie, "log", lambda msg: logged.append(msg))
+
+    start = time.monotonic()
+    asyncio.run(leerie._run_mise_install(tmp_path, log_dir, st, None))
+    elapsed = time.monotonic() - start
+
+    assert elapsed < 5, f"provisioning blocked for {elapsed}s on a hung mise ls"
+    assert any("skipping version capture" in m for m in logged)
+    assert st.data["provision"]["mise_versions"] == {}

--- a/tests/test_pr_writer_git_helper_bounded.py
+++ b/tests/test_pr_writer_git_helper_bounded.py
@@ -1,0 +1,116 @@
+"""`_compose_pr_via_llm`'s nested `_git` helper (leerie.py:32170-32187) must
+not hang phase_finalize forever on a stalled git process (e.g. lock
+contention on the shared bind-mounted .git across concurrent worktree
+operations). It wraps `proc.communicate()` in `asyncio.wait_for` bounded by
+`PR_WRITER_GIT_TIMEOUT_SEC` and swallows the timeout via the function's
+existing fail-open `except Exception` contract.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import subprocess
+
+import pytest
+
+
+def _run(cmd, cwd, check=True):
+    r = subprocess.run(cmd, cwd=cwd, capture_output=True, text=True)
+    if check:
+        assert r.returncode == 0, f"{cmd} failed in {cwd}: {r.stderr}"
+    return r
+
+
+@pytest.fixture
+def repo(tmp_path):
+    root = tmp_path / "repo"
+    root.mkdir()
+    _run(["git", "init", "-q", "-b", "main"], root)
+    _run(["git", "config", "user.email", "t@t"], root)
+    _run(["git", "config", "user.name", "t"], root)
+    (root / "README.md").write_text("hi\n")
+    _run(["git", "add", "-A"], root)
+    _run(["git", "commit", "-qm", "init"], root)
+    return root
+
+
+@pytest.fixture
+def st(leerie, repo, tmp_path):
+    leerie_root = tmp_path / ".leerie"
+    (leerie_root / "runs" / "r1").mkdir(parents=True)
+    s = leerie.State(leerie_root, "r1", repo_root=repo)
+    yield s
+    s.release_lock()
+
+
+def _caps(leerie):
+    caps = dict(leerie.DEFAULT_CAPS)
+    caps["max_total_workers"] = 100
+    return caps
+
+
+class _HangingProc:
+    """Stand-in for `asyncio.subprocess.Process` whose `communicate()`
+    never resolves, mimicking a git process stalled on lock contention."""
+
+    returncode = None
+
+    async def communicate(self):
+        await asyncio.Event().wait()  # never set: blocks forever
+
+    async def wait(self):
+        await asyncio.Event().wait()
+
+    def kill(self):
+        self.returncode = -9
+
+    def terminate(self):
+        self.returncode = -15
+
+    @property
+    def pid(self):
+        return 999999
+
+
+def test_git_helper_bounded_by_timeout_not_unbounded_hang(
+        leerie, monkeypatch, st, repo):
+    st.data["working_branch"] = "main"
+    monkeypatch.setattr(leerie, "PR_WRITER_GIT_TIMEOUT_SEC", 0.05)
+
+    async def _fake_create_subprocess_exec(*args, **kwargs):
+        return _HangingProc()
+
+    monkeypatch.setattr(
+        asyncio, "create_subprocess_exec", _fake_create_subprocess_exec)
+
+    terminated = []
+
+    async def _fake_terminate_proc_tree(proc):
+        terminated.append(proc)
+
+    monkeypatch.setattr(
+        leerie, "_terminate_proc_tree", _fake_terminate_proc_tree)
+
+    async def _fake_claude_p(**kwargs):
+        raise AssertionError(
+            "claude_p must not be reached if git context collection hangs")
+
+    monkeypatch.setattr(leerie, "claude_p", _fake_claude_p)
+
+    async def _bounded():
+        return await asyncio.wait_for(
+            leerie._compose_pr_via_llm(
+                st, _caps(leerie), {}, {}, repo, None),
+            timeout=5.0)
+
+    # The whole call must return well within the outer 5s ceiling instead of
+    # hanging forever — proves the fix, not just that a timeout is *possible*.
+    asyncio.run(_bounded())
+
+    # Fail-open: no PR title/body written, so the launcher's bash fallback
+    # takes over exactly as it does for any other _compose_pr_via_llm error.
+    assert not (st.run_dir / "run.json").exists() or \
+        "pr_title" not in json.loads(
+            (st.run_dir / "run.json").read_text() or "{}")
+    # The stalled git subprocess must be reaped, not orphaned.
+    assert len(terminated) >= 1

--- a/tests/test_prune_subtask_worktree.py
+++ b/tests/test_prune_subtask_worktree.py
@@ -118,6 +118,56 @@ def test_prune_falls_back_to_rmtree_when_git_leaves_dir_behind(
         "shutil.rmtree fallback")
 
 
+def test_prune_passes_a_bounded_timeout_to_run_proc(leerie, monkeypatch):
+    """`_prune_subtask_worktree` must pass an explicit, non-None timeout to
+    `run_proc` for its `git worktree remove` call -- this call site fires
+    unconditionally after every wave's integrate_wave, so an unbounded
+    `run_proc` (default: no timeout) can hang the orchestrator forever."""
+    captured = {}
+
+    async def fake_run_proc(cmd, **kwargs):
+        captured.update(kwargs)
+        return subprocess.CompletedProcess(cmd, 0, "", "")
+    monkeypatch.setattr(leerie, "run_proc", fake_run_proc)
+
+    async def fake_rmtree_fallback(*args, **kwargs):
+        return None
+    monkeypatch.setattr(leerie, "_rmtree_fallback_and_prune", fake_rmtree_fallback)
+
+    asyncio.run(leerie._prune_subtask_worktree("sid-x", Path("/tmp/does-not-matter")))
+
+    assert captured.get("timeout") is not None, (
+        "_prune_subtask_worktree must pass an explicit, non-None timeout "
+        "to run_proc for the git worktree remove call"
+    )
+    assert captured["timeout"] > 0
+
+
+def test_prune_survives_run_proc_timeout(leerie, tmp_path, monkeypatch):
+    """If `run_proc` raises `subprocess.TimeoutExpired` for the `git
+    worktree remove` call, `_prune_subtask_worktree` must catch it and fall
+    through to the existing rmtree fallback rather than letting the
+    exception propagate and take down the wave."""
+    repo = _make_repo(tmp_path / "repo")
+    monkeypatch.chdir(repo)
+    leerie_dir = repo / ".leerie" / "runs" / "run-id"
+    wt_dir = leerie_dir / "worktrees" / "sid-x"
+    wt_dir.mkdir(parents=True)
+    (wt_dir / "leftover.txt").write_text("stray\n")
+
+    async def fake_run_proc(cmd, **kwargs):
+        raise subprocess.TimeoutExpired(cmd, kwargs.get("timeout") or 0)
+    monkeypatch.setattr(leerie, "run_proc", fake_run_proc)
+
+    asyncio.run(leerie._prune_subtask_worktree("sid-x", leerie_dir))
+
+    assert not wt_dir.exists(), (
+        "a TimeoutExpired from the git worktree remove call must not "
+        "propagate -- it must be caught and fall through to the "
+        "shutil.rmtree fallback"
+    )
+
+
 def test_prune_then_reset_of_sibling_still_works(leerie, tmp_path, monkeypatch):
     """After a prune, a blocked/failed sibling sid's own worktree can still
     be reset via `_reset_subtask_worktree` independently — proves the two

--- a/tests/test_reset_subtask_worktree.py
+++ b/tests/test_reset_subtask_worktree.py
@@ -103,6 +103,47 @@ def test_reset_falls_back_to_rmtree_when_git_leaves_dir_behind(
         "shutil.rmtree fallback")
 
 
+def test_reset_passes_a_bounded_timeout_to_run_proc_for_worktree_remove(
+        leerie, monkeypatch):
+    """`_reset_subtask_worktree`'s `git worktree remove` call previously
+    called `run_proc` with no `timeout` (defaults to None / unbounded at
+    leerie.py's run_proc), so a hung removal could block a wave forever —
+    same hang class 505007d fixed for cleanup.sh/_run_script. It must pass
+    an explicit bounded timeout for the `git worktree remove` call."""
+    captured = {}
+
+    async def fake_run_proc(cmd, **kwargs):
+        if cmd[:3] == ["git", "worktree", "remove"]:
+            captured.update(kwargs)
+        return subprocess.CompletedProcess(cmd, 0, "", "")
+    monkeypatch.setattr(leerie, "run_proc", fake_run_proc)
+
+    asyncio.run(leerie._reset_subtask_worktree(
+        "sid-x", Path("/tmp/leerie-dir"), "run-id"))
+
+    assert captured.get("timeout") is not None, (
+        "_reset_subtask_worktree must pass an explicit, non-None timeout "
+        "to run_proc for the `git worktree remove` call"
+    )
+    assert captured["timeout"] > 0
+
+
+def test_reset_survives_a_worktree_remove_timeout(leerie, monkeypatch):
+    """Execution-level pin: if `git worktree remove` times out,
+    `_reset_subtask_worktree` must still complete instead of letting
+    `subprocess.TimeoutExpired` propagate uncaught — falling through to
+    the existing rmtree fallback rather than crashing the wave."""
+    async def fake_run_proc(cmd, **kwargs):
+        if cmd[:3] == ["git", "worktree", "remove"]:
+            raise subprocess.TimeoutExpired(cmd, kwargs.get("timeout") or 240)
+        return subprocess.CompletedProcess(cmd, 0, "", "")
+    monkeypatch.setattr(leerie, "run_proc", fake_run_proc)
+
+    # Should not raise.
+    asyncio.run(leerie._reset_subtask_worktree(
+        "sid-x", Path("/tmp/leerie-dir"), "run-id"))
+
+
 def test_resets_so_worktree_add_b_succeeds_on_retry(leerie, tmp_path, monkeypatch):
     """The end-to-end shape this helper exists to enable: after reset, a
     fresh `git worktree add -b <branch>` succeeds where it would otherwise


### PR DESCRIPTION
## Summary

Fixes runs hanging for up to an hour after finishing (success or failure) by bounding the last unguarded `proc.communicate()` call sites in `orchestrator/leerie.py`: the PR writer's git-context helper, the mise version-capture step, and the `git worktree remove` calls in the reset/prune worktree helpers.

## Which layer(s) does this PR touch?

(See [`CLAUDE.md`](../CLAUDE.md) for the three-layer rule.)

- [ ] `docs/DESIGN.md` (architecture)
- [x] `docs/IMPLEMENTATION.md` (code surface)
- [x] `orchestrator/leerie.py` (code)
- [x] docs / tests / CI

Change propagated top-down: no architectural change was needed (DESIGN's existing bounded-subprocess principle already covers this), so IMPLEMENTATION.md was updated alongside the code to document the new `PR_WRITER_GIT_TIMEOUT_SEC` and `MISE_LS_TIMEOUT` constants and the bounded `git worktree remove` calls.

## Checklist

- [ ] `pytest tests/` passes
- [ ] `git diff --stat` reviewed for scope

## Conformance notes

- tests-failed (`pytest`): `test_terminate_proc_tree_reaps_grandchildren`, `test_terminate_proc_tree_reaps_detached_session_grandchildren`, and `test_descendant_tracker_reaps_orphaned_backgrounded_subprocess` in `tests/test_signal_cleanup.py` fail (6 failed, 8530 passed, 119 skipped, 1337.70s). These are named identically in the BASELINE block as pre-existing red tests on the base tree, and CLAUDE.md's Testing section documents this file as concurrency/timing-sensitive; the diff does not touch `test_signal_cleanup.py` or any code path it exercises.
- rule-residual: `build/lint/tests must pass` not fixed — same three `test_signal_cleanup.py` failures, judged pre-existing rather than introduced by this run for the reasons above.

## Related issue

<!-- Closes #N -->
